### PR TITLE
Fixes #5111 - product info did list options

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -69,6 +69,7 @@ module HammerCLIKatello
         end
       end
 
+      build_options
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand


### PR DESCRIPTION
Product info did not list options because it was missing the
call to build_options.

related to https://github.com/theforeman/hammer-cli/pull/112
