### PR TITLE
Fixes #5730 - Enable searching in ContentHostTasks

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -52,4 +52,22 @@ module HammerCLIKatello
   class RemoveAssociatedCommand < HammerCLIForeman::RemoveAssociatedCommand
     include HammerCLIKatello::ResolverCommons
   end
+
+  class NestedResourceListCommand < HammerCLIKatello::ListCommand
+    # obtain resource id
+    def request_params
+      params = super
+      params['id'] ||= get_identifier
+      params
+    end
+
+    # override to use searchables defined
+    def self.custom_option_builders
+      builders = super
+      if resource_defined?
+        builders <<  HammerCLIForeman::SearchablesOptionBuilder.new(resource, searchables)
+      end
+      builders
+    end
+  end
 end

--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -71,7 +71,7 @@ module HammerCLIKatello
       build_options
     end
 
-    class TasksCommand < HammerCLIKatello::ListCommand
+    class TasksCommand < HammerCLIKatello::NestedResourceListCommand
       resource :systems, :tasks
 
       command_name "tasks"


### PR DESCRIPTION
This fixes the use of seaching in the Task subcommand for ContentHost.
Command previously, did not list --name as a valid parameter and did not
try to search for the resource.
