### PR TITLE
fixes #9679 - fix host collection erratum install

### DIFF
--- a/lib/hammer_cli_katello/host_collection_erratum.rb
+++ b/lib/hammer_cli_katello/host_collection_erratum.rb
@@ -12,7 +12,8 @@ module HammerCLIKatello
         'ERRATA',
         _("List of Errata to install"),
         :required => true,
-        :format => HammerCLI::Options::Normalizers::List.new)
+        :format => HammerCLI::Options::Normalizers::List.new,
+        :attribute_name => :content)
 
       def content_type
         'errata'


### PR DESCRIPTION
Errata should be renamed to content, like packages is here:
  https://github.com/Katello/hammer-cli-katello/blob/master/lib/hammer_cli_katello/host_collection_package.rb#L13
