### PR TITLE
fixes #5601, #5603 - host-collections: add support for update & add/remove-content-host

### DIFF
--- a/lib/hammer_cli_katello/associating_commands.rb
+++ b/lib/hammer_cli_katello/associating_commands.rb
@@ -42,5 +42,26 @@ module HammerCLIKatello
       end
 
     end
+
+    module ContentHost
+      extend HammerCLIForeman::AssociatingCommands::CommandExtension
+
+      class AddContentHostCommand < HammerCLIKatello::AddAssociatedCommand
+        command_name 'add-content-host'
+        associated_resource :systems
+
+        success_message _("The content host has been added")
+        failure_message _("Could not add content host")
+      end
+
+      class RemoveContentHostCommand < HammerCLIKatello::RemoveAssociatedCommand
+        command_name 'remove-content-host'
+        associated_resource :systems
+
+        success_message _("The content host has been removed")
+        failure_message _("Could not remove content host")
+      end
+
+    end
   end
 end

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -1,6 +1,8 @@
 module HammerCLIKatello
 
-  class HostCollection < HammerCLI::AbstractCommand
+  class HostCollection < HammerCLIKatello::Command
+    resource :host_collections
+
     class ListCommand < HammerCLIKatello::ListCommand
       resource :host_collections, :index
 
@@ -50,6 +52,13 @@ module HammerCLIKatello
       build_options
     end
 
+    class UpdateCommand < HammerCLIKatello::UpdateCommand
+      success_message _("Host collection updated")
+      failure_message _("Could not update the the host collection")
+
+      build_options
+    end
+
     class DeleteCommand < HammerCLIKatello::DeleteCommand
       resource :host_collections, :destroy
 
@@ -58,6 +67,8 @@ module HammerCLIKatello
 
       build_options
     end
+
+    HammerCLIKatello::AssociatingCommands::ContentHost.extend_command(self)
 
     autoload_subcommands
   end


### PR DESCRIPTION
This commits add support for the following commands:

host-collection update
host-collection add-content-host
host-collection remove-content-host
