### PR TITLE
Fixes #5433 - Display redhat repo url

### DIFF
--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -18,6 +18,7 @@ module HammerCLIKatello
       output do
         field :label, _("Label")
         field :description, _("Description")
+        field :redhat_repository_url, _("Red Hat Repository URL")
       end
     end
 


### PR DESCRIPTION
Added a line to display the redhat repository url
for a given org, since there is no place to determine
that after the removal of providers subcommand in hammer
