### PR TITLE
Initial cut at making the manifest commands async

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.version = HammerCLIKatello.version
 
   spec.add_dependency 'hammer_cli_foreman', '~> 0.0.16'
+  spec.add_dependency 'hammer_cli_foreman_tasks'
   spec.add_dependency 'katello_api', '~> 0.0.5'
 
   spec.add_development_dependency 'rake'

--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -3,6 +3,7 @@ require 'hammer_cli_foreman'
 require 'hammer_cli/exit_codes'
 require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/output/fields'
+require 'hammer_cli_foreman_tasks'
 
 require 'katello_api'
 

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -31,7 +31,7 @@ module HammerCLIKatello
       apipie_options
     end
 
-    class UploadCommand < HammerCLIKatello::WriteCommand
+    class UploadCommand < HammerCLIForemanTasks::AsyncCommand
       resource KatelloApi::Resources::Subscription, 'upload'
       command_name "upload"
 
@@ -54,7 +54,7 @@ module HammerCLIKatello
              :required => true, :format => BinaryFile.new
     end
 
-    class DeleteManfiestCommand < HammerCLIKatello::WriteCommand
+    class DeleteManfiestCommand < HammerCLIForemanTasks::AsyncCommand
       resource KatelloApi::Resources::Subscription, 'delete_manifest'
       command_name "delete_manifest"
 
@@ -64,7 +64,7 @@ module HammerCLIKatello
       apipie_options
     end
 
-    class RefreshManfiestCommand < HammerCLIKatello::WriteCommand
+    class RefreshManfiestCommand < HammerCLIForemanTasks::AsyncCommand
       resource KatelloApi::Resources::Subscription, 'refresh_manifest'
       command_name "refresh_manifest"
 


### PR DESCRIPTION
More info for @Inecas and @komidore64. Related to 

https://github.com/Katello/hammer-cli-katello/pull/49

When I run this I get:

```
NoMethodError (undefined method `[]' for nil:NilClass):
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/task_progress.rb:54:in `task_pending?'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/task_progress.rb:14:in `render'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/helper.rb:7:in `block in task_progress'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/helper.rb:6:in `tap'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/helper.rb:6:in `task_progress'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/bundler/gems/hammer-cli-foreman-tasks-ff213ae3e73e/lib/hammer_cli_foreman_tasks/async_command.rb:11:in `execute'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    /home/bkearney/code/hammer-cli/lib/hammer_cli/abstract.rb:22:in `run'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    /home/bkearney/code/hammer-cli/lib/hammer_cli/abstract.rb:22:in `run'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    /home/bkearney/code/hammer-cli/lib/hammer_cli/abstract.rb:22:in `run'
    /home/bkearney/.rvm/gems/ruby-1.9.3-p484/gems/clamp-0.6.3/lib/clamp/command.rb:125:in `run'
    bin/hammer:77:in `<main>'
```
