### PR TITLE
Release Version in content-host info being empty due to a typo.

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -45,7 +45,7 @@ module HammerCLIKatello
           field :name, _("Content View")
         end
         field :entitlementStatus, _("Entitlement Status")
-        field :releaseVer, _("Release Version")
+        field :release_ver, _("Release Version")
         field :autoheal, _("Autoheal")
         from :errata_counts do
           field :security, _("Security Errata")


### PR DESCRIPTION
Rresolves https://bugzilla.redhat.com/show_bug.cgi?id=1199137

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>