### PR TITLE
Fixes #7144 - add/remove content-hosts fails

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -104,7 +104,23 @@ module HammerCLIKatello
       build_options
     end
 
+    # TODO: temp fix until apipie reports correct type for type array params
+    module HostCollectionIDsAsNormalizedList
+      def self.included(base)
+        base.option "--content-host-ids", "CONTENT_HOST_IDS", _("Array of content-host ids"),
+                    :format => HammerCLI::Options::Normalizers::List.new
+      end
+
+      def all_options
+        result = super
+        result['option_system_ids'] = result['option_content_host_ids']
+        result.delete 'option_content_host_ids'
+        result
+      end
+    end
+
     class AddContentHostCommand < HammerCLIKatello::SingleResourceCommand
+      include HostCollectionIDsAsNormalizedList
       command_name 'add-content-host'
       action :add_systems
 
@@ -115,6 +131,7 @@ module HammerCLIKatello
     end
 
     class RemoveContentHostCommand < HammerCLIKatello::SingleResourceCommand
+      include HostCollectionIDsAsNormalizedList
       command_name 'remove-content-host'
       action :remove_systems
 


### PR DESCRIPTION
Temp fix until https://github.com/theforeman/hammer-cli/pull/138 can get in.

This --content-host-ids is not being treated as an array and is therefore 
being sent incorrectly through apipie. There is currently a bug with
apipie where the type for the params are not being reported correctly.
This is a temp fix until the apipie issue can be fixed.
