### PR TITLE
Fixes #8547 - Showing error when no env params

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -72,10 +72,6 @@ module HammerCLIKatello
              :flag,
              _("force content view promotion and bypass lifecycle environment restriction")
 
-      option "--from-lifecycle-environment", "FROM_ENVIRONMENT",
-             _("Name of the source environment"), :attribute_name => :option_environment_name
-      option "--from-lifecycle-environment-id", "FROM_ENVIRONMENT_ID",
-             _("Id of the source environment"), :attribute_name => :option_environment_id
       option "--to-lifecycle-environment", "TO_ENVIRONMENT",
              _("Name of the target environment"), :attribute_name => :option_to_environment_name
       option "--to-lifecycle-environment-id", "TO_ENVIRONMENT_ID",


### PR DESCRIPTION
To test, try not supplying "--to-lifecycle-environment-id" and "--to-lifecycle-environment" and you should get an error message:

```
Could not promote the content view:
  Error: Missing options to search lifecycle_environment
```