### PR TITLE
Revert "manifest async commands"

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.version = HammerCLIKatello.version
 
   spec.add_dependency 'hammer_cli_foreman', '~> 0.0.16'
-  spec.add_dependency 'hammer_cli_foreman_tasks'
   spec.add_dependency 'katello_api', '~> 0.0.5'
 
   spec.add_development_dependency 'rake'

--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -3,7 +3,6 @@ require 'hammer_cli_foreman'
 require 'hammer_cli/exit_codes'
 require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/output/fields'
-require 'hammer_cli_foreman_tasks'
 
 require 'katello_api'
 

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -31,7 +31,7 @@ module HammerCLIKatello
       apipie_options
     end
 
-    class UploadCommand < HammerCLIForemanTasks::AsyncCommand
+    class UploadCommand < HammerCLIKatello::WriteCommand
       resource KatelloApi::Resources::Subscription, 'upload'
       command_name "upload"
 
@@ -54,7 +54,7 @@ module HammerCLIKatello
              :required => true, :format => BinaryFile.new
     end
 
-    class DeleteManfiestCommand < HammerCLIForemanTasks::AsyncCommand
+    class DeleteManfiestCommand < HammerCLIKatello::WriteCommand
       resource KatelloApi::Resources::Subscription, 'delete_manifest'
       command_name "delete_manifest"
 
@@ -64,7 +64,7 @@ module HammerCLIKatello
       apipie_options
     end
 
-    class RefreshManfiestCommand < HammerCLIForemanTasks::AsyncCommand
+    class RefreshManfiestCommand < HammerCLIKatello::WriteCommand
       resource KatelloApi::Resources::Subscription, 'refresh_manifest'
       command_name "refresh_manifest"
 


### PR DESCRIPTION
This reverts commit 6e46a8df85a71b4eab3ddc291108509afdccc637.

i jumped the gun and shouldn't have merged this into master yet until after an
RPM has been built. this change will be placed back into master once a
hammer_cli_foreman_tasks gem/RPM exists in nightly that is available for
requiring.
