### PR TITLE
Fixes #8203, #9226 - Docker counts displayed on repo info

### DIFF
--- a/lib/hammer_cli_katello/docker_image.rb
+++ b/lib/hammer_cli_katello/docker_image.rb
@@ -9,10 +9,16 @@ module HammerCLIKatello
         field :id, _("ID")
         field :image_id, _("Image ID")
         field :size, _("Size")
+        field :tag_count, _("Tags")
       end
 
       build_options do |o|
         o.expand.including(:products, :organizations, :content_views)
+      end
+
+      def extend_data(data)
+        data["tag_count"] = data["tags"].size
+        data
       end
     end
 

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -33,6 +33,8 @@ module HammerCLIKatello
         field :url, _("URL")
         field :_publish_via_http, _("Publish Via HTTP")
         field :full_path, _("Published At")
+        field :docker_upstream_name, _("Upstream Repository Name"),
+              Fields::Field, :hide_blank => true
 
         label _("Product") do
           from :product do
@@ -61,28 +63,35 @@ module HammerCLIKatello
           field :package_group_total, _("Package Groups"), Fields::Field, :hide_blank => true
           field :errata_total, _("Errata"), Fields::Field, :hide_blank => true
           field :puppet_total, _("Puppet Modules"), Fields::Field, :hide_blank => true
+          field :docker_image_total, _("Docker Images"), Fields::Field, :hide_blank => true
+          field :docker_tag_total, _("Docker Tags"), Fields::Field, :hide_blank => true
         end
       end
 
-      def send_request
-        super.tap do |data|
-          data["_redhat_repo"] = data["product_type"] == "redhat" ? _("yes") : _("no")
-          data["_publish_via_http"] = data["unprotected"] ? _("yes") : _("no")
-          data["_sync_state"] = get_sync_status(data["sync_state"])
-          setup_content_counts(data)
+      def extend_data(data)
+        data["_redhat_repo"] = data["product_type"] == "redhat" ? _("yes") : _("no")
+        data["_publish_via_http"] = data["unprotected"] ? _("yes") : _("no")
+        data["_sync_state"] = get_sync_status(data["sync_state"])
+        if data["content_type"] == "yum" && data["gpg_key"]
+          data["gpg_key_name"] = data["gpg_key"]["name"]
         end
+
+        setup_content_counts(data) if data["content_counts"]
+        data
       end
 
       def setup_content_counts(data)
-        if data["content_type"] == "yum"
-          if data["content_counts"]
-            data["package_total"]  =  data["content_counts"]["rpm"]
-            data["package_group_total"]  =  data["content_counts"]["package_group"]
-            data["errata_total"]  =  data["content_counts"]["erratum"]
-          end
-          data["gpg_key_name"] = data["gpg_key"]["name"] if data["gpg_key"]
-        else
-          data["puppet_total"] = data["content_counts"]["puppet_module"] if data["content_counts"]
+        content_counts = data["content_counts"]
+        case data["content_type"]
+        when "yum"
+          data["package_total"]  =  content_counts["rpm"]
+          data["package_group_total"]  =  content_counts["package_group"]
+          data["errata_total"]  =  content_counts["erratum"]
+        when "docker"
+          data["docker_image_total"] = content_counts["docker_image"]
+          data["docker_tag_total"] = content_counts["docker_tag"]
+        when "puppet"
+          data["puppet_total"] = content_counts["puppet_module"]
         end
       end
 


### PR DESCRIPTION
Docker Images / Docker Tag information can be now
seen in the hammer repository info command