### PR TITLE
Fixes #6987 - set unlimited_content_hosts

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -35,6 +35,13 @@ module HammerCLIKatello
     class CreateCommand < HammerCLIKatello::CreateCommand
       include UuidRequestable
       resource :host_collections, :create
+      def request_params
+        super.tap do |params|
+          if params['max_content_hosts'] && params['unlimited_content_hosts'].nil?
+            params['unlimited_content_hosts'] = false
+          end
+        end
+      end
 
       success_message _("Host collection created")
       failure_message _("Could not create the host collection")


### PR DESCRIPTION
creation of host-collections with the --max-content-hosts flag also
sets the unlimited_content_hosts flag.
