### PR TITLE
Fixes #6465 - AK update skip resolv depend resours

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -67,6 +67,16 @@ module HammerCLIKatello
     class UpdateCommand < HammerCLIKatello::UpdateCommand
       include LifecycleEnvironmentNameResolvable
       action :update
+
+      def request_params
+        if options.key? "option_id"
+          # super for grandparent
+          ::HammerCLI::Apipie::Command.instance_method(:request_params).bind(self).call
+        else
+          super
+        end
+      end
+
       success_message _("Activation key updated")
       failure_message _("Could not update the activation key")
 


### PR DESCRIPTION
This changes the ActivationKey update command to skip checking of
dependent resources if the id is given.
