### PR TITLE
Fixes #6466 - AK info for nonexistent org id

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -35,6 +35,15 @@ module HammerCLIKatello
       include LifecycleEnvironmentNameResolvable
       action :show
 
+      def request_params
+        params = super
+        if options.keys.any? { |o| o.match(/\Aoption_organization.*/) }
+          params['organization_id'] = resolver.organization_id(
+                            resolver.scoped_options('organization', all_options))
+        end
+        params
+      end
+
       output do
         field :name, _("Name")
         field :id, _("ID")


### PR DESCRIPTION
this fixes an issue when the users passes --organiztion_id in addition
to the --id. The org argument is accepted only if --id is not being
used. This will present an error message if other arguments are passed
along with --id.
