### PR TITLE
Fixes #6056 - HC override desc create/update sysid

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -4,6 +4,12 @@ module HammerCLIKatello
     resource :host_collections
 
     module UuidRequestable
+      def self.included(base)
+        base.option "--system-ids",
+                    "SYSTEM_IDS",
+                    "List of system ids to replace the content hosts in host collection",
+                    :format => HammerCLI::Options::Normalizers::List.new
+      end
 
       def request_params
         params = super


### PR DESCRIPTION
Override host-collection create/update's description for --system-ids so
that it asks the user for ids.
