### PR TITLE
Fixes #6894,bz1123473 - rm system in HC helpfultxt

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -7,7 +7,7 @@ module HammerCLIKatello
       def self.included(base)
         base.option "--host-collection-ids",
                     "HOST_COLLECTION_IDS",
-                    _("Array of system ids to replace the content hosts in host collection"),
+                    _("Array of content host ids to replace the content hosts in host collection"),
                     :format => HammerCLI::Options::Normalizers::List.new
       end
 


### PR DESCRIPTION
Remove references to system in the host-collection helpful text
