### PR TITLE
Fixes 6291 - puppet module display and takes uuid

### DIFF
--- a/lib/hammer_cli_katello/content_view_puppet_module.rb
+++ b/lib/hammer_cli_katello/content_view_puppet_module.rb
@@ -8,8 +8,7 @@ module HammerCLIKatello
 
     class ListCommand < HammerCLIKatello::ListCommand
       output do
-        field :id, _("ID")
-        field :uuid, _("UUID")
+        field :uuid, _("ID")
         field :name, _("Name")
         field :author, _("Author")
         field :version, _("Version")
@@ -30,10 +29,16 @@ module HammerCLIKatello
     class CreateCommand < HammerCLIKatello::CreateCommand
       command_name "add"
 
+      option "--id", "ID", _("id of the puppet module to associate")
+
+      def request_params
+        super.tap { |params| params['uuid'] = params.delete('id') if params['id'] }
+      end
+
       success_message _("Puppet module added to content view")
       failure_message _("Could not add the puppet module")
 
-      build_options
+      build_options :without => :uuid
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
@@ -42,7 +47,22 @@ module HammerCLIKatello
       success_message _("Puppet module removed from content view")
       failure_message _("Couldn't remove puppet module from the content view")
 
-      build_options
+      def resolve_puppet_module_id_from_uuid(options)
+        uuid = options.delete HammerCLI.option_accessor_name("id")
+        options[HammerCLI.option_accessor_name("uuid")] = uuid
+        resolver.content_view_puppet_module_id(options)
+      end
+
+      def all_options
+        if super['option_id']
+          super.merge(HammerCLI.option_accessor_name("id") =>
+                      resolve_puppet_module_id_from_uuid(super))
+        else
+          super
+        end
+      end
+
+      build_options :without => :uuid
     end
 
     autoload_subcommands


### PR DESCRIPTION
this changes puppet-module commands so they consistently display uuids
and take uuids for options. The database ids will be hidden and uuids
displaye dot users will be laelled as Ids. all the --id filags will
accept uuids.
