### PR TITLE
Changes to sync plan based on usage.

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -30,10 +30,13 @@ module HammerCLIKatello
       option "--interval", "INTERVAL", _("how often synchronization should run"),
              :default => 'none',
              :format => HammerCLI::Options::Normalizers::Enum.new(
-                %w('none', 'hourly', 'daily', 'weekly')
+                %w(none hourly daily weekly)
               )
-      option "--sync-date", "SYNC_DATE", _("start date and time of the synchronization"),
-             :format => HammerCLI::Options::Normalizers::DateTime.new, :required => true
+
+      option "--sync-date", "SYNC_DATE",
+             _("start date and time of the synchronization defaults to now"),
+             :format => HammerCLI::Options::Normalizers::DateTime.new,
+             :default => DateTime.now.strftime("%F %T")
 
       success_message _("Sync plan created")
       failure_message _("Could not create the sync plan")
@@ -46,7 +49,7 @@ module HammerCLIKatello
 
       option "--interval", "INTERVAL", _("how often synchronization should run"),
              :format => HammerCLI::Options::Normalizers::Enum.new(
-                %('none', 'hourly', 'daily', 'weekly')
+                %w(none hourly daily weekly)
               )
       option "--sync-date", "SYNC_DATE", _("start date and time of the synchronization"),
              :format => HammerCLI::Options::Normalizers::DateTime.new


### PR DESCRIPTION
Two main changes are:

1) using %w() requires no comments and ticks. This was causing validation errors
2) Default the sync plan time to today so that I do not need to specify it.
