### PR TITLE
Fixes #6263 - rename associating HC remove cmd

### DIFF
--- a/lib/hammer_cli_katello/associating_commands.rb
+++ b/lib/hammer_cli_katello/associating_commands.rb
@@ -34,7 +34,7 @@ module HammerCLIKatello
       end
 
       class RemoveHostCollectionCommand < HammerCLIKatello::RemoveAssociatedCommand
-        command_name 'remove-repository'
+        command_name 'remove-host-collection'
         associated_resource :host_collections
 
         success_message _("The host collection has been removed")


### PR DESCRIPTION
In the associating command for Host Collection, this change renames
the 'remove-repository' command to 'remove-host-collection'
