### PR TITLE
Fixes #6105 - subs refresh_hist & delete-manifest

### DIFF
--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -65,7 +65,7 @@ module HammerCLIKatello
              :required => true, :format => BinaryFile.new
     end
 
-    class DeleteManfiestCommand < HammerCLIKatello::DeleteCommand
+    class DeleteManfiestCommand < HammerCLIKatello::Command
       include SystemIdDescriptionOverridable
       include HammerCLIForemanTasks::Async
 
@@ -78,7 +78,7 @@ module HammerCLIKatello
       build_options
     end
 
-    class RefreshManfiestCommand < HammerCLIKatello::SingleResourceCommand
+    class RefreshManfiestCommand < HammerCLIKatello::Command
       include HammerCLIForemanTasks::Async
 
       resource :subscriptions, :refresh_manifest


### PR DESCRIPTION
subscription refresh-history and delete-manifest commands were
requesting subscription id when subscription id should not need to be
provided. Fix was to use Command rather than a SingleResourceCommand.
