### PR TITLE
Exception handling for not found

### DIFF
--- a/lib/hammer_cli_katello/exception_handler.rb
+++ b/lib/hammer_cli_katello/exception_handler.rb
@@ -20,10 +20,15 @@ module HammerCLIKatello
       HammerCLI::EX_DATAERR
     end
 
+    def handle_not_found(e)
+      handle_katello_error(e)
+      HammerCLI::EX_NOT_FOUND
+    end
+
     def handle_katello_error(e)
       response = JSON.parse(e.response)
       response = HammerCLIForeman.record_to_common_format(response)
-      print_error response["displayMessage"]
+      print_error response["displayMessage"] || response["full_messages"]
     end
 
   end


### PR DESCRIPTION
404 error message responses store error messages under the key "full_messages".
