### PR TITLE
Fixes #8242 - Create docker-tag command

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -121,4 +121,9 @@ module HammerCLIKatello
                                          'HammerCLIKatello::DockerImageCommand',
                                          'hammer_cli_katello/docker_image'
   )
+
+  HammerCLI::MainCommand.lazy_subcommand("docker-tag", _("Manipulate docker tags"),
+                                         'HammerCLIKatello::DockerTagCommand',
+                                         'hammer_cli_katello/docker_tag'
+  )
 end

--- a/lib/hammer_cli_katello/docker_tag.rb
+++ b/lib/hammer_cli_katello/docker_tag.rb
@@ -1,0 +1,33 @@
+module HammerCLIKatello
+  class DockerTagCommand < HammerCLIKatello::Command
+    resource :docker_tags
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      output do
+        field :id, _("ID")
+        field :tag, _("Tag")
+        field :repository_id, _("Repository ID")
+      end
+
+      build_options do |o|
+        o.expand.including(:products, :organizations, :content_views)
+      end
+    end
+
+    class InfoCommand < HammerCLIKatello::InfoCommand
+      output do
+        field :id, _("ID")
+        field :tag, _("Tag")
+        field :repository_id, _("Repository ID")
+
+        from :image do
+          field :id, _("Docker Image ID")
+        end
+      end
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/4793

```
❯ h docker-tag list
---|--------|----------------
ID | TAG    | REPOSITORY NAME
---|--------|----------------
16 | latest | redis
15 | 2.8.17 | redis
14 | 2.8    | redis
13 | 2.8.10 | redis
12 | 2.8.11 | redis
11 | 2.8.14 | redis
10 | 2.6.17 | redis
9  | 2.6    | redis
8  | 2.8.8  | redis
7  | 2.8.6  | redis
6  | 2.8.12 | redis
5  | 2.8.7  | redis
4  | 2.8.15 | redis
3  | 2.8.9  | redis
2  | 2.8.16 | redis
1  | 2.8.13 | redis
---|--------|----------------
❯ h docker-tag info --id 16
ID:              16
Tag:             latest
Repository ID:   5
Repository Name: redis
Docker Image ID: a6b77710-ff5e-4804-9c80-66274a1742cb
```
