### PR TITLE
fixes #5602 - host-collections: add command to list content-hosts

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -34,6 +34,19 @@ module HammerCLIKatello
       build_options
     end
 
+    class ContentHostsCommand < HammerCLIKatello::ListCommand
+      resource :host_collections, :systems
+      command_name "content-hosts"
+
+      output do
+        field :id, _("ID")
+        field :uuid, _("UUID")
+        field :name, _("Name")
+      end
+
+      build_options
+    end
+
     class CopyCommand < HammerCLIKatello::CreateCommand
       success_message _("Host collection created")
       failure_message _("Could not create the host collection")


### PR DESCRIPTION
Added a list command to show the list of content-hosts in a
host-collection. E.g.

hammer> host-collection content-hosts --id 1
---|--------------------------------------|-----------------
ID | UUID                                 | NAME
---|--------------------------------------|-----------------
9  | 054925b5-2046-494d-afe8-8b56dc5a5596 | sat6client.devel
---|--------------------------------------|-----------------
