### PR TITLE
Fixes #11801 : Update the version of gettext, and modify the rake file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ doc/
 .ruby-version
 .ruby-gemset
 .*.sw?
+
+# Locale files
+locale/*/*.edit.po
+locale/*/*.po.time_stamp

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [katello.hammer-cli-katello]
-file_filter = locale/<lang>/hammer-cli-katello.po
+file_filter = locale/<lang>/hammer-cli-katello.edit.po
 source_file = locale/hammer-cli-katello.pot
 source_lang = en
 type = PO

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-gem 'gettext', '~> 2.0'
+gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')

--- a/Rakefile
+++ b/Rakefile
@@ -29,18 +29,25 @@ end
 
 namespace :gettext do
 
-  desc "Update pot file"
-  task :find do
+  task :setup do
     require "hammer_cli_katello/version"
     require "hammer_cli_katello/i18n"
-    require 'gettext/tools'
+    require 'gettext/tools/task'
 
     domain = HammerCLIKatello::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name,
-                           domain.translated_files,
-                           "#{domain.domain_name} #{HammerCLIKatello.version}",
-                           :po_root => domain.locale_dir
-                          )
+    GetText::Tools::Task.define do |task|
+      task.package_name = domain.domain_name
+      task.package_version = HammerCLIKatello.version.to_s
+      task.domain = domain.domain_name
+      task.mo_base_directory = domain.locale_dir
+      task.po_base_directory = domain.locale_dir
+      task.files = domain.translated_files
+    end
+  end
+
+  desc "Update pot file"
+  task :find => [:setup] do
+    Rake::Task["gettext:po:update"].invoke
   end
 
 end


### PR DESCRIPTION
This brings hammer-cli-katello in line with hammer-cli. Also, it would be
good to get this tool into transifex like the other hammer plugins.