### PR TITLE
Fixes #7151 - hc create/update --content-hosts

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -13,8 +13,8 @@ module HammerCLIKatello
 
       def request_params
         params = super
-        params['system_uuids'] = option_host_collection_ids unless option_host_collection_ids.nil?
-        params.delete('host_collection_ids') if params.keys.include? 'host_collection_ids'
+        params['system_uuids'] = option_system_ids unless option_system_ids.nil?
+        params.delete('system_ids') if params.keys.include? 'system_ids'
         params
       end
     end


### PR DESCRIPTION
host-collection create and update are ignoring --content-hosts because
ability to alias resource names from systems to host-collections (this
causes the option names to change).
