### PR TITLE
bump to version 0.0.4

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.version = HammerCLIKatello.version
 
-  spec.add_dependency 'hammer_cli_foreman', '~> 0.1.0'
-  spec.add_dependency 'hammer_cli_foreman_tasks'
+  spec.add_dependency 'hammer_cli_foreman', '~> 0.1.1'
+  spec.add_dependency 'hammer_cli_foreman_tasks', '~> 0.0.3'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'thor'

--- a/lib/hammer_cli_katello/version.rb
+++ b/lib/hammer_cli_katello/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIKatello
   def self.version
-    @version ||= Gem::Version.new('0.0.3')
+    @version ||= Gem::Version.new('0.0.4')
   end
 end


### PR DESCRIPTION
hammer_cli was bumped to `0.1.1` (20 may 2014)
hammer_cli_foreman was bumped to `0.1.1` (20 may 2014)

also bumping hammer_cli_foreman_tasks to `0.0.3` at the same time as this
one.
