### PR TITLE
fixes #4919 - hammer systemgroup info has NO params, BZ1080475

### DIFF
--- a/lib/hammer_cli_katello/system_group.rb
+++ b/lib/hammer_cli_katello/system_group.rb
@@ -26,8 +26,9 @@ module HammerCLIKatello
     class InfoCommand < HammerCLIKatello::InfoCommand
       resource :system_groups, :show
 
-      output ListCommand.output_definition do
-      end
+      output ListCommand.output_definition
+
+      build_options
     end
 
     class CopyCommand < HammerCLIKatello::CreateCommand


### PR DESCRIPTION
Katello/katello#4032 should preferably be merged first
