### PR TITLE
Remove duplicate require line

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -16,7 +16,6 @@ module HammerCLIKatello
   require 'hammer_cli_katello/exception_handler.rb'
   require "#{File.dirname(__FILE__)}/hammer_cli_katello/commands.rb"
   require "#{File.dirname(__FILE__)}/hammer_cli_katello/version.rb"
-  require "#{File.dirname(__FILE__)}/hammer_cli_katello/exception_handler.rb"
 
   require "hammer_cli_katello/commands"
   require "hammer_cli_katello/scoped_names"


### PR DESCRIPTION
Looks like @jlsherrill already fixed this in https://github.com/Katello/hammer-cli-katello/pull/82 but didn't merge it to content-views, thus my fix was a duplicate. This is to remove the redundant line.
