### PR TITLE
Fixes #11740 - Added Enabled to sync plan BZ1261122

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -9,6 +9,7 @@ module HammerCLIKatello
         field :name, _("Name")
         field :sync_date, _("Start Date"), Fields::Date
         field :interval, _("Interval")
+        field :enabled, _("Enabled"), Fields::Boolean
       end
 
       build_options


### PR DESCRIPTION
Fixes #1261122 - Added 'Enabled' to sync plan.
    
As per Bugzilla #1261122, `hammer sync-plan info` does not display the 'enabled' field.
    
```bash
hammer -u admin -p changeme sync-plan create --interval daily --name Daily --description 'Daily sync' --enabled true --sync-date "2015-09-08 09:00:00" --organization "Default Organization"
Sync plan created
    
hammer -u admin -p changeme sync-plan info --organization "Default Organization" --name Daily
ID:          98
Name:        Daily
Start Date:  2015/09/08 09:00:00
Interval:    daily
Description: Daily sync
require 'hammer_cli'
Created at:  2015/09/08 15:57:17
Updated at:  2015/09/08 15:57:17
```
    
The proposed fix adds the 'enabled' field to the output generaged:
    
```bash
hammer -u admin -p changeme sync-plan info --organization "Default Organization" --name Daily
ID:          98
Name:        Daily
Start Date:  2015/09/08 09:00:00
Interval:    daily
Description: Daily sync
Enabled:     true
Created at:  2015/09/08 15:57:17
Updated at:  2015/09/08 16:14:12