### PR TITLE
Fixes #6096 - override sub --system-id description

### DIFF
--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -5,7 +5,17 @@ require 'hammer_cli_foreman/commands'
 module HammerCLIKatello
 
   class SubscriptionCommand < HammerCLI::AbstractCommand
+    module SystemIdDescriptionOverridable
+      def self.included(base)
+        base.option "--system-id",
+                    "ID",
+                    _("ID of the content host")
+      end
+    end
+
     class ListCommand < HammerCLIKatello::ListCommand
+      include SystemIdDescriptionOverridable
+
       resource :subscriptions, :index
 
       output do
@@ -56,6 +66,7 @@ module HammerCLIKatello
     end
 
     class DeleteManfiestCommand < HammerCLIKatello::DeleteCommand
+      include SystemIdDescriptionOverridable
       include HammerCLIForemanTasks::Async
 
       resource :subscriptions, :delete_manifest


### PR DESCRIPTION
hammer subscription list/delete-manifest --system-id flag's description
describes uuid when it should just describe ID
