### PR TITLE
Fixes #6345 - add description to list product cmd

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -7,6 +7,7 @@ module HammerCLIKatello
       output do
         field :id, _("ID")
         field :name, _("Name")
+        field :description, _("Description")
 
         from :organization do
           field :name, _("Organization")


### PR DESCRIPTION
This adds the description field to the product's list subcommand.
