### PR TITLE
Fixes #11110 - hammer content-view --help wrong remove-content descri…

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -191,6 +191,7 @@ module HammerCLIKatello
 
     class RemoveContentViewVersionCommand < HammerCLIKatello::RemoveAssociatedCommand
       command_name 'remove-version'
+      desc _('Remove a version of a content view')
 
       def association_name(plural = false)
         plural ? "components" : "component"


### PR DESCRIPTION
…ption

remove-content description is wrongly copied from the next sub-command.

The fix just adds proper description to RemoveContentViewVersionCommand to
prevent copying it from the next sub-command.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>