### PR TITLE
Fixes #6261 - add delete subcommand to AK

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -73,6 +73,15 @@ module HammerCLIKatello
       build_options
     end
 
+    class DeleteCommand < HammerCLIKatello::DeleteCommand
+      include LifecycleEnvironmentNameResolvable
+      action :destroy
+      success_message _("Activation key deleted")
+      failure_message _("Could not delete the activation key")
+
+      build_options
+    end
+
     class SubscriptionsCommand < HammerCLIKatello::ListCommand
       resource :subscriptions, :index
       desc _("List associated subscriptions")


### PR DESCRIPTION
this adds the 'delete' subcommand to activation-key
