### PR TITLE
hammer_cli_foreman gem dependency

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |spec|
   spec.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   spec.add_dependency("hammer_cli")
+  spec.add_dependency("hammer_cli_foreman")
   spec.add_dependency("katello_api")
+
   spec.add_development_dependency("rake")
   spec.add_development_dependency("thor")
   spec.add_development_dependency("minitest", "4.7.4")


### PR DESCRIPTION
since we're going to be extending a couple foreman entities, it would make
sense to include them
