### PR TITLE
Fixes #5135 BZ 1085541; removed duplicate output.

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -39,8 +39,6 @@ module HammerCLIKatello
         field :label, _("Label")
         field :description, _("Description")
 
-        field :sync_plan_id, _("Sync Plan ID")
-
         from :sync_status do
           field :state, _("Sync State")
         end


### PR DESCRIPTION
This removed the duplicated entry for `Sync Plan ID` when using
`hammer product info` for an existing Product. This fixes #5135 and BZ
1085541.
