### PR TITLE
Fixes #6640 - Update rubocop to 0.24.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,8 +19,11 @@ Encoding:
 LineLength:
   Max: 100
 
-FavorSprintf:
+FormatString:
   Enabled: false # we use % for i18n
 
 IfUnlessModifier:
   Enabled: false
+
+Next:
+  Enabled: false # don't force next over conditions

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 begin
   require 'rubocop/rake_task'
-  Rubocop::RakeTask.new
+  RuboCop::RakeTask.new
 
   desc "Runs Rubocop style checker with xml output for Jenkins"
   task 'rubocop:jenkins' do
@@ -27,7 +27,6 @@ task :default do
   Rake::Task['rubocop'].execute
 end
 
-
 namespace :gettext do
 
   desc "Update pot file"
@@ -37,7 +36,11 @@ namespace :gettext do
     require 'gettext/tools'
 
     domain = HammerCLIKatello::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name, domain.translated_files, "#{domain.domain_name} #{HammerCLIKatello.version.to_s}", :po_root => domain.locale_dir)
+    GetText.update_pofiles(domain.domain_name,
+                           domain.translated_files,
+                           "#{domain.domain_name} #{HammerCLIKatello.version}",
+                           :po_root => domain.locale_dir
+                          )
   end
 
 end

--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.unshift(File.expand_path('../lib', __FILE__))
+$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
 
 require 'hammer_cli_katello/version'
 
@@ -7,12 +7,13 @@ Gem::Specification.new do |spec|
   spec.authors = ['Katello']
   spec.email = ['katello@lists.fedorahosted.org']
   spec.license = "GPL-3"
-  spec.description = 'Hammer-CLI-Katello is a plugin for Hammer to provide connectivity to a Katello server.'
+  spec.description = 'Hammer-CLI-Katello is a plugin for Hammer to provide' \
+    ' connectivity to a Katello server.'
   spec.summary = 'Katello commands for Hammer'
   spec.homepage = 'http://github.com/theforeman/hammer-cli-katello'
 
   spec.files = Dir['lib/**/*.rb', 'locale/**/**']
-  spec.test_files = `git ls-files -- {test,spec,features}/*`.split($\)
+  spec.test_files = `git ls-files -- {test,spec,features}/*`.split($ORS)
 
   spec.name = 'hammer_cli_katello'
   spec.require_paths = ['lib']
@@ -29,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'ci_reporter'
 
-  spec.add_development_dependency "rubocop", "0.17.0"
+  spec.add_development_dependency "rubocop", "0.24.1"
   spec.add_development_dependency "rubocop-checkstyle_formatter"
 end

--- a/lib/hammer_cli_katello/gpg_key.rb
+++ b/lib/hammer_cli_katello/gpg_key.rb
@@ -42,7 +42,7 @@ module HammerCLIKatello
       success_message _("GPG Key created")
       failure_message _("Could not create GPG Key")
 
-      build_options  :without => [:content]
+      build_options :without => [:content]
       option "--key", "GPG_KEY_FILE", _("GPG Key file"),
              :attribute_name => :option_content,
              :required => true,

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -99,7 +99,7 @@ module HammerCLIKatello
 
     class AddContentHostCommand < HammerCLIKatello::SingleResourceCommand
       command_name 'add-content-host'
-      action  :add_systems
+      action :add_systems
 
       success_message _("The content host(s) has been added")
       failure_message _("Could not add content host(s)")
@@ -109,7 +109,7 @@ module HammerCLIKatello
 
     class RemoveContentHostCommand < HammerCLIKatello::SingleResourceCommand
       command_name 'remove-content-host'
-      action  :remove_systems
+      action :remove_systems
 
       success_message _("The content host(s) has been removed")
       failure_message _("Could not remove content host(s)")

--- a/lib/hammer_cli_katello/output/fields.rb
+++ b/lib/hammer_cli_katello/output/fields.rb
@@ -1,13 +1,15 @@
 require 'hammer_cli'
 
-module HammerCLIKatello::Output
-  module Fields
+module HammerCLIKatello
+  module Output
+    module Fields
 
-    class ChecksumFilePair < ::Fields::Field
+      class ChecksumFilePair < ::Fields::Field
+      end
+
+      class Dependency < ::Fields::Field
+      end
+
     end
-
-    class Dependency < ::Fields::Field
-    end
-
   end
 end

--- a/lib/hammer_cli_katello/output/formatters.rb
+++ b/lib/hammer_cli_katello/output/formatters.rb
@@ -1,32 +1,34 @@
-module HammerCLIKatello::Output
-  module Formatters
+module HammerCLIKatello
+  module Output
+    module Formatters
 
-    class ChecksumFormatter < HammerCLI::Output::Formatters::FieldFormatter
+      class ChecksumFormatter < HammerCLI::Output::Formatters::FieldFormatter
 
-      def tags
-        [:screen]
-      end
+        def tags
+          [:screen]
+        end
 
-      def format(items, field_params = {})
-        "%s  %s" % items.reverse
-      end
-    end
-
-    class DependencyFormatter < HammerCLI::Output::Formatters::FieldFormatter
-
-      def format(dependency, field_params = {})
-        name = dependency[:name] || dependency['name']
-        version = dependency[:version_requirement] || dependency['version_requirement']
-        if version
-          "%s ( %s )" % [name, version]
-        else
-          name
+        def format(items, _ = {})
+          "%s  %s" % items.reverse
         end
       end
+
+      class DependencyFormatter < HammerCLI::Output::Formatters::FieldFormatter
+
+        def format(dependency, _ = {})
+          name = dependency[:name] || dependency['name']
+          version = dependency[:version_requirement] || dependency['version_requirement']
+          if version
+            "%s ( %s )" % [name, version]
+          else
+            name
+          end
+        end
+      end
+
+      HammerCLI::Output::Output.register_formatter(ChecksumFormatter.new, :ChecksumFilePair)
+      HammerCLI::Output::Output.register_formatter(DependencyFormatter.new, :Dependency)
+
     end
-
-    HammerCLI::Output::Output.register_formatter(ChecksumFormatter.new, :ChecksumFilePair)
-    HammerCLI::Output::Output.register_formatter(DependencyFormatter.new, :Dependency)
-
   end
 end

--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -60,7 +60,7 @@ module HammerCLIKatello
 
     def send_request
       super.tap do |data|
-        data['services'].each do |name, service|
+        data['services'].each do |_, service|
           service['_response'] = get_server_response(service)
         end
       end


### PR DESCRIPTION
This requires https://github.com/Katello/hammer-cli-katello/pull/204

See [the rubocop changelog for details about what's new](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md).
