### PR TITLE
Fixes #5697 system subcommands ignore filtering by name and environment-...

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -2,6 +2,24 @@ module HammerCLIKatello
 
   class ContentHostCommand < HammerCLI::AbstractCommand
 
+    module NameOrganizationEnvironmentIdSearchable
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def resolver
+          HammerCLIKatello::UuidIdResolver.new(super.api,
+                                               HammerCLIKatello::EnvironmentSearchables.new)
+        end
+
+        def searchables
+          @searchables ||= HammerCLIKatello::EnvironmentSearchables.new
+          @searchables
+        end
+      end
+    end
+
     class ListCommand < HammerCLIKatello::ListCommand
       resource :systems, :index
 
@@ -10,10 +28,12 @@ module HammerCLIKatello
         field :name, _("Name")
       end
 
-      build_options :without => [:environment_id]
+      build_options
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
+      include NameOrganizationEnvironmentIdSearchable
+
       resource :systems, :show
 
       output do
@@ -53,6 +73,7 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      include NameOrganizationEnvironmentIdSearchable
       resource :systems, :update
 
       success_message _("Content host updated")
@@ -62,6 +83,7 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
+      include NameOrganizationEnvironmentIdSearchable
       resource :systems, :destroy
 
       success_message _("Content host deleted")
@@ -71,6 +93,23 @@ module HammerCLIKatello
     end
 
     class TasksCommand < HammerCLIKatello::ListCommand
+      include NameOrganizationEnvironmentIdSearchable
+
+      def request_params
+        params = super
+        params['id'] ||= get_identifier
+        params
+      end
+
+      # override so that command can use the searchables defined in UuidAsIdResolvable
+      def self.custom_option_builders
+        builders = super
+        if resource_defined?
+          builders <<  HammerCLIForeman::SearchablesOptionBuilder.new(resource, searchables)
+        end
+        builders
+      end
+
       resource :systems, :tasks
 
       command_name "tasks"
@@ -85,5 +124,4 @@ module HammerCLIKatello
   cmd_desc = _("manipulate content hosts on the server")
   cmd_cls  = HammerCLIKatello::ContentHostCommand
   HammerCLI::MainCommand.subcommand(cmd_name, cmd_desc, cmd_cls)
-
 end

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -33,4 +33,20 @@ module HammerCLIKatello
 
   end
 
+  class EnvironmentSearchables < Searchables
+
+    DEFAULT_SEARCHABLES = Searchables::DEFAULT_SEARCHABLES +
+      [HammerCLIForeman::Searchable.new("environment-id", _("environment id to search by"))]
+
+    def for(resource)
+      SEARCHABLES[resource.singular_name.to_sym] || DEFAULT_SEARCHABLES
+    end
+  end
+
+  class UuidIdResolver < HammerCLIKatello::IdResolver
+
+    def get_id(resource_name, options)
+      options[HammerCLI.option_accessor_name("id")] || find_resource(resource_name, options)['uuid']
+    end
+  end
 end


### PR DESCRIPTION
...id

Depends on https://github.com/Katello/katello/pull/4071
- Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=985393
- info, tasks and update should be able to be used by passing
- name,environment,organization search
