### PR TITLE
Fixes #7950 - Show docker repos in a CV

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -33,7 +33,13 @@ module HammerCLIKatello
           field :name, _("Organization")
         end
 
-        collection :repositories, _("Repositories") do
+        collection :_yum_repositories, _("Yum Repositories") do
+          field :id, _("ID")
+          field :name, _("Name")
+          field :label, _("Label")
+        end
+
+        collection :_docker_repositories, _("Docker Repositories") do
           field :id, _("ID")
           field :name, _("Name")
           field :label, _("Label")
@@ -67,6 +73,17 @@ module HammerCLIKatello
         collection :activation_keys, _("Activation Keys") do
           custom_field Fields::Reference
         end
+      end
+
+      def extend_data(data)
+        data["_yum_repositories"] = data["repositories"].select do |repo|
+          repo["content_type"] == "yum"
+        end
+
+        data["_docker_repositories"] = data["repositories"].select do |repo|
+          repo["content_type"] == "docker"
+        end
+        data
       end
 
       build_options

--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -66,6 +66,7 @@ module HammerCLIKatello
           from :content do
             field :name, _("Repo Name")
             field :contentUrl, _("URL")
+            field :type, _("Content Type")
           end
         end
       end


### PR DESCRIPTION
Code to show docker information like

```
$ hammer content-view info --organization=docker --name=wow
ID:                  5
Name:                wow
Label:               wow
Composite:           
Description:         
Content Host Count:  0
Organization:        docker
Yum Repositories:    
 1) ID:    17
    Name:  zoo
    Label: zoo
Docker Repositories: 
 1) ID:    29
    Name:  fedora/rabbitmq
    Label: fedora_rabbitmq
Puppet Modules:      

Environments:        
 1) ID:   2
    Name: Library
Versions:            
 1) ID:        4
    Version:   1
    Published: 2014/10/10 19:14:30
 2) ID:        7
    Version:   2
    Published: 2014/10/10 20:31:58
 3) ID:        8
    Version:   3
    Published: 2014/10/14 19:43:49
Components:          

Activation Keys:
```
