### PR TITLE
Fixes #5070 - Disabling name for associate commands

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -28,7 +28,13 @@ module HammerCLIKatello
 
   end
 
-  class AddAssociatedCommand < HammerCLIForeman::AddAssociatedCommand; end
+  class AddAssociatedCommand < HammerCLIForeman::AddAssociatedCommand
+    identifiers :id
+    associated_identifiers :id
+  end
 
-  class RemoveAssociatedCommand < HammerCLIForeman::RemoveAssociatedCommand; end
+  class RemoveAssociatedCommand < HammerCLIForeman::RemoveAssociatedCommand
+    identifiers :id
+    associated_identifiers :id
+  end
 end


### PR DESCRIPTION
No resources support name yet (see the "Scriptability of Hammer" thread) so we're doing the same as other command does by disabling it until Tomas implements support.
