### PR TITLE
Fixes #6327 - cv resolv env name opt BZ1111231

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -8,6 +8,7 @@ module HammerCLIKatello
     resource :content_views
 
     class ListCommand < HammerCLIKatello::ListCommand
+      include LifecycleEnvironmentNameResolvable
       output do
         field :id, _("Content View ID")
         field :name, _("Name")
@@ -113,6 +114,7 @@ module HammerCLIKatello
     end
 
     class RemoveFromEnvironmentCommand < HammerCLIKatello::SingleResourceCommand
+      include LifecycleEnvironmentNameResolvable
       include HammerCLIForemanTasks::Async
 
       action :remove_from_environment


### PR DESCRIPTION
Fixes issue where content-view --lifecycle-environment option
resolves for the puppet environment instead of the
lifecycle-environment.
