### PR TITLE
Ping was not working because it was not inheriting from the foreman comm...

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -2,6 +2,8 @@ module HammerCLIKatello
 
   class WriteCommand < HammerCLIForeman::WriteCommand; end
 
+  class ReadCommand < HammerCLIForeman::ReadCommand; end
+
   class ListCommand < HammerCLIForeman::ListCommand; end
 
   class InfoCommand < HammerCLIForeman::InfoCommand

--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
 
-  class PingCommand < HammerCLI::Apipie::ReadCommand
+  class PingCommand < HammerCLIKatello::ReadCommand
 
     resource KatelloApi::Resources::Ping, :index
 


### PR DESCRIPTION
...ands.

Created a new ReadCommand for Katello which inherits from the foreman command.
Subclassed ping command from the new ReadCommand
