### PR TITLE
Fixes #5794 : Improve how Async commands are done in katello-cli.

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -25,6 +25,10 @@ module HammerCLIKatello
     include HammerCLIKatello::ResolverCommons
   end
 
+  class SingleResourceCommand < HammerCLIForeman::SingleResourceCommand
+    include HammerCLIKatello::ResolverCommons
+  end
+
   class ListCommand < HammerCLIForeman::ListCommand
     include HammerCLIKatello::ResolverCommons
   end

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -88,7 +88,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class DeleteCommand < HammerCLIForemanTasks::AsyncCommand
+    class DeleteCommand < HammerCLIKatello::DeleteCommand
+      include HammerCLIForemanTasks::Async
+
       action :destroy
       command_name "delete"
 
@@ -98,7 +100,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class PublishCommand < HammerCLIForemanTasks::AsyncCommand
+    class PublishCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       action :publish
       command_name "publish"
 
@@ -108,7 +112,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class RemoveFromEnvironmentCommand < HammerCLIForemanTasks::AsyncCommand
+    class RemoveFromEnvironmentCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       action :remove_from_environment
       command_name "remove-from-environment"
 
@@ -118,7 +124,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class RemoveCommand < HammerCLIForemanTasks::AsyncCommand
+    class RemoveCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       # command to remove content view environments and versions from a content view.
       # corresponds to the UI screen.
       action :remove

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -56,7 +56,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class PromoteCommand < HammerCLIForemanTasks::AsyncCommand
+    class PromoteCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       action :promote
       command_name "promote"
 
@@ -66,7 +68,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class DeleteCommand < HammerCLIForemanTasks::AsyncCommand
+    class DeleteCommand < HammerCLIKatello::DeleteCommand
+      include HammerCLIForemanTasks::Async
+
       action :destroy
       command_name "delete"
 

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -101,7 +101,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class SyncCommand < HammerCLIForemanTasks::AsyncCommand
+    class SyncCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       action :sync
       command_name "synchronize"
 

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -30,7 +30,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class UploadCommand < HammerCLIForemanTasks::AsyncCommand
+    class UploadCommand < HammerCLIKatello::Command
+      include HammerCLIForemanTasks::Async
+
       resource :subscriptions, :upload
       command_name "upload"
 
@@ -53,7 +55,9 @@ module HammerCLIKatello
              :required => true, :format => BinaryFile.new
     end
 
-    class DeleteManfiestCommand < HammerCLIForemanTasks::AsyncCommand
+    class DeleteManfiestCommand < HammerCLIKatello::DeleteCommand
+      include HammerCLIForemanTasks::Async
+
       resource :subscriptions, :delete_manifest
       command_name "delete-manifest"
 
@@ -63,7 +67,9 @@ module HammerCLIKatello
       build_options
     end
 
-    class RefreshManfiestCommand < HammerCLIForemanTasks::AsyncCommand
+    class RefreshManfiestCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
       resource :subscriptions, :refresh_manifest
       command_name "refresh-manifest"
 


### PR DESCRIPTION
The main use case driving this is subscription upload --organization-label.

This is a replacement for https://github.com/Katello/hammer-cli-katello/pull/169.
I am not sure why this does not apply, but it does not.
