### PR TITLE
Fix error because exception class does not exist

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -4,12 +4,13 @@ require 'hammer_cli/exit_codes'
 module HammerCLIKatello
 
   def self.exception_handler_class
-    HammerCLIKatello::ExceptionHandler
+    HammerCLI::ExceptionHandler
   end
 
   # require 'hammer_cli_katello/stuff'
   # ...
   # ...
   require 'hammer_cli_katello/ping'
+  require 'hammer_cli_katello/product'
 
 end


### PR DESCRIPTION
When a hammer command fails, it complains about the exception class not existing.
This was observed using product subcommand.  See referenced pull-requests.
