### PR TITLE
Build missing options for listing repositories

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -10,6 +10,7 @@ module HammerCLIKatello
         field :content_type, _("Content Type")
       end
 
+      build_options
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand


### PR DESCRIPTION
Without this, `hammer repository list` is useless.
