### PR TITLE
Fixes #6154 - ch lfenv option and resolve lfenv

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -11,6 +11,7 @@ module HammerCLIKatello
     HammerCLIKatello::ExceptionHandler
   end
 
+  require 'hammer_cli_katello/lifecycle_environment_name_resolvable'
   require "hammer_cli_katello/commands"
   require "hammer_cli_katello/associating_commands"
   require "hammer_cli_katello/version"

--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -4,6 +4,7 @@ module HammerCLIKatello
     resource :activation_keys
 
     class ListCommand < HammerCLIKatello::ListCommand
+      include LifecycleEnvironmentNameResolvable
       action :index
 
       output do
@@ -31,6 +32,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
+      include LifecycleEnvironmentNameResolvable
       action :show
 
       output do
@@ -54,6 +56,7 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
+      include LifecycleEnvironmentNameResolvable
       action :create
       success_message _("Activation key created")
       failure_message _("Could not create the activation key")
@@ -62,6 +65,7 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      include LifecycleEnvironmentNameResolvable
       action :update
       success_message _("Activation key updated")
       failure_message _("Could not update the activation key")

--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -9,6 +9,7 @@ module HammerCLIKatello
     end
 
     class ListCommand < HammerCLIKatello::ListCommand
+      include LifecycleEnvironmentNameResolvable
       resource :systems, :index
 
       output do
@@ -20,6 +21,7 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
+      include LifecycleEnvironmentNameResolvable
       include IdDescriptionOverridable
       resource :systems, :show
 
@@ -43,6 +45,7 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
+      include LifecycleEnvironmentNameResolvable
       resource :systems, :create
 
       output InfoCommand.output_definition
@@ -62,6 +65,7 @@ module HammerCLIKatello
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
       include IdDescriptionOverridable
+      include LifecycleEnvironmentNameResolvable
       resource :systems, :update
 
       success_message _("Content host updated")
@@ -72,6 +76,7 @@ module HammerCLIKatello
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
       include IdDescriptionOverridable
+      include LifecycleEnvironmentNameResolvable
       resource :systems, :destroy
 
       success_message _("Content host deleted")

--- a/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
@@ -1,0 +1,33 @@
+module HammerCLIKatello
+  module LifecycleEnvironmentNameResolvable
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def resource_name_mapping
+        mapping = Command.resource_name_mapping
+        mapping[:environment] = :lifecycle_environment
+        mapping
+      end
+    end
+
+    def lifecycle_environment_resolve_options(options)
+      {
+        HammerCLI.option_accessor_name("name") => options['option_environment_name'],
+        HammerCLI.option_accessor_name("id") => options['option_environment_id'],
+        HammerCLI.option_accessor_name("organization_id") => options["option_organization_id"],
+        HammerCLI.option_accessor_name("organization_name") => options["option_organization_name"]
+      }
+    end
+
+    def all_options
+      result = super.clone
+      if result['option_environment_name']
+        result['option_environment_id'] =  resolver.lifecycle_environment_id(
+                                             lifecycle_environment_resolve_options(result))
+      end
+      result
+    end
+  end
+end


### PR DESCRIPTION
This converts the --environment, --environment-id flags  content-host
subcommand to --lifecycle-environment, --lifecycle-environment-id
respectively. This also solves the issue where --environment was
resolving an ::Environment instead of a Katello::KTEnvironment.
