### PR TITLE
Refs #9518, #9310 - Show container repo image name

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -35,6 +35,8 @@ module HammerCLIKatello
         field :full_path, _("Published At")
         field :docker_upstream_name, _("Upstream Repository Name"),
               Fields::Field, :hide_blank => true
+        field :container_repository_name, _("Container Repository Name"),
+              Fields::Field, :hide_blank => true
 
         label _("Product") do
           from :product do


### PR DESCRIPTION
Repo info will now show a field called "Container Image Name" for docker
repos. Users can use this information to populate the repository_name in
hammer docker container create call.

Ties with https://github.com/Katello/katello/pull/5077