### PR TITLE
Fixes #5613 - Content Hosts outputs uuid bz1084722

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -18,8 +18,7 @@ module HammerCLIKatello
 
       output do
         field :name, _("Name")
-        field :id, _("ID")
-        field :uuid, _("UUID")
+        field :uuid, _("ID")
         field :description, _("Description")
         field :location, _("Location")
         from :environment do
@@ -38,6 +37,8 @@ module HammerCLIKatello
 
     class CreateCommand < HammerCLIKatello::CreateCommand
       resource :systems, :create
+
+      output InfoCommand.output_definition
 
       success_message _("Content host created")
       failure_message _("Could not create content host")


### PR DESCRIPTION
Content hosts will now ouput uuid instead of id to align the input for
the commands to the output of the commands.
