### PR TITLE
Fixes #6761 - lazy loaded subcommands

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -24,20 +24,82 @@ module HammerCLIKatello
   require 'hammer_cli_katello/id_resolver'
 
   # commands
-  require "hammer_cli_katello/activation_key"
-  require "hammer_cli_katello/gpg_key"
-  require "hammer_cli_katello/lifecycle_environment"
-  require "hammer_cli_katello/organization"
-  require "hammer_cli_katello/ping"
-  require "hammer_cli_katello/product"
-  require "hammer_cli_katello/puppet_module"
-  require "hammer_cli_katello/repository"
-  require "hammer_cli_katello/repository_set"
-  require "hammer_cli_katello/subscription"
-  require "hammer_cli_katello/sync_plan"
-  require "hammer_cli_katello/host_collection"
-  require "hammer_cli_katello/content_host"
-  require "hammer_cli_katello/content_view"
-  require "hammer_cli_katello/capsule"
+  HammerCLI::MainCommand.lazy_subcommand("activation-key", _("Manipulate activation keys."),
+                                         'HammerCLIKatello::ActivationKeyCommand',
+                                         'hammer_cli_katello/activation_key'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand!("organization", _("Manipulate organizations"),
+                                          'HammerCLIKatello::Organization',
+                                          'hammer_cli_katello/organization'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("gpg", _("manipulate GPG Key actions on the server"),
+                                         'HammerCLIKatello::GpgKeyCommand',
+                                         'hammer_cli_katello/gpg_key'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("lifecycle-environment",
+                                         _("manipulate lifecycle_environments on the server"),
+                                         'HammerCLIKatello::LifecycleEnvironmentCommand',
+                                         'hammer_cli_katello/lifecycle_environment'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("ping", _("get the status of the server"),
+                                         'HammerCLIKatello::PingCommand',
+                                         'hammer_cli_katello/ping'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("product", _("Manipulate products."),
+                                         'HammerCLIKatello::Product',
+                                         'hammer_cli_katello/product'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("puppet-module", _("View Puppet Module details."),
+                                         'HammerCLIKatello::PuppetModule',
+                                         'hammer_cli_katello/puppet_module'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("repository", _("Manipulate repositories"),
+                                         'HammerCLIKatello::Repository',
+                                         'hammer_cli_katello/repository'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("repository-set",
+                                         _("manipulate repository sets on the server"),
+                                         'HammerCLIKatello::RepositorySetCommand',
+                                         'hammer_cli_katello/repository_set'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("subscription", _("Manipulate subscriptions."),
+                                         'HammerCLIKatello::SubscriptionCommand',
+                                         'hammer_cli_katello/subscription'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand('sync-plan', _("Manipulate sync plans"),
+                                         'HammerCLIKatello::SyncPlan',
+                                         'hammer_cli_katello/sync_plan'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand('host-collection', _("Manipulate host collections"),
+                                         'HammerCLIKatello::HostCollection',
+                                         'hammer_cli_katello/host_collection'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("content-host",
+                                         _("manipulate content hosts on the server"),
+                                         'HammerCLIKatello::ContentHostCommand',
+                                         'hammer_cli_katello/content_host'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("content-view", _("Manipulate content views."),
+                                         'HammerCLIKatello::ContentView',
+                                         'hammer_cli_katello/content_view'
+  )
+
+  HammerCLI::MainCommand.lazy_subcommand("capsule", _("Manipulate capsule"),
+                                         'HammerCLIKatello::Capsule',
+                                         'hammer_cli_katello/capsule'
+  )
 
 end

--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -193,6 +193,3 @@ module HammerCLIKatello
   end
 
 end
-
-HammerCLI::MainCommand.subcommand("activation-key", _("Manipulate activation keys."),
-                                  HammerCLIKatello::ActivationKeyCommand)

--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -104,5 +104,4 @@ module HammerCLIKatello
     autoload_subcommands
   end
 
-  HammerCLI::MainCommand.subcommand "capsule", _("Manipulate capsule"), Capsule
 end

--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -103,9 +103,4 @@ module HammerCLIKatello
     autoload_subcommands
   end
 
-  cmd_name = "content-host"
-  cmd_desc = _("manipulate content hosts on the server")
-  cmd_cls  = HammerCLIKatello::ContentHostCommand
-  HammerCLI::MainCommand.subcommand(cmd_name, cmd_desc, cmd_cls)
-
 end

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -198,6 +198,3 @@ module HammerCLIKatello
                HammerCLIKatello::ContentViewVersion
   end
 end
-
-HammerCLI::MainCommand.subcommand "content-view", _("Manipulate content views."),
-                                  HammerCLIKatello::ContentView

--- a/lib/hammer_cli_katello/gpg_key.rb
+++ b/lib/hammer_cli_katello/gpg_key.rb
@@ -69,7 +69,4 @@ module HammerCLIKatello
     autoload_subcommands
   end
 
-  HammerCLI::MainCommand.subcommand("gpg",
-                                    _("manipulate GPG Key actions on the server"),
-                                    HammerCLIKatello::GpgKeyCommand)
 end

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -120,6 +120,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand 'host-collection', _("Manipulate host collections"),
-                                  HammerCLIKatello::HostCollection

--- a/lib/hammer_cli_katello/lifecycle_environment.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment.rb
@@ -93,8 +93,4 @@ module HammerCLIKatello
     autoload_subcommands
   end
 
-  cmd_name = "lifecycle-environment"
-  cmd_desc = _("manipulate lifecycle_environments on the server")
-  cmd_cls  = HammerCLIKatello::LifecycleEnvironmentCommand
-  HammerCLI::MainCommand.subcommand(cmd_name, cmd_desc, cmd_cls)
 end

--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -1,3 +1,5 @@
+require 'hammer_cli_foreman/organization'
+
 module HammerCLIKatello
 
   class Organization < HammerCLIForeman::Organization
@@ -61,6 +63,3 @@ module HammerCLIKatello
   end
 
 end
-
-HammerCLI::MainCommand.subcommand! 'organization', _("Manipulate organizations"),
-                                   HammerCLIKatello::Organization

--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -78,7 +78,4 @@ module HammerCLIKatello
 
   end # class PingCommand
 
-  HammerCLI::MainCommand.subcommand("ping", _("get the status of the server"),
-                                    HammerCLIKatello::PingCommand)
-
 end # module HammerCLIKatello

--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -120,6 +120,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand "product", _("Manipulate products."),
-                                  HammerCLIKatello::Product

--- a/lib/hammer_cli_katello/puppet_module.rb
+++ b/lib/hammer_cli_katello/puppet_module.rb
@@ -48,7 +48,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand "puppet-module",
-                                  "View Puppet Module details.",
-                                  HammerCLIKatello::PuppetModule

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -250,6 +250,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand "repository", _("Manipulate repositories"),
-                                  HammerCLIKatello::Repository

--- a/lib/hammer_cli_katello/repository_set.rb
+++ b/lib/hammer_cli_katello/repository_set.rb
@@ -83,6 +83,4 @@ module HammerCLIKatello
     autoload_subcommands
   end
 
-  HammerCLI::MainCommand.subcommand("repository-set", _("manipulate repository sets on the server"),
-                                    HammerCLIKatello::RepositorySetCommand)
 end

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -99,6 +99,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand("subscription", _("Manipulate subscriptions."),
-                                  HammerCLIKatello::SubscriptionCommand)

--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -69,6 +69,3 @@ module HammerCLIKatello
     autoload_subcommands
   end
 end
-
-HammerCLI::MainCommand.subcommand 'sync-plan', _("Manipulate sync plans"),
-                                  HammerCLIKatello::SyncPlan


### PR DESCRIPTION
Subcommands loaded lazily to speed up hammer's startup.

Requires https://github.com/theforeman/hammer-cli/pull/126
