### PR TITLE
Fixes #8511 - Add remove content command

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -244,6 +244,28 @@ module HammerCLIKatello
       end
     end
 
+    class RemoveContentCommand < HammerCLIKatello::SingleResourceCommand
+      include RepositoryScopedToProduct
+
+      resource :repositories, :remove_content
+      command_name "remove-content"
+
+      option ["--content-ids"], "CONTENT_IDS",
+        _("Comma separated list of package/puppet module/docker image ids"),
+        :format => HammerCLI::Options::Normalizers::List.new, :required => true
+
+      def request_params
+        super.tap do |opts|
+          opts[:uuids] = option_content_ids
+        end
+      end
+
+      success_message _("Repository content removed")
+      failure_message _("Could not remove content")
+
+      build_options :without => ["uuids"]
+    end
+
     autoload_subcommands
   end
 end


### PR DESCRIPTION
I think we should add options to look up content by content-specific attributes (package name, docker image id, etc) but am wondering if that should be a separate PR since it's going to require a big effort that may prevent this from being included in katello 2.1.
