### PR TITLE
Fixes #6079 - Display org name of a capsule env

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -43,6 +43,10 @@ module HammerCLIKatello
         output do
           field :id, _("ID")
           field :name, _("Name")
+          from :organization do
+            field :name, _("Organization")
+          end
+
         end
 
         build_options
@@ -55,6 +59,10 @@ module HammerCLIKatello
         output do
           field :id, _("ID")
           field :name, _("Name")
+          from :organization do
+            field :name, _("Organization")
+          end
+
         end
 
         build_options


### PR DESCRIPTION
Added code to show the org info along with the environment for the
following calls

hammer> capsule content available-lifecycle-environments --id 1

hammer> capsule content lifecycle-environments --id 1
