### PR TITLE
CLI for Product should display ID and not Product ID.

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -5,7 +5,7 @@ module HammerCLIKatello
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do
-        field :id, _("Product ID")
+        field :id, _("ID")
         field :name, _("Name")
 
         from :provider do
@@ -33,7 +33,7 @@ module HammerCLIKatello
       include HammerCLIKatello::ScopedNameCommand
 
       output do
-        field :id, _("Product ID")
+        field :id, _("ID")
         field :name, _("Name")
         field :label, _("Label")
         field :description, _("Description")


### PR DESCRIPTION
Changing the output for Product CLI from displaying "Product ID" to "ID" as
it currently happens with all other resources. This also helps QE automation
as it expects all resources to have a "ID" field.
