### PR TITLE
Fixes #7076 - product sync-plan-id option twice

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -97,9 +97,6 @@ module HammerCLIKatello
       resource :products, :update
 
       build_options :without => [:name, :label, :provider_id, :description, :gpg_key_id]
-      # TODO: set to --sync-plan-id
-      option "--sync_plan_id", "SYNC_PLAN_ID", _("plan numeric identifier"),
-             :attribute_name => :option_sync_plan_id, :required => true
     end
 
     class RemoveSyncPlanCommand < HammerCLIKatello::UpdateCommand


### PR DESCRIPTION
This fixes an issue where the sync-plan-id option is displayed twice in
the helpful texts for the product set-sync-plan, remove-sync-plan
commands.
