### PR TITLE
Ref #3897 - dynamic bindings

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hammer_cli_foreman', '~> 0.0.16'
   spec.add_dependency 'hammer_cli_foreman_tasks'
-  spec.add_dependency 'katello_api', '~> 0.0.8'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'thor'

--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -5,8 +5,6 @@ require 'hammer_cli_foreman/commands'
 require 'hammer_cli_foreman/output/fields'
 require 'hammer_cli_foreman_tasks'
 
-require 'katello_api'
-
 module HammerCLIKatello
 
   def self.exception_handler_class

--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   class ActivationKeyCommand < HammerCLI::AbstractCommand
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::ActivationKey, 'index'
+      resource :activation_keys, :index
 
       output do
         field :id, _("ID")
@@ -23,7 +23,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::ActivationKey, :show
+      resource :activation_keys, :show
 
       identifiers :id
 

--- a/lib/hammer_cli_katello/associating_commands.rb
+++ b/lib/hammer_cli_katello/associating_commands.rb
@@ -5,7 +5,7 @@ module HammerCLIKatello
 
       class AddRepositoryCommand < HammerCLIKatello::AddAssociatedCommand
         command_name 'add-repository'
-        associated_resource KatelloApi::Resources::Repository
+        associated_resource :repositories
         apipie_options
 
         success_message "The repository has been associated"
@@ -14,7 +14,7 @@ module HammerCLIKatello
 
       class RemoveRepositoryCommand < HammerCLIKatello::RemoveAssociatedCommand
         command_name 'remove-repository'
-        associated_resource KatelloApi::Resources::Repository
+        associated_resource :repositories
         apipie_options
 
         success_message "The repository has been removed"

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -5,7 +5,7 @@ require 'hammer_cli_katello/content_view_version'
 module HammerCLIKatello
 
   class ContentView < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::ContentView
+    resource :content_views
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do
@@ -105,7 +105,7 @@ module HammerCLIKatello
         plural ? "components" : "component"
       end
 
-      associated_resource KatelloApi::Resources::ContentViewVersion
+      associated_resource :content_view_versions
       apipie_options
 
       success_message "The component version has been added"
@@ -126,7 +126,7 @@ module HammerCLIKatello
         plural ? "components" : "component"
       end
 
-      associated_resource KatelloApi::Resources::ContentViewVersion
+      associated_resource :content_view_versions
       apipie_options
 
       success_message "The component version has been removed"

--- a/lib/hammer_cli_katello/content_view_puppet_module.rb
+++ b/lib/hammer_cli_katello/content_view_puppet_module.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   class ContentViewPuppetModule < HammerCLI::Apipie::Command
 
-    resource KatelloApi::Resources::ContentViewPuppetModule
+    resource :content_view_puppet_modules
     command_name 'puppet-module'
     desc 'View and manage puppet modules'
 

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -1,7 +1,7 @@
 module HammerCLIKatello
 
   class ContentViewVersion < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::ContentViewVersion
+    resource :content_view_versions
     command_name 'version'
     desc 'View and manage content view versions'
 

--- a/lib/hammer_cli_katello/filter.rb
+++ b/lib/hammer_cli_katello/filter.rb
@@ -4,7 +4,7 @@ module HammerCLIKatello
 
   class Filter < HammerCLI::Apipie::Command
 
-    resource KatelloApi::Resources::ContentViewFilter
+    resource :content_view_filters
     command_name 'filter'
     desc 'View and manage filters'
 

--- a/lib/hammer_cli_katello/filter_rule.rb
+++ b/lib/hammer_cli_katello/filter_rule.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   class FilterRule < HammerCLI::Apipie::Command
 
-    resource KatelloApi::Resources::ContentViewFilterRule
+    resource :content_view_filter_rules
     command_name 'rule'
     desc 'View and manage filter rules'
 

--- a/lib/hammer_cli_katello/gpg_key.rb
+++ b/lib/hammer_cli_katello/gpg_key.rb
@@ -3,7 +3,7 @@ module HammerCLIKatello
   class GpgKeyCommand < HammerCLI::AbstractCommand
 
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::GpgKey, :index
+      resource :gpg_keys, :index
 
       output do
         field :id, _("ID")
@@ -14,7 +14,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::GpgKey, :show
+      resource :gpg_keys, :show
       output do
         field :id, _("ID")
         field :name, _("Name")
@@ -48,9 +48,11 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
-      resource KatelloApi::Resources::GpgKey, :create
+      resource :gpg_keys, :create
+
       success_message _("GPG Key created")
       failure_message _("Could not create GPG Key")
+
       apipie_options  :without => [:content]
       option "--key", "GPG_KEY_FILE", _("GPG Key file"),
              :attribute_name => :option_content,
@@ -59,9 +61,10 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      resource :gpg_keys, :update
+
       success_message _("GPG Key updated")
       failure_message _("Could not update GPG Key")
-      resource KatelloApi::Resources::GpgKey, :update
 
       identifiers :id
 
@@ -76,9 +79,10 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
+      resource :gpg_keys, :destroy
+
       success_message _("GPG Key deleted")
       failure_message _("Could not delete the GPG Key")
-      resource KatelloApi::Resources::GpgKey, :destroy
 
       identifiers :id
       def request_params

--- a/lib/hammer_cli_katello/lifecycle_environment.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment.rb
@@ -3,7 +3,7 @@ module HammerCLIKatello
   class LifecycleEnvironmentCommand < HammerCLI::AbstractCommand
 
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::Environment, :index
+      resource :lifecycle_environments, :index
 
       output do
         field :id, _("ID")
@@ -15,7 +15,7 @@ module HammerCLIKatello
     end
 
     class PathsCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::LifecycleEnvironment, :paths
+      resource :lifecycle_environments, :paths
 
       command_name "paths"
 
@@ -35,7 +35,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::Environment
+      resource :lifecycle_environments
       include HammerCLIKatello::ScopedNameCommand
 
       output do
@@ -56,8 +56,9 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
-      resource KatelloApi::Resources::LifecycleEnvironment, :create
+      resource :lifecycle_environments, :create
       include HammerCLIKatello::ScopedName
+
       success_message _("Environment created")
       failure_message _("Could not create environment")
 
@@ -70,10 +71,11 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      resource :lifecycle_environments
+      include HammerCLIKatello::ScopedNameCommand
+
       success_message _("Environment updated")
       failure_message _("Could not update environment")
-      include HammerCLIKatello::ScopedNameCommand
-      resource KatelloApi::Resources::LifecycleEnvironment
 
       identifiers :id
 
@@ -85,10 +87,11 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
+      resource :lifecycle_environments
+      include HammerCLIKatello::ScopedNameCommand
+
       success_message _("Environment deleted")
       failure_message _("Could not delete environment")
-      include HammerCLIKatello::ScopedNameCommand
-      resource KatelloApi::Resources::LifecycleEnvironment
 
       identifiers :id
 

--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -3,7 +3,7 @@ module HammerCLIKatello
   class Organization < HammerCLIForeman::Organization
 
     class ListCommand < HammerCLIForeman::Organization::ListCommand
-      resource KatelloApi::Resources::Organization, "index"
+      resource :organizations, :index
 
       output do
         field :label, _("Label")
@@ -14,7 +14,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIForeman::Organization::InfoCommand
-      resource KatelloApi::Resources::Organization, "show"
+      resource :organizations, :show
 
       output do
         field :label, _("Label")
@@ -25,7 +25,7 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIForeman::Organization::UpdateCommand
-      resource KatelloApi::Resources::Organization, "update"
+      resource :organizations, :update
 
       success_message _("Organization updated")
       failure_message _("Could not update the organization")
@@ -34,7 +34,7 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
-      resource KatelloApi::Resources::Organization, "create"
+      resource :organizations, :create
 
       success_message _("Organization created")
       failure_message _("Could not create the organization")
@@ -43,7 +43,7 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
-      resource ForemanApi::Resources::Organization, "destroy"
+      resource :organizations, :destroy
 
       success_message _("Organization deleted")
       failure_message _("Could not delete the organization")

--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   class PingCommand < HammerCLIKatello::ReadCommand
 
-    resource KatelloApi::Resources::Ping, :index
+    resource :ping, :index
 
     output do
       from "services" do

--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -1,7 +1,7 @@
 module HammerCLIKatello
 
-  class Product < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::Product
+  class Product < HammerCLIForeman::Command
+    resource :products
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do
@@ -86,7 +86,7 @@ module HammerCLIKatello
       success_message _("Synchronization plan assigned.")
       failure_message _("Could not assign synchronization plan.")
 
-      resource KatelloApi::Resources::Product, "update"
+      resource :products, :update
 
       apipie_options :without => declared_identifiers.keys +
         [:name, :label, :provider_id, :description, :gpg_key_id]
@@ -104,7 +104,7 @@ module HammerCLIKatello
       success_message _("Synchronization plan removed.")
       failure_message _("Could not remove synchronization plan.")
 
-      resource KatelloApi::Resources::Product, "update"
+      resource :products, :update
 
       apipie_options :without => [:name, :label, :provider_id, :description,
                                   :gpg_key_id, :sync_plan_id]

--- a/lib/hammer_cli_katello/provider.rb
+++ b/lib/hammer_cli_katello/provider.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
-  class Provider < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::Provider
+  class Provider < HammerCLIForeman::Command
+    resource :providers
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do

--- a/lib/hammer_cli_katello/puppet_module.rb
+++ b/lib/hammer_cli_katello/puppet_module.rb
@@ -1,7 +1,7 @@
 module HammerCLIKatello
 
   class PuppetModule < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::PuppetModule
+    resource :puppet_modules
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -1,7 +1,7 @@
 module HammerCLIKatello
 
-  class Repository < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::Repository
+  class Repository < HammerCLIForeman::Command
+    resource :repositories
 
     class ListCommand < HammerCLIForeman::ListCommand
       output do
@@ -14,7 +14,7 @@ module HammerCLIKatello
     end
 
     class SyncCommand < HammerCLIForemanTasks::AsyncCommand
-      action "sync"
+      action :sync
       command_name "synchronize"
 
       success_message _("Repository is being synchronized in task %{id}s")

--- a/lib/hammer_cli_katello/repository_set.rb
+++ b/lib/hammer_cli_katello/repository_set.rb
@@ -3,7 +3,7 @@ module HammerCLIKatello
   class RepositorySetCommand < HammerCLI::AbstractCommand
 
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::RepositorySet, :index
+      resource :repository_sets, :index
 
       output do
         field :id, _("ID")
@@ -24,7 +24,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::RepositorySet, :show
+      resource :repository_sets, :show
 
       output do
         field :id, _("ID")
@@ -55,8 +55,9 @@ module HammerCLIKatello
     end
 
     class EnableCommand < HammerCLIKatello::UpdateCommand
+      resource :repository_sets, :enable
       command_name "enable"
-      resource KatelloApi::Resources::RepositorySet, :enable
+
       success_message _("Repository set enabled")
       failure_message _("Could not enable repository set")
 
@@ -64,8 +65,9 @@ module HammerCLIKatello
     end
 
     class DisableCommand < HammerCLIKatello::UpdateCommand
+      resource :repository_sets, :disable
       command_name "disable"
-      resource KatelloApi::Resources::RepositorySet, :disable
+
       success_message _("Repository set disabled")
       failure_message _("Could not disable repository set")
 

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -1,5 +1,4 @@
 require 'hammer_cli'
-require 'katello_api'
 require 'hammer_cli_foreman'
 require 'hammer_cli_foreman/commands'
 
@@ -7,7 +6,7 @@ module HammerCLIKatello
 
   class SubscriptionCommand < HammerCLI::AbstractCommand
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::Subscription, 'index'
+      resource :subscriptions, :index
 
       output do
         field :product_name, _("Name")
@@ -32,7 +31,7 @@ module HammerCLIKatello
     end
 
     class UploadCommand < HammerCLIForemanTasks::AsyncCommand
-      resource KatelloApi::Resources::Subscription, 'upload'
+      resource :subscriptions, :upload
       command_name "upload"
 
       class BinaryFile < HammerCLI::Options::Normalizers::File
@@ -55,7 +54,7 @@ module HammerCLIKatello
     end
 
     class DeleteManfiestCommand < HammerCLIForemanTasks::AsyncCommand
-      resource KatelloApi::Resources::Subscription, 'delete_manifest'
+      resource :subscriptions, :delete_manifest
       command_name "delete_manifest"
 
       success_message _("Manifest is being deleted in task %{id}s")
@@ -65,7 +64,7 @@ module HammerCLIKatello
     end
 
     class RefreshManfiestCommand < HammerCLIForemanTasks::AsyncCommand
-      resource KatelloApi::Resources::Subscription, 'refresh_manifest'
+      resource :subscriptions, :refresh_manifest
       command_name "refresh_manifest"
 
       success_message _("Manifest is being refreshed in task %{id}s")

--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
-  class SyncPlan < HammerCLI::Apipie::Command
-    resource KatelloApi::Resources::SyncPlan
+  class SyncPlan < HammerCLIForeman::Command
+    resource :sync_plans
 
     class ListCommand < HammerCLIForeman::ListCommand
 

--- a/lib/hammer_cli_katello/system.rb
+++ b/lib/hammer_cli_katello/system.rb
@@ -3,7 +3,7 @@ module HammerCLIKatello
   class SystemCommand < HammerCLI::AbstractCommand
 
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::System, :index
+      resource :systems, :index
 
       output do
         field :uuid, _("ID")
@@ -14,7 +14,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::System, :show
+      resource :systems, :show
 
       identifiers :id
 
@@ -39,9 +39,10 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
+      resource :systems, :create
+
       success_message _("System created")
       failure_message _("Could not create system")
-      resource KatelloApi::Resources::System, :create
 
       def request_params
         super.tap do |params|
@@ -54,9 +55,10 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      resource :systems, :update
+
       success_message _("System updated")
       failure_message _("Could not update system")
-      resource KatelloApi::Resources::System, :update
 
       identifiers :id
 
@@ -64,9 +66,10 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
+      resource :systems, :destroy
+
       success_message _("System deleted")
       failure_message _("Could not delete system")
-      resource KatelloApi::Resources::System, :destroy
 
       identifiers :id
 
@@ -74,7 +77,7 @@ module HammerCLIKatello
     end
 
     class TasksCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::System, :tasks
+      resource :systems, :tasks
 
       command_name "tasks"
 

--- a/lib/hammer_cli_katello/system_group.rb
+++ b/lib/hammer_cli_katello/system_group.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   class SystemGroup < HammerCLI::AbstractCommand
     class ListCommand < HammerCLIKatello::ListCommand
-      resource KatelloApi::Resources::SystemGroup, "index"
+      resource :system_groups, :index
 
       output do
         field :id, _("ID")
@@ -15,15 +15,16 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
+      resource :system_groups, :create
+
       success_message _("System group created")
       failure_message _("Could not create the system group")
-      resource KatelloApi::Resources::SystemGroup, "create"
 
       apipie_options
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
-      resource KatelloApi::Resources::SystemGroup, "show"
+      resource :system_groups, :show
 
       output ListCommand.output_definition do
       end
@@ -33,7 +34,7 @@ module HammerCLIKatello
       success_message _("System group created")
       failure_message _("Could not create the system group")
       command_name "copy"
-      action "copy"
+      action :copy
 
       validate_options do
         all(:option_name).required unless option(:option_id).exist?


### PR DESCRIPTION
This makes hammer-cli-katello compatible with dynamic bindings. For this to work you need to apply https://github.com/theforeman/hammer-cli/pull/88 and https://github.com/theforeman/hammer-cli-foreman/pull/89 to hammer packages. Server part needs https://github.com/Katello/katello/pull/3772 and https://github.com/theforeman/foreman/pull/1265. It is also recommended to use upstream version of bindings (https://github.com/Apipie/apipie-bindings)

It would be great if someone could put the effort in testing this PR at this stage and check what things I've missed. While all the other PRs are open it is relatively easy to change things. I appreciate any comments.
