### PR TITLE
Fixes #5893 - Fixes product info's content

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -61,7 +61,7 @@ module HammerCLIKatello
           field :deletable, _("Deletable")
         end
 
-        collection :productContent, _("Content") do
+        collection :product_content, _("Content") do
           from :content do
             field :name, _("Repo Name")
             field :contentUrl, _("URL")


### PR DESCRIPTION
Hammer product info was not displaying the content collection due to
the key being changed from 'productContent' to 'product_content'
