### PR TITLE
Fixes #6453 - CH requires CV if env exst BZ1092712

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -60,6 +60,12 @@ module HammerCLIKatello
         end
       end
 
+      validate_options do
+        if any(:option_environment_id, :option_environment_name).exist?
+          any(:option_content_view_name, :option_content_view_id).required
+        end
+      end
+
       build_options :without => [:facts, :type, :installed_products]
     end
 


### PR DESCRIPTION
Content host create requires user to provide content view when user
provides the lifecycle environment options.
