### PR TITLE
Fixes #6055 - HC add/remove-content-host take uuid

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -91,7 +91,25 @@ module HammerCLIKatello
       build_options
     end
 
-    HammerCLIKatello::AssociatingCommands::ContentHost.extend_command(self)
+    class AddContentHostCommand < HammerCLIKatello::SingleResourceCommand
+      command_name 'add-content-host'
+      action  :add_systems
+
+      success_message _("The content host(s) has been added")
+      failure_message _("Could not add content host(s)")
+
+      build_options
+    end
+
+    class RemoveContentHostCommand < HammerCLIKatello::SingleResourceCommand
+      command_name 'remove-content-host'
+      action  :remove_systems
+
+      success_message _("The content host(s) has been removed")
+      failure_message _("Could not remove content host(s)")
+
+      build_options
+    end
 
     autoload_subcommands
   end


### PR DESCRIPTION
the host-collection command's --system-id option was accepting database
ids instead of uuids. This uses the
add_host_collections/remove_host_collections action instead of the
AssociatingCommands (which uses the update action). This is a simpler
approach than trying to alter/override the behavior of an
AssociatingCommand to accept uuids.
