### PR TITLE
fixes #8765 - rpm spec should match dependencies of gem

### DIFF
--- a/rubygem-hammer_cli_katello.spec
+++ b/rubygem-hammer_cli_katello.spec
@@ -21,7 +21,8 @@ Source1: katello.yml
 Requires: ruby(abi)
 %endif
 Requires: ruby(rubygems)
-Requires: rubygem(hammer_cli) >= 0.1.1
+Requires: rubygem(hammer_cli) >= 0.1.3
+Requires: rubygem(hammer_cli_bootdisk)
 Requires: rubygem(hammer_cli_foreman_tasks) >= 0.0.3
 BuildRequires: ruby(rubygems)
 %if 0%{?fedora} || 0%{?rhel} > 6


### PR DESCRIPTION
Fixes broken BATS tests.   The gem requires foreman_bootdisk, the RPM should as well.

Tests are failing because the gem won't load:

```
# hammer -u admin -p changeme repository list --organization-id 1
Warning: An error occured while loading module hammer_cli_katello
Error: No such sub-command 'repository'

See: 'hammer --help'
[root@prometheus yum.repos.d]# 
```

I've matched the dependencies of the gem in this PR.   Although, the ruby `~>` operator should mandate we set an upper limit of the version I kept the hammer convention of not setting that.
