### PR TITLE
Fixes #5729 - content-host lookup by uuid

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -10,7 +10,7 @@ module HammerCLIKatello
         field :name, _("Name")
       end
 
-      build_options :without => [:environment_id]
+      build_options
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -19,6 +19,10 @@ module HammerCLIKatello
 
   class IdResolver < HammerCLIForeman::IdResolver
 
+    def system_id(options)
+      options[HammerCLI.option_accessor_name("id")] || find_resource(:systems, options)['uuid']
+    end
+
     def create_search_options(options, resource)
       return super if resource.name == :organizations
 
@@ -32,5 +36,4 @@ module HammerCLIKatello
     end
 
   end
-
 end


### PR DESCRIPTION
In the info, create, delete commands, non-id params can be used to
search for the resource. Currently the resource can not be found because
the command looks up the resource by its internal id instead of using the
uuid. This fix allows the commands to look up the resource by uuid.
