### PR TITLE
Refs #7796 - Shows docker registry names for CDN enablement

### DIFF
--- a/lib/hammer_cli_katello/repository_set.rb
+++ b/lib/hammer_cli_katello/repository_set.rb
@@ -44,6 +44,7 @@ module HammerCLIKatello
           field :basearch, _("Arch")
           field :releasever, _("Release")
         end
+        field :registry_name, _("Registry Name")
         field :enabled, _("Enabled"), Fields::Boolean
       end
 


### PR DESCRIPTION
hammer repository-set available-repositories --product-id=21 --id=3877

will now show a Registry Name for docker repos.