### PR TITLE
Fixes #9183 - Remove duplicate key for content_view

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -26,7 +26,6 @@ module HammerCLIKatello
         s("author", _("Puppet module's author to search by")),
         s("uuid", _("Puppet module's UUID to search by"))
       ],
-      :content_view =>         [s_name(_("Content view name"))],
       :content_view_version => [s("version", _("Content view version number"))]
     }
 


### PR DESCRIPTION
Keeping it doesn't cause any issue, however without this removal we get this warning on every hammer call

`/home/daniel/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/hammer_cli_katello-0.0.7/lib/hammer_cli_katello/id_resolver.rb:9: warning: duplicated key at line 29 ignored: :content_view`