### PR TITLE
DO NOT MERGE Add repository update command

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -2,13 +2,14 @@ module HammerCLIKatello
 
   class Repository < HammerCLI::Apipie::Command
     resource KatelloApi::Resources::Repository
-    apipie_options
 
     class CreateCommand < HammerCLIForeman::CreateCommand
       identifiers :id, :organization_id, :product_id
 
       success_message "Repository created"
       failure_message "Could not create the repository"
+
+      apipie_options
     end
 
     class UpdateCommand < HammerCLIForeman::UpdateCommand
@@ -16,6 +17,8 @@ module HammerCLIKatello
 
       success_message "Repository updated"
       failure_message "Could not update the repository"
+
+      apipie_options
     end
 
     autoload_subcommands


### PR DESCRIPTION
This command was developed and tested against https://github.com/Katello/katello/pull/3597 for making a Red Had repository enabled or disabled, **which must be merged before this pull request**

This only enables/disables by repository id at the moment.

TODO: Need to enable/disable by name/product combo.
