### PR TITLE
fixes #10623 - cvv resolver uses max version if > 1 found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ doc/
 .rvmrc
 .ruby-version
 .ruby-gemset
+.*.sw?

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -78,6 +78,13 @@ module HammerCLIKatello
              _("Name of the target environment"), :attribute_name => :option_to_environment_name
       option "--to-lifecycle-environment-id", "TO_ENVIRONMENT_ID",
              _("Id of the target environment"), :attribute_name => :option_to_environment_id
+      option "--from-lifecycle-environment", "FROM_ENVIRONMENT_ID",
+             _("Environment name from where to promote its version from (if version is unknown)"),
+             :attribute_name => :option_from_environment_name
+      option "--from-lifecycle-environment-id", "FROM_ENVIRONMENT_ID",
+             _(["Id of the environment from where to promote its version ",
+                "from (if version is unknown)"].join),
+               :attribute_name => :option_from_environment_id
 
       def environment_search_options
         {


### PR DESCRIPTION
include from-environment

replacing https://github.com/Katello/hammer-cli-katello/pull/296