### PR TITLE
refs #9628 - need to use params instead of options

### DIFF
--- a/lib/hammer_cli_katello/lifecycle_environment.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment.rb
@@ -18,7 +18,7 @@ module HammerCLIKatello
 
       def request_params
         params = super
-        prior = options.delete(HammerCLI.option_accessor_name("prior"))
+        prior = params.delete("prior")
         if prior
           params["prior_id"] = resolver.lifecycle_environment_id(
             HammerCLI.option_accessor_name("name") => prior,


### PR DESCRIPTION
not sure how i missed this before, but `options` is a method that
returns a generated array that isn't persistent, so calling `#delete` on
it is pointless. on the other hand, `params` is a variable containing a
hash that isn't thrown away.