### PR TITLE
Fixes #11802 : Pull in the downstream strings.

### DIFF
--- a/locale/de/hammer-cli-katello.po
+++ b/locale/de/hammer-cli-katello.po
@@ -1,0 +1,1522 @@
+# hpeters <hpeters@redhat.com>, 2015. #zanata
+# jdimanos <jdimanos@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-27 11:53+0000\n"
+"Last-Translator: hpeters <hpeters@redhat.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Name"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Grenze"
+
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Beschreibung"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Hostsammlung erstellt"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "Hostsammlung konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Inhaltshosts insgesamt"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Inhaltshosts maximal"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Hostsammlung aktualisiert"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "Hostsammlung konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Hostsammlung gelöscht"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "Hostsammlung konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "Inhaltshosts wurden hinzugefügt"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "Inhaltshosts konnten nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "Inhaltshosts wurden entfernt"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "Inhaltshosts konnten nicht entfernt werden"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Hostsammlungen bearbeiten"
+
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Kennung"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Red Hat Repository-URL"
+
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Organisation aktualisiert"
+
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "Organisation konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Organisation erstellt"
+
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "Organisation konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Organisation gelöscht"
+
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "Organisation konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Organisationen bearbeiten"
+
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Typ"
+
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "GPG-Schlüssel"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Aktivierte Repositorys"
+
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Architektur"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Release"
+
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "Repository aktiviert"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "Repository konnte nicht aktiviert werden"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Repository deaktiviert"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "Repository konnte nicht deaktiviert werden"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "Regel-ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "Filter-ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Version"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Minimumversion"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Maximalversion"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "Errata-ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Startdatum"
+
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Enddatum"
+
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Typen"
+
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Erstellt"
+
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Aktualisiert"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Filterregel erstellt"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "Filterregel konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Filterregel aktualisiert"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "Filterregel konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Filterregel gelöscht"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "Filterregel konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "Inhaltsansichts-ID"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Verbund"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "Repository-IDs"
+
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Organisation"
+
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Repositorys"
+
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Puppet-Module"
+
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Autor"
+
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Umgebungen"
+
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Versionen"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Veröffentlicht"
+
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Komponenten"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Inhaltsansicht erstellt"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "Inhaltsansicht konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Verbundinhaltsansicht erstellen"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Inhaltsansicht aktualisiert"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "Inhaltsansicht konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "Inhaltsansicht wird gelöscht durch Task %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "Inhaltsansicht konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "Inhaltsansicht wird veröffentlicht durch Task %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "Inhaltsansicht konnte nicht veröffentlicht werden"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "Inhaltsansicht wird von Umgebung entfernt durch Task %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "Inhaltsansicht konnte nicht aus Umgebung entfernt werden"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Kommagetrennte Liste der zu entfernenden Versions-IDs"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Kommagetrennte Liste der zu entfernenden Umgebungs-IDs"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "Inhaltsansichtsobjekte werden entfernt durch Task %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "Objekte konnten nicht aus Inhaltsansicht entfernt werden"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "Komponentenversion wurde hinzugefügt"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "Version konnte nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "Komponentenversion wurde entfernt"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "Version konnte nicht entfernt werden"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Inhaltsansichten bearbeiten."
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Verbraucht"
+
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "Lebenszyklusumgebung"
+
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Inhaltsansicht"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} von %{limit}"
+
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Unbegrenzt"
+
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Hostsammlungen"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Aktivierungsschlüssel erstellt"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "Aktivierungsschlüssel konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Aktivierungsschlüssel aktualisiert"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "Aktivierungsschlüssel konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Aktivierungsschlüssel gelöscht"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "Aktivierungsschlüssel konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Verknüpfte Subskriptionen anzeigen"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Subskription zum Aktivierungsschlüssel hinzugefügt"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "Subskription konnte nicht zum Aktivierungsschlüssel hinzugefügt werden"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Subskription entfernen"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Subskription vom Aktivierungsschlüssel entfernt"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "Subskription konnte nicht vom Aktivierungsschlüssel entfernt werden"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Verknüpfte Hostsammlungen anzeigen"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Aktivierungsschlüssel bearbeiten."
+
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Intervall"
+
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Erstellt um"
+
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Aktualisiert um"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "Häufigkeit der Synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "Startdatum und -zeit der Synchronisation sind standardmäßig sofort"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "Synchronisationsplan erstellt"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "Synchronisationsplan konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "Startdatum und -zeit der Synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "Synchronisationsplan aktualisiert"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "Synchronisationsplan konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "Synchronisationsplan gelöscht"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "Synchronisationsplan konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Synchronisationspläne bearbeiten"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Letzter (derzeit %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Puppet-Modul zur Inhaltsansicht hinzugefügt"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Puppet-Modul konnte nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Puppet-Modul aus Inhaltsansicht entfernt"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "Puppet-Modul konnte nicht aus Inhaltsansicht entfernt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "Repository wurde verknüpft"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "Repository konnte nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "Repository wurde entfernt"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "Repository konnte nicht entfernt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "Hostsammlung wurde verknüpft"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "Hostsammlung konnte nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "Hostsammlung wurde entfernt"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "Hostsammlung konnte nicht entfernt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "Inhaltshost wurde hinzugefügt"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "Inhaltshost konnte nicht hinzugefügt werden"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "Inhaltshost wurde entfernt"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "Inhaltshost konnte nicht entfernt werden"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Inhaltstyp"
+
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Produkt"
+
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Inhalt"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "GPG-Schlüssel erstellt"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "GPG-Schlüssel konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "GPG-Schlüsseldatei"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "GPG-Schlüssel aktualisiert"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "GPG-Schlüssel konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "GPG-Schlüssel gelöscht"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "GPG-Schlüssel konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Vertrag"
+
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Account"
+
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Support"
+
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Anzahl"
+
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Verknüpft"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "Manifest wird hochgeladen durch Task %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Hochladen von Manifest fehlgeschlagen"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "Subskriptions-Manifestdatei"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "Manifest wird gelöscht durch Task %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Löschen von Manifest fehlgeschlagen"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "Manifest wird aktualisiert durch Task %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Aktualisieren von Manifest fehlgeschlagen"
+
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Status"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Statusmeldung"
+
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Zeit"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Subskriptionen bearbeiten."
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID des Inhaltshosts"
+
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Standort"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "Berechtigungsstatus"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Release-Version"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Automatische Neusubskription"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Inhaltshost erstellt"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "Inhaltshost konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "Inhaltshost aktualisiert"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "Inhaltshost konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "Inhaltshost gelöscht"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "Inhaltshost konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Zusammenfassung"
+
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Lizenz"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Projektseite"
+
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Quelle"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Abhängigkeiten"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "Dateiprüfsummen"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Tag-Liste"
+
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat Repository"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Über HTTP veröffentlichen"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Veröffentlicht unter"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Synchronisation"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Letzte Synchronisation"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Anzahl der Inhalte"
+
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Pakete"
+
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Paketgruppen"
+
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Errata"
+
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "ja"
+
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "nein"
+
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Fehlgeschlagen"
+
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Erfolgreich"
+
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Abgeschlossen"
+
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Fehler"
+
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "Läuft"
+
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "Wartet"
+
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Abgebrochen"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "Nicht synchronisiert"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "Repository wird synchronisiert durch Task %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "Repository konnte nicht synchronisiert werden"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Repository erstellt"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "Repository konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Repository aktualisiert"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "Repository konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Repository gelöscht"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "Repository konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Repository-Inhalte hochgeladen"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "Inhalte konnten nicht hochgeladen werden"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+"Dateien oder Verzeichnis mit Dateien als Inhalte für ein Repository hochladen"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Datei \"%s\" erfolgreich hochgeladen."
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"Hochladen der Datei \"%s\" zum Repository ist fehlgeschlagen. Bitte prüfen "
+"Sie die Datei und versuchen Sie es erneut."
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Repositorys bearbeiten"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Inhaltsansichtsname"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Inhaltsansichtskennung"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "Inhaltsansicht wird übertragen durch Task %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "Inhaltsansicht konnte nicht übertragen werden"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "Synchronisationsstatus"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Produkt erstellt"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "Produkt konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "Synchronisationsplan-ID"
+
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "GPG-Schlüssel-ID"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Schreibgeschützt"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Löschbar"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Repository-Name"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Produkt aktualisiert"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "Produkt konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Produkt gelöscht"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "Produkt konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Synchronisationsplan zu Produkt zuweisen."
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "Synchronisationsplan zugewiesen."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "Synchronisationsplan konnte nicht zugewiesen werden."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "Zuweisung von Synchronisationsplan und Produkt löschen."
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "Synchronisationsplan entfernt."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "Synchronisationsplan konnte nicht entfernt werden."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Produkte bearbeiten."
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Serverantwort"
+
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "FEHLER"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Dauer: %s ms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Meldung: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Name des zu suchenden Aktivierungsschlüssels"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Name der zu suchenden Capsule"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Name des zu suchenden Inhaltshosts"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Name der zu suchenden Inhaltsansicht"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Name des zu suchenden GPG-Schlüssels"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "Name der zu suchenden Hostsammlung"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "Name der zu suchenden Lebenszyklusumgebung"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Name der zu suchenden Organisation"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "Kennung der zu suchenden Organisation"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Name des zu suchenden Produkts"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Name des zu suchenden Repositorys"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Name der zu suchenden Repository-Gruppe"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Name der zu suchenden Subskription"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Name des zu suchenden Synchronisationsplans"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Name der zu suchenden Task"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Name des zu suchenden Benutzers"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Name des zu suchenden Puppet-Moduls"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Name des zu suchenden Puppet-Modulautors"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "Name der zu suchenden Puppet-Modul-UUID"
+
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Zu suchender Name"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Einbeziehung"
+
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Regeln"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Filter erstellt"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "Filter konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Filter aktualisiert"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "Filter konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Filter gelöscht"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "Filter konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Vorherige"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Lebenszykluspfad"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Library"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Vorherige Lebenszyklusumgebung"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Umgebung erstellt"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "Umgebung konnte nicht erstellt werden"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Umgebung aktualisiert"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "Umgebung konnte nicht aktualisiert werden"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Umgebung gelöscht"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "Umgebung konnte nicht gelöscht werden"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Eigenschaften"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Capsule-Inhalte verwalten"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "Lebenszyklusumgebung erfolgreich zur Capsule hinzugefügt"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "Lebenszyklusumgebung konnte nicht zur Capsule hinzugefügt werden"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "Lebenszyklusumgebung erfolgreich von Capsule entfernt"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "Lebenszyklusumgebung konnte nicht von Capsule entfernt werden"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Capsule-Inhalte werden synchronisiert in Task %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Capsule-Inhalte konnten nicht synchronisiert werden"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Capsule bearbeiten"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author hpeters
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author hpeters
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author hpeters
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author jdimanos
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author hpeters
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author jdimanos
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project RHEL Deployment Guide, version 6.2, document Product_Subscriptions_and_Entitlements, author hpeters
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/en/hammer-cli-katello.po
+++ b/locale/en/hammer-cli-katello.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer-cli-katello 0.0.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-09 16:17-0400\n"
 "PO-Revision-Date: 2014-03-10 15:12+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,1198 +16,902 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: lib/hammer_cli_katello/id_resolver.rb:7
-#: lib/hammer_cli_katello/id_resolver.rb:12
-msgid "Name to search by"
-msgstr ""
-
-#: lib/hammer_cli_katello/id_resolver.rb:8
-msgid "Label to search by"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:12 lib/hammer_cli_katello/ping.rb:19
-#: lib/hammer_cli_katello/ping.rb:26 lib/hammer_cli_katello/ping.rb:33
-#: lib/hammer_cli_katello/ping.rb:40 lib/hammer_cli_katello/ping.rb:47
-#: lib/hammer_cli_katello/repository.rb:47
-#: lib/hammer_cli_katello/subscription.rb:85
-msgid "Status"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
-#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
-#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
-msgid "Server Response"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:58
-msgid "FAIL"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:73
-msgid "Duration: %sms"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:75
-msgid "Message: %s"
-msgstr ""
-
-#: lib/hammer_cli_katello/ping.rb:81
-msgid "get the status of the server"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:10
-#: lib/hammer_cli_katello/organization.rb:22
-#: lib/hammer_cli_katello/repository.rb:22
-#: lib/hammer_cli_katello/content_view.rb:14
-#: lib/hammer_cli_katello/content_view.rb:26
-#: lib/hammer_cli_katello/content_view.rb:37
-#: lib/hammer_cli_katello/filter.rb:32
-#: lib/hammer_cli_katello/lifecycle_environment.rb:39
-#: lib/hammer_cli_katello/content_view_version.rb:39
-#: lib/hammer_cli_katello/content_view_version.rb:45
-#: lib/hammer_cli_katello/product.rb:38
-msgid "Label"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:11
-#: lib/hammer_cli_katello/organization.rb:23
-#: lib/hammer_cli_katello/sync_plan.rb:20
-#: lib/hammer_cli_katello/activation_key.rb:39
-#: lib/hammer_cli_katello/puppet_module.rb:25
-#: lib/hammer_cli_katello/content_view.rb:28
-#: lib/hammer_cli_katello/lifecycle_environment.rb:40
-#: lib/hammer_cli_katello/host_collection.rb:11
-#: lib/hammer_cli_katello/content_host.rb:23
-#: lib/hammer_cli_katello/product.rb:39
-msgid "Description"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:24
-msgid "Red Hat Repository URL"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:34
-msgid "Organization updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:35
-msgid "Could not update the organization"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:43
-msgid "Organization created"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:44
-msgid "Could not create the organization"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:52
-msgid "Organization deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:53
-msgid "Could not delete the organization"
-msgstr ""
-
-#: lib/hammer_cli_katello/organization.rb:63
-msgid "Manipulate organizations"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:9
-msgid "Id"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:10
-#: lib/hammer_cli_katello/repository.rb:21
-#: lib/hammer_cli_katello/repository.rb:35
-#: lib/hammer_cli_katello/repository.rb:42
-#: lib/hammer_cli_katello/sync_plan.rb:9
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:24
-#: lib/hammer_cli_katello/filter_rule.rb:14
-#: lib/hammer_cli_katello/filter_rule.rb:31
-#: lib/hammer_cli_katello/subscription.rb:12
-#: lib/hammer_cli_katello/activation_key.rb:11
-#: lib/hammer_cli_katello/activation_key.rb:37
-#: lib/hammer_cli_katello/activation_key.rb:49
-#: lib/hammer_cli_katello/activation_key.rb:79
-#: lib/hammer_cli_katello/activation_key.rb:152
-#: lib/hammer_cli_katello/puppet_module.rb:9
-#: lib/hammer_cli_katello/puppet_module.rb:20
-#: lib/hammer_cli_katello/content_view.rb:13
-#: lib/hammer_cli_katello/content_view.rb:25
-#: lib/hammer_cli_katello/content_view.rb:36
-#: lib/hammer_cli_katello/content_view.rb:43
-#: lib/hammer_cli_katello/content_view.rb:51
-#: lib/hammer_cli_katello/content_view.rb:62
-#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
-#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
-#: lib/hammer_cli_katello/lifecycle_environment.rb:9
-#: lib/hammer_cli_katello/lifecycle_environment.rb:38
-#: lib/hammer_cli_katello/repository_set.rb:11
-#: lib/hammer_cli_katello/repository_set.rb:22
-#: lib/hammer_cli_katello/repository_set.rb:26
-#: lib/hammer_cli_katello/repository_set.rb:39
-#: lib/hammer_cli_katello/host_collection.rb:9
-#: lib/hammer_cli_katello/content_host.rb:10
-#: lib/hammer_cli_katello/content_host.rb:20
-#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
-#: lib/hammer_cli_katello/gpg_key.rb:28
-#: lib/hammer_cli_katello/content_view_version.rb:11
-#: lib/hammer_cli_katello/content_view_version.rb:27
-#: lib/hammer_cli_katello/content_view_version.rb:38
-#: lib/hammer_cli_katello/content_view_version.rb:44
-#: lib/hammer_cli_katello/content_view_version.rb:50
-#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:37
-msgid "Name"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:11
-#: lib/hammer_cli_katello/repository.rb:27
-#: lib/hammer_cli_katello/gpg_key.rb:29
-msgid "Content Type"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:20
-#: lib/hammer_cli_katello/repository.rb:34
-#: lib/hammer_cli_katello/repository.rb:41
-#: lib/hammer_cli_katello/sync_plan.rb:8
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
-#: lib/hammer_cli_katello/subscription.rb:19
-#: lib/hammer_cli_katello/activation_key.rb:10
-#: lib/hammer_cli_katello/activation_key.rb:38
-#: lib/hammer_cli_katello/activation_key.rb:48
-#: lib/hammer_cli_katello/activation_key.rb:78
-#: lib/hammer_cli_katello/activation_key.rb:151
-#: lib/hammer_cli_katello/puppet_module.rb:8
-#: lib/hammer_cli_katello/puppet_module.rb:19
-#: lib/hammer_cli_katello/content_view.rb:24
-#: lib/hammer_cli_katello/content_view.rb:35
-#: lib/hammer_cli_katello/content_view.rb:41
-#: lib/hammer_cli_katello/content_view.rb:50
-#: lib/hammer_cli_katello/content_view.rb:55
-#: lib/hammer_cli_katello/content_view.rb:61
-#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
-#: lib/hammer_cli_katello/lifecycle_environment.rb:8
-#: lib/hammer_cli_katello/lifecycle_environment.rb:37
-#: lib/hammer_cli_katello/repository_set.rb:9
-#: lib/hammer_cli_katello/repository_set.rb:21
-#: lib/hammer_cli_katello/repository_set.rb:25
-#: lib/hammer_cli_katello/host_collection.rb:8
-#: lib/hammer_cli_katello/content_host.rb:9
-#: lib/hammer_cli_katello/content_host.rb:21
-#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
-#: lib/hammer_cli_katello/gpg_key.rb:27
-#: lib/hammer_cli_katello/content_view_version.rb:10
-#: lib/hammer_cli_katello/content_view_version.rb:26
-#: lib/hammer_cli_katello/content_view_version.rb:37
-#: lib/hammer_cli_katello/content_view_version.rb:43
-#: lib/hammer_cli_katello/content_view_version.rb:49
-#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:36
 msgid "ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/repository.rb:24
-#: lib/hammer_cli_katello/content_view.rb:31
-#: lib/hammer_cli_katello/lifecycle_environment.rb:42
-#: lib/hammer_cli_katello/gpg_key.rb:23 lib/hammer_cli_katello/product.rb:12
-#: lib/hammer_cli_katello/product.rb:55
-msgid "Organization"
+msgid "Name"
 msgstr ""
 
-#: lib/hammer_cli_katello/repository.rb:26
-msgid "Red Hat Repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:28
-#: lib/hammer_cli_katello/product.rb:67
-msgid "URL"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:29
-#: lib/hammer_cli_katello/repository.rb:123
-#: lib/hammer_cli_katello/repository.rb:146
-msgid "Publish Via HTTP"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:30
-msgid "Published At"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:32
-#: lib/hammer_cli_katello/subscription.rb:20
-#: lib/hammer_cli_katello/gpg_key.rb:31
-msgid "Product"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:39
-#: lib/hammer_cli_katello/product.rb:50
-msgid "GPG Key"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:46
-msgid "Sync"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:48
-msgid "Last Sync Date"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:51
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:26
-#: lib/hammer_cli_katello/filter_rule.rb:39
-#: lib/hammer_cli_katello/content_view.rb:45
-#: lib/hammer_cli_katello/filter.rb:45
-msgid "Created"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:52
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:27
-#: lib/hammer_cli_katello/filter_rule.rb:40
-#: lib/hammer_cli_katello/content_view.rb:46
-#: lib/hammer_cli_katello/filter.rb:46
-msgid "Updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:54
-msgid "Content Counts"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:55
-msgid "Packages"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:56
-msgid "Package Groups"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:57
-msgid "Errata"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:58
-#: lib/hammer_cli_katello/content_view.rb:40
-#: lib/hammer_cli_katello/content_view_version.rb:48
-msgid "Puppet Modules"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:64
-#: lib/hammer_cli_katello/repository.rb:65
-msgid "yes"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:64
-#: lib/hammer_cli_katello/repository.rb:65
-msgid "no"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:87
-msgid "Failed"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:88
-msgid "Success"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:89
-msgid "Finished"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:90
-msgid "Error"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:91
-msgid "Running"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:92
-msgid "Waiting"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:93
-msgid "Canceled"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:94
-msgid "Not Synced"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:111
-msgid "Repository is being synchronized in task %{id}"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:112
-msgid "Could not synchronize the repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:120
-msgid "Repository created"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:121
-msgid "Could not create the repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:142
-msgid "Repository updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:143
-msgid "Could not update the repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:154
-msgid "Repository deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:155
-msgid "Could not delete the Repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository.rb:163
-msgid "Manipulate repositories"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:10
-#: lib/hammer_cli_katello/filter_rule.rb:19
-#: lib/hammer_cli_katello/filter_rule.rb:36
-#: lib/hammer_cli_katello/filter.rb:42
-msgid "Start Date"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:11
-msgid "Interval"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:21
-msgid "Created at"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:22
-msgid "Updated at"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:30
-#: lib/hammer_cli_katello/sync_plan.rb:49
-msgid "how often synchronization should run"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:37
-msgid "start date and time of the synchronization defaults to now"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:41
-msgid "Sync plan created"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:42
-msgid "Could not create the sync plan"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:53
-msgid "start date and time of the synchronization"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:56
-msgid "Sync plan updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:57
-msgid "Could not update the sync plan"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:63
-msgid "Sync plan destroyed"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:64
-msgid "Could not destroy the sync plan"
-msgstr ""
-
-#: lib/hammer_cli_katello/sync_plan.rb:73
-msgid "Manipulate sync plans"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:11
-msgid "The repository has been associated"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:12
-msgid "Could not add repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:19
-msgid "The repository has been removed"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:20
-msgid "Could not remove repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:32
-msgid "The host collection has been associated"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:33
-msgid "Could not add host collection"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:40
-msgid "The host collection has been removed"
-msgstr ""
-
-#: lib/hammer_cli_katello/associating_commands.rb:41
-msgid "Could not remove host collection"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:23
-#: lib/hammer_cli_katello/content_view.rb:42
-#: lib/hammer_cli_katello/content_host.rb:22
-msgid "UUID"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:25
-#: lib/hammer_cli_katello/puppet_module.rb:11
-#: lib/hammer_cli_katello/puppet_module.rb:22
-#: lib/hammer_cli_katello/content_view.rb:44
-#: lib/hammer_cli_katello/content_view_version.rb:51
-msgid "Author"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:41
-msgid "Puppet module added to content view"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
-msgid "Could not add the puppet module"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:48
-msgid "Puppet module updated for content view"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:49
-msgid "Could not update the puppet module"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:62
-msgid "Puppet module removed from content view"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view_puppet_module.rb:63
-#: lib/hammer_cli_katello/filter.rb:69
-msgid "Could not delete the filter"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:11
-#: lib/hammer_cli_katello/filter_rule.rb:28
-msgid "Rule ID"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:12
-#: lib/hammer_cli_katello/filter_rule.rb:29
-#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
-msgid "Filter ID"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:15
-#: lib/hammer_cli_katello/filter_rule.rb:32
-#: lib/hammer_cli_katello/puppet_module.rb:10
-#: lib/hammer_cli_katello/puppet_module.rb:21
-#: lib/hammer_cli_katello/content_view.rb:56
-#: lib/hammer_cli_katello/filter.rb:38
-#: lib/hammer_cli_katello/content_view_version.rb:12
-#: lib/hammer_cli_katello/content_view_version.rb:28
-#: lib/hammer_cli_katello/content_view_version.rb:52
-msgid "Version"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:16
-#: lib/hammer_cli_katello/filter_rule.rb:33
-#: lib/hammer_cli_katello/filter.rb:39
-msgid "Minimum Version"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:17
-#: lib/hammer_cli_katello/filter_rule.rb:34
-#: lib/hammer_cli_katello/filter.rb:40
-msgid "Maximum Version"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:18
-#: lib/hammer_cli_katello/filter_rule.rb:35
-#: lib/hammer_cli_katello/filter.rb:41
-msgid "Errata ID"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:20
-#: lib/hammer_cli_katello/filter_rule.rb:37
-#: lib/hammer_cli_katello/subscription.rb:18
-#: lib/hammer_cli_katello/filter.rb:43
-msgid "End Date"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:38
-#: lib/hammer_cli_katello/filter.rb:44
-msgid "Types"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:47
-msgid "Filter rule created"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:48
-msgid "Could not create the filter rule"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:54
-msgid "Filter rule updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:55
-msgid "Could not update the filter rule"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:61
-msgid "Filter rule deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter_rule.rb:62
-msgid "Could not delete the filter rule"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:13
-msgid "Contract"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:14
-msgid "Account"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:15
-msgid "Support"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:16
-#: lib/hammer_cli_katello/subscription.rb:21
-msgid "Quantity"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:17
-#: lib/hammer_cli_katello/activation_key.rb:12
 msgid "Consumed"
 msgstr ""
 
-#: lib/hammer_cli_katello/subscription.rb:22
-msgid "Attached"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:26
-#: lib/hammer_cli_katello/activation_key.rb:25
-msgid "Unlimited"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:51
-msgid "Manifest is being uploaded in task %{id}"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:52
-msgid "Manifest upload failed"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:55
-msgid "Subscription manifest file"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:64
-msgid "Manifest is being deleted in task %{id}"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:65
-msgid "Manifest deletion failed"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:74
-msgid "Manifest is being refreshed in task %{id}"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:75
-msgid "Manifest refresh failed"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:86
-msgid "Status Message"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:87
-msgid "Time"
-msgstr ""
-
-#: lib/hammer_cli_katello/subscription.rb:97
-msgid "Manipulate subscriptions."
-msgstr ""
-
-#: lib/hammer_cli_katello/activation_key.rb:14
-#: lib/hammer_cli_katello/activation_key.rb:41
-#: lib/hammer_cli_katello/content_host.rb:26
 msgid "Lifecycle Environment"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:17
-#: lib/hammer_cli_katello/activation_key.rb:44
-#: lib/hammer_cli_katello/content_host.rb:29
 msgid "Content View"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:22
 msgid "%{consumed} of %{limit}"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:47
+msgid "Unlimited"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
 msgid "Host Collections"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:58
 msgid "Activation key created"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:59
 msgid "Could not create the activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:66
 msgid "Activation key updated"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:67
 msgid "Could not update the activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:74
+msgid "Activation key deleted"
+msgstr ""
+
+msgid "Could not delete the activation key"
+msgstr ""
+
 msgid "List associated subscriptions"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:82
-#: lib/hammer_cli_katello/activation_key.rb:101
-#: lib/hammer_cli_katello/activation_key.rb:127
-#: lib/hammer_cli_katello/activation_key.rb:155
 msgid "resource ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:102
-#: lib/hammer_cli_katello/activation_key.rb:128
 msgid "subscription ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:103
 msgid "subscription quantity"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:117
 msgid "Subscription added to activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:118
 msgid "Could not add subscription to activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:124
 msgid "Remove subscription"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:140
 msgid "Subscription removed from activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:141
 msgid "Could not remove subscription from activation key"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:147
 msgid "List associated host collections"
 msgstr ""
 
-#: lib/hammer_cli_katello/activation_key.rb:175
 msgid "Manipulate activation keys."
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:24
-msgid "Summary"
+msgid "The repository has been associated"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:26
-msgid "License"
+msgid "Could not add repository"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:27
-msgid "Project Page"
+msgid "The repository has been removed"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:28
-msgid "Source"
+msgid "Could not remove repository"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:29
-msgid "Dependencies"
+msgid "The host collection has been associated"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:30
-msgid "Checksums"
+msgid "Could not add host collection"
 msgstr ""
 
-#: lib/hammer_cli_katello/puppet_module.rb:31
-msgid "Tag List"
+msgid "The host collection has been removed"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:12
-#: lib/hammer_cli_katello/content_view_version.rb:15
-#: lib/hammer_cli_katello/content_view_version.rb:31
-msgid "Content View ID"
+msgid "Could not remove host collection"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:15
-#: lib/hammer_cli_katello/content_view.rb:27
-msgid "Composite"
+msgid "The content host has been added"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:16
-msgid "Repository IDs"
+msgid "Could not add content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:34
-#: lib/hammer_cli_katello/filter.rb:29
-#: lib/hammer_cli_katello/repository_set.rb:24
-#: lib/hammer_cli_katello/content_view_version.rb:42
-#: lib/hammer_cli_katello/product.rb:15
-msgid "Repositories"
+msgid "The content host has been removed"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:49
-#: lib/hammer_cli_katello/content_view_version.rb:36
-msgid "Environments"
+msgid "Could not remove content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:54
-msgid "Versions"
+msgid "Id"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:57
-msgid "Published"
+msgid "URL"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:60
-msgid "Components"
+msgid "Features"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:70
-msgid "Content view created"
+msgid "Created at"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:71
-msgid "Could not create the content view"
+msgid "Updated at"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:73
-msgid "Create a composite content view"
+msgid "Manage the capsule content"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:85
-msgid "Content view updated"
+msgid "Organization"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:86
-msgid "Could not update the content view"
+msgid "Lifecycle environment successfully added to the capsule"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:95
-#: lib/hammer_cli_katello/content_view_version.rb:73
-msgid "Content view is being deleted with task %{id}"
+msgid "Could not add the lifecycle environment to the capsule"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:96
-#: lib/hammer_cli_katello/content_view_version.rb:74
-msgid "Could not delete the content view"
+msgid "Lifecycle environment successfully removed from the capsule"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:105
-msgid "Content view is being published with task %{id}"
+msgid "Could not remove the lifecycle environment from the capsule"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:106
-msgid "Could not publish the content view"
+msgid "Capsule content is being synchronized in task %{id}"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:115
-msgid "Content view is being removed from environment with task %{id}"
+msgid "Could not synchronize capsule content"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:116
-msgid "Could not remove the content view from environment"
+msgid "Manipulate capsule"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:128
-msgid "Comma separated list of version ids to remove"
+msgid "ID of the content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view.rb:130
-msgid "Comma separated list of environment ids to remove"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:140
-msgid "Content view objects are being removed task %{id}"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:141
-msgid "Could not remove objects from content view"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:156
-msgid "The component version has been added"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:157
-msgid "Could not add version"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:170
-msgid "The component version has been removed"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:171
-msgid "Could not remove version"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_view.rb:192
-msgid "Manipulate content views."
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
-#: lib/hammer_cli_katello/repository_set.rb:10
-msgid "Type"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
-msgid "Inclusion"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:35
-msgid "Rules"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:54
-msgid "Filter created"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:55
-msgid "Could not create the filter"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:61
-msgid "Filter updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:62
-msgid "Could not update the filter"
-msgstr ""
-
-#: lib/hammer_cli_katello/filter.rb:68
-msgid "Filter deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:10
-msgid "Prior"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:21
-msgid "Lifecycle Path"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:44
-msgid "Library"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:45
-msgid "Prior Lifecycle Environment"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:52
-msgid "Environment created"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:53
-msgid "Could not create environment"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:68
-msgid "Environment updated"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:69
-msgid "Could not update environment"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:84
-msgid "Environment deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:85
-msgid "Could not delete environment"
-msgstr ""
-
-#: lib/hammer_cli_katello/lifecycle_environment.rb:94
-msgid "manipulate lifecycle_environments on the server"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:27
-#: lib/hammer_cli_katello/repository_set.rb:44
-msgid "Enabled"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:41
-msgid "Arch"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:42
-msgid "Release"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:64
-msgid "Repository enabled"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:65
-msgid "Could not enable repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:74
-msgid "Repository disabled"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:75
-msgid "Could not disable repository"
-msgstr ""
-
-#: lib/hammer_cli_katello/repository_set.rb:83
-msgid "manipulate repository sets on the server"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:10
-msgid "Limit"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:20
-#: lib/hammer_cli_katello/host_collection.rb:43
-msgid "Host collection created"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:21
-#: lib/hammer_cli_katello/host_collection.rb:44
-msgid "Could not create the host collection"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:30
-msgid "Total Content Hosts"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:31
-msgid "Max Content Hosts"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:56
-msgid "Host collection deleted"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:57
-msgid "Could not delete the host collection"
-msgstr ""
-
-#: lib/hammer_cli_katello/host_collection.rb:66
-msgid "Manipulate host collections"
-msgstr ""
-
-#: lib/hammer_cli_katello/content_host.rb:24
 msgid "Location"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:31
 msgid "Entitlement Status"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:32
 msgid "Release Version"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:33
 msgid "Autoheal"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:42
 msgid "Content host created"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:43
 msgid "Could not create content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:58
 msgid "Content host updated"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:59
 msgid "Could not update content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:67
 msgid "Content host deleted"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:68
 msgid "Could not delete content host"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_host.rb:85
 msgid "manipulate content hosts on the server"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:64
-msgid "Content"
+msgid "Content View ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:42
-msgid "GPG Key created"
+msgid "Label"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:43
-msgid "Could not create GPG Key"
+msgid "Composite"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
-msgid "GPG Key file"
+msgid "Repository IDs"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:53
-msgid "GPG Key updated"
+msgid "Repositories"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:54
-msgid "Could not update GPG Key"
+msgid "Puppet Modules"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:63
-msgid "GPG Key deleted"
+msgid "UUID"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:64
-msgid "Could not delete the GPG Key"
+msgid "Author"
 msgstr ""
 
-#: lib/hammer_cli_katello/gpg_key.rb:73
-msgid "manipulate GPG Key actions on the server"
+msgid "Created"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view_version.rb:16
-#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Updated"
+msgstr ""
+
+msgid "Environments"
+msgstr ""
+
+msgid "Versions"
+msgstr ""
+
+msgid "Version"
+msgstr ""
+
+msgid "Published"
+msgstr ""
+
+msgid "Components"
+msgstr ""
+
+msgid "Content view created"
+msgstr ""
+
+msgid "Could not create the content view"
+msgstr ""
+
+msgid "Create a composite content view"
+msgstr ""
+
+msgid "Content view updated"
+msgstr ""
+
+msgid "Could not update the content view"
+msgstr ""
+
+msgid "Content view is being deleted with task %{id}"
+msgstr ""
+
+msgid "Could not delete the content view"
+msgstr ""
+
+msgid "Content view is being published with task %{id}"
+msgstr ""
+
+msgid "Could not publish the content view"
+msgstr ""
+
+msgid "Content view is being removed from environment with task %{id}"
+msgstr ""
+
+msgid "Could not remove the content view from environment"
+msgstr ""
+
+msgid "Comma separated list of version ids to remove"
+msgstr ""
+
+msgid "Comma separated list of environment ids to remove"
+msgstr ""
+
+msgid "Content view objects are being removed task %{id}"
+msgstr ""
+
+msgid "Could not remove objects from content view"
+msgstr ""
+
+msgid "The component version has been added"
+msgstr ""
+
+msgid "Could not add version"
+msgstr ""
+
+msgid "The component version has been removed"
+msgstr ""
+
+msgid "Could not remove version"
+msgstr ""
+
+msgid "Manipulate content views."
+msgstr ""
+
+msgid "Latest(Currently %s)"
+msgstr ""
+
+msgid "Puppet module added to content view"
+msgstr ""
+
+msgid "Could not add the puppet module"
+msgstr ""
+
+msgid "Puppet module removed from content view"
+msgstr ""
+
+msgid "Couldn't remove puppet module from the content view"
+msgstr ""
+
 msgid "Content View Name"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view_version.rb:17
-#: lib/hammer_cli_katello/content_view_version.rb:33
 msgid "Content View Label"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view_version.rb:63
 msgid "Content view is being promoted with task %{id}"
 msgstr ""
 
-#: lib/hammer_cli_katello/content_view_version.rb:64
 msgid "Could not promote the content view"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:18 lib/hammer_cli_katello/product.rb:42
+msgid "Filter ID"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Inclusion"
+msgstr ""
+
+msgid "Rules"
+msgstr ""
+
+msgid "Minimum Version"
+msgstr ""
+
+msgid "Maximum Version"
+msgstr ""
+
+msgid "Errata ID"
+msgstr ""
+
+msgid "Start Date"
+msgstr ""
+
+msgid "End Date"
+msgstr ""
+
+msgid "Types"
+msgstr ""
+
+msgid "Filter created"
+msgstr ""
+
+msgid "Could not create the filter"
+msgstr ""
+
+msgid "Filter updated"
+msgstr ""
+
+msgid "Could not update the filter"
+msgstr ""
+
+msgid "Filter deleted"
+msgstr ""
+
+msgid "Could not delete the filter"
+msgstr ""
+
+msgid "Rule ID"
+msgstr ""
+
+msgid "Filter rule created"
+msgstr ""
+
+msgid "Could not create the filter rule"
+msgstr ""
+
+msgid "Filter rule updated"
+msgstr ""
+
+msgid "Could not update the filter rule"
+msgstr ""
+
+msgid "Filter rule deleted"
+msgstr ""
+
+msgid "Could not delete the filter rule"
+msgstr ""
+
+msgid "Content Type"
+msgstr ""
+
+msgid "Product"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "GPG Key created"
+msgstr ""
+
+msgid "Could not create GPG Key"
+msgstr ""
+
+msgid "GPG Key file"
+msgstr ""
+
+msgid "GPG Key updated"
+msgstr ""
+
+msgid "Could not update GPG Key"
+msgstr ""
+
+msgid "GPG Key deleted"
+msgstr ""
+
+msgid "Could not delete the GPG Key"
+msgstr ""
+
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+msgid "Limit"
+msgstr ""
+
+msgid "Host collection created"
+msgstr ""
+
+msgid "Could not create the host collection"
+msgstr ""
+
+msgid "Total Content Hosts"
+msgstr ""
+
+msgid "Max Content Hosts"
+msgstr ""
+
+msgid "Host collection updated"
+msgstr ""
+
+msgid "Could not update the the host collection"
+msgstr ""
+
+msgid "Host collection deleted"
+msgstr ""
+
+msgid "Could not delete the host collection"
+msgstr ""
+
+msgid "The content host(s) has been added"
+msgstr ""
+
+msgid "Could not add content host(s)"
+msgstr ""
+
+msgid "The content host(s) has been removed"
+msgstr ""
+
+msgid "Could not remove content host(s)"
+msgstr ""
+
+msgid "Manipulate host collections"
+msgstr ""
+
+msgid "Activation key name to search by"
+msgstr ""
+
+msgid "Capsule name to search by"
+msgstr ""
+
+msgid "Content host name to search by"
+msgstr ""
+
+msgid "Content view name to search by"
+msgstr ""
+
+msgid "Gpg key name to search by"
+msgstr ""
+
+msgid "Host collection name to search by"
+msgstr ""
+
+msgid "Lifecycle environment name to search by"
+msgstr ""
+
+msgid "Organization name to search by"
+msgstr ""
+
+msgid "Organization label to search by"
+msgstr ""
+
+msgid "Product name to search by"
+msgstr ""
+
+msgid "Repository name to search by"
+msgstr ""
+
+msgid "Repository set name to search by"
+msgstr ""
+
+msgid "Subscription name to search by"
+msgstr ""
+
+msgid "Sync plan name to search by"
+msgstr ""
+
+msgid "Task name to search by"
+msgstr ""
+
+msgid "User name to search by"
+msgstr ""
+
+msgid "Puppet module name to search by"
+msgstr ""
+
+msgid "Puppet module's author to search by"
+msgstr ""
+
+msgid "Puppet module's UUID to search by"
+msgstr ""
+
+msgid "Name to search by"
+msgstr ""
+
+msgid "Prior"
+msgstr ""
+
+msgid "Lifecycle Path"
+msgstr ""
+
+msgid "Library"
+msgstr ""
+
+msgid "Prior Lifecycle Environment"
+msgstr ""
+
+msgid "Environment created"
+msgstr ""
+
+msgid "Could not create environment"
+msgstr ""
+
+msgid "Environment updated"
+msgstr ""
+
+msgid "Could not update environment"
+msgstr ""
+
+msgid "Environment deleted"
+msgstr ""
+
+msgid "Could not delete environment"
+msgstr ""
+
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+msgid "Red Hat Repository URL"
+msgstr ""
+
+msgid "Organization updated"
+msgstr ""
+
+msgid "Could not update the organization"
+msgstr ""
+
+msgid "Organization created"
+msgstr ""
+
+msgid "Could not create the organization"
+msgstr ""
+
+msgid "Organization deleted"
+msgstr ""
+
+msgid "Could not delete the organization"
+msgstr ""
+
+msgid "Manipulate organizations"
+msgstr ""
+
+msgid "%s  %s"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Server Response"
+msgstr ""
+
+msgid "FAIL"
+msgstr ""
+
+msgid "Duration: %sms"
+msgstr ""
+
+msgid "Message: %s"
+msgstr ""
+
+msgid "get the status of the server"
+msgstr ""
+
 msgid "Sync State"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:27
 msgid "Product created"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:28
 msgid "Could not create the product"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:45
 msgid "Sync Plan ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:47
 msgid "GPG"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:49
 msgid "GPG Key ID"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:58
+msgid "GPG Key"
+msgstr ""
+
 msgid "Readonly"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:61
 msgid "Deletable"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:66
 msgid "Repo Name"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:75
 msgid "Product updated"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:76
 msgid "Could not update the product"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:82
 msgid "Product destroyed"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:83
 msgid "Could not destroy the product"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:89
 msgid "Assign sync plan to product."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:92
 msgid "Synchronization plan assigned."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:93
 msgid "Could not assign synchronization plan."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:99 lib/hammer_cli_katello/product.rb:114
 msgid "plan numeric identifier"
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:104
 msgid "Delete assignment sync plan and product."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:107
 msgid "Synchronization plan removed."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:108
 msgid "Could not remove synchronization plan."
 msgstr ""
 
-#: lib/hammer_cli_katello/product.rb:122
 msgid "Manipulate products."
+msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "License"
+msgstr ""
+
+msgid "Project Page"
+msgstr ""
+
+msgid "Source"
+msgstr ""
+
+msgid "Dependencies"
+msgstr ""
+
+msgid "File checksums"
+msgstr ""
+
+msgid "Tag List"
+msgstr ""
+
+msgid "Red Hat Repository"
+msgstr ""
+
+msgid "Publish Via HTTP"
+msgstr ""
+
+msgid "Published At"
+msgstr ""
+
+msgid "Sync"
+msgstr ""
+
+msgid "Last Sync Date"
+msgstr ""
+
+msgid "Content Counts"
+msgstr ""
+
+msgid "Packages"
+msgstr ""
+
+msgid "Package Groups"
+msgstr ""
+
+msgid "Errata"
+msgstr ""
+
+msgid "yes"
+msgstr ""
+
+msgid "no"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Success"
+msgstr ""
+
+msgid "Finished"
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "Waiting"
+msgstr ""
+
+msgid "Canceled"
+msgstr ""
+
+msgid "Not Synced"
+msgstr ""
+
+msgid "Repository is being synchronized in task %{id}"
+msgstr ""
+
+msgid "Could not synchronize the repository"
+msgstr ""
+
+msgid "Repository created"
+msgstr ""
+
+msgid "Could not create the repository"
+msgstr ""
+
+msgid "Repository updated"
+msgstr ""
+
+msgid "Could not update the repository"
+msgstr ""
+
+msgid "Repository deleted"
+msgstr ""
+
+msgid "Could not delete the Repository"
+msgstr ""
+
+msgid "Repository content uploaded"
+msgstr ""
+
+msgid "Could not upload the content"
+msgstr ""
+
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+
+msgid "Successfully uploaded file '%s'."
+msgstr ""
+
+msgid "Failed to upload file '%s' to repository. Please check the file and try again."
+msgstr ""
+
+msgid "Manipulate repositories"
+msgstr ""
+
+msgid "Enabled Repositories"
+msgstr ""
+
+msgid "Arch"
+msgstr ""
+
+msgid "Release"
+msgstr ""
+
+msgid "Enabled"
+msgstr ""
+
+msgid "Repository enabled"
+msgstr ""
+
+msgid "Could not enable repository"
+msgstr ""
+
+msgid "Repository disabled"
+msgstr ""
+
+msgid "Could not disable repository"
+msgstr ""
+
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+msgid "Contract"
+msgstr ""
+
+msgid "Account"
+msgstr ""
+
+msgid "Support"
+msgstr ""
+
+msgid "Quantity"
+msgstr ""
+
+msgid "Attached"
+msgstr ""
+
+msgid "Manifest is being uploaded in task %{id}"
+msgstr ""
+
+msgid "Manifest upload failed"
+msgstr ""
+
+msgid "Subscription manifest file"
+msgstr ""
+
+msgid "Manifest is being deleted in task %{id}"
+msgstr ""
+
+msgid "Manifest deletion failed"
+msgstr ""
+
+msgid "Manifest is being refreshed in task %{id}"
+msgstr ""
+
+msgid "Manifest refresh failed"
+msgstr ""
+
+msgid "Status Message"
+msgstr ""
+
+msgid "Time"
+msgstr ""
+
+msgid "Manipulate subscriptions."
+msgstr ""
+
+msgid "Interval"
+msgstr ""
+
+msgid "how often synchronization should run"
+msgstr ""
+
+msgid "start date and time of the synchronization defaults to now"
+msgstr ""
+
+msgid "Sync plan created"
+msgstr ""
+
+msgid "Could not create the sync plan"
+msgstr ""
+
+msgid "start date and time of the synchronization"
+msgstr ""
+
+msgid "Sync plan updated"
+msgstr ""
+
+msgid "Could not update the sync plan"
+msgstr ""
+
+msgid "Sync plan destroyed"
+msgstr ""
+
+msgid "Could not destroy the sync plan"
+msgstr ""
+
+msgid "Manipulate sync plans"
 msgstr ""

--- a/locale/es/hammer-cli-katello.po
+++ b/locale/es/hammer-cli-katello.po
@@ -1,0 +1,1596 @@
+# gguerrer <gguerrer@redhat.com>, 2012. #zanata
+# gguerrer <gguerrer@redhat.com>, 2013. #zanata
+# agarcia <agarcia@redhat.com>, 2014. #zanata
+# gguerrer <gguerrer@redhat.com>, 2014. #zanata
+# gguerrer <gguerrer@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-27 06:33+0000\n"
+"Last-Translator: gguerrer <gguerrer@redhat.com>\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Nombre"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Límite"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Descripción"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Recopilación de hosts creada"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "No se ha podido crear la recopilación de hosts"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Número de hosts de contenido total"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Número máximo de hosts de contenido"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Recopilación de hosts actualizada"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "No se ha podido actualizar la recopilación de hosts"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Recopilación de hosts borrada"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "No se ha podido borrar la recopilación de hosts"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "Se han añadido los hosts de contenido"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "No se han podido añadir los hosts de contenido"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "Se han eliminado los hosts de contenido"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "No se han podido eliminar los hosts de contenido"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Manipular las recopilaciones de hosts"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Etiqueta"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "URL del repositorio de Red Hat"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Se actualizó la organización"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "No se pudo actualizar la organización"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Se creó la organización"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "No se pudo crear la organización"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Se borró la organización"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "No se pudo borrar la organización"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Manipular organizaciones"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Tipo"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "Llave GPG"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Repositorios habilitados"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Arquitectura"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Lanzamiento"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "Repositorio habilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "No se ha podido habilitar el repositorio"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Repositorio inhabilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "No se ha podido inhabilitar el repositorio"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "ID de regla"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "ID de filtro"
+
+# translation auto-copied from project Red Hat Satellite Installation Guide, version 6.0, document Prerequisites3
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Versión"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Versión mínima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Versión máxima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "ID de erratas"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Fecha de inicio"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Fecha de terminación"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author gguerrer
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Tipos"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Creado"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Actualizado"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Regla de filtro creada"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "No se ha podido crear la regla de filtro"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Regla de filtro actualizada"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "No se ha podido actualizar la regla de filtro"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Regla de filtro borrada"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "No se ha podido borrar la regla de filtro"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "ID de vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Compuesto"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "ID de repositorio"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Organización"
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author gguerrer
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Repositorios"
+
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Módulos puppet"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project nautilus, version 3.8.2, document nautilus
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Autor"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Entornos"
+
+# translation auto-copied from project PressGang CCMS topics, version BRMS_5.2.0_User_Guide, document Section-IDE
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Versiones"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Publicado"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30481-632191, author agarcia
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Componentes"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Vista de contenido creada"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "No se ha podido crear la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Crear una vista de contenido compuesta"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Vista de contenido actualizada"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "No se ha podido actualizar la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "La vista de contenido se está borrando mediante la tarea %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "No se ha podido borrar la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "La vista de contenido se está publicando mediante la tarea %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "No se ha podido publicar la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr ""
+"La vista de contenido se está eliminando del entorno mediante la tarea %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "No se ha podido eliminar la vista de contenido del entorno"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Lista separada por comas de los ID de versión que se van a eliminar"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Lista separada por comas de los ID de entorno que se van a eliminar"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr ""
+"Los objetos de vista de contenido se están eliminando mediante la tarea %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "No se han podido eliminar los objetos de la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "La versión de componente se ha añadido"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "No se ha podido añadir la versión"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "La versión de componente se ha eliminado"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "No se ha podido eliminar la versión"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Manipular vistas de contenido."
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Consumido"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups, author gguerrer
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "El entorno de ciclo de vida"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Vista de contenido"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} de %{limit}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author gguerrer
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Ilimitado"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard, author gguerrer
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Colecciones de hosts"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Llave de activación creada"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "No se ha podido crear la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Llave de activación actualizada"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "No se ha podido actualizar la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Llave de activación borrada"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "No se ha podido borrar la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Mostrar suscripciones asociadas"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Suscripción añadida a la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "No se ha podido añadir la suscripción a la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Eliminar suscripción"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Suscripción eliminada de la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "No se ha podido eliminar la suscripción de la llave de activación"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Mostrar recopilaciones de hosts asociados"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Manipular llaves de activación."
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Intervalo"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Creado"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Actualizado"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "frecuencia con la que debería ejecutarse la sincronización"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr ""
+"fecha y hora de inicio de las opciones predeterminadas de sincronización "
+"hasta ahora"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "Plan de sincronización creado"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "No se ha podido crear el plan de sincronización"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "fecha y hora de inicio de la sincronización"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "Plan de sincronización actualizado"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "No se ha podido actualizar el plan de sincronización"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "Plan de sincronización destruido"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "No se ha podido destruir el plan de sincronización"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Manipular planes de sincronización"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Más reciente (actualmente %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Módulo puppet añadido a la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "No se ha podido añadir el módulo puppet"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Módulo puppet eliminado de la vista de contenido"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "No se ha podido eliminar el módulo puppet de la vista de contenido"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "El repositorio se ha asociado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "No se ha podido añadir el repositorio"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "El repositorio se ha eliminado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "No se ha podido eliminar el repositorio"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "La recopilación de hosts se ha asociado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "No se ha podido añadir la recopilación de hosts"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "La recopilación de hosts se ha eliminado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "No se ha podido eliminar la recopilación de hosts"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "El host de contenido se ha añadido"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "No se ha podido añadir el host de contenido"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "El host de contenido se ha eliminado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "No se ha podido eliminar el host de contenido"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Tipo de contenido"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Producto"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Contenido"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "Llave GPG creada"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "No se ha podido crear la llave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "Archivo de llave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "Llave GPG actualizada"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "No se ha podido actualizar la llave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "Llave GPG borrada"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "No se ha podido borrar la llave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Contrato"
+
+# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author gguerrer
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Cuenta"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Soporte"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Cantidad"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Adjuntado"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "El manifiesto se está cargando en la tarea %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Error al cargar el manifiesto"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "Archivo del manifiesto de suscripción"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "El manifiesto se está borrando en la tarea %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Error al borrar el manifiesto"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "El manifiesto se está actualizando en la tarea %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Error al actualizar el manifiesto"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Estado"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Mensaje de estado"
+
+# translation auto-copied from project control-center, version 3.8.6, document gnome-control-center-2.0
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Hora"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Manipular suscripciones."
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID del host de contenido"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Ubicación"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "Estado de autorización"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Versión de lanzamiento"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "AutoHeal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Host de contenido creado"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "No se ha podido crear el host de contenido"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "El host de contenido se ha actualizado"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "No se ha podido actualizar el host de contenido"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "Host de contenido borrado"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "No se ha podido borrar el host de contenido"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Resumen"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Licencia"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Página de proyecto"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Fuente"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Dependencias"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "Suma de verificación de archivos"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Lista de etiquetas"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Repositorio de Red Hat"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Publicar mediante HTTP"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Publicado en"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Sincronización"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Última fecha de sincronización"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Recuentos de contenido"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Paquetes"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Grupos de paquetes"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Erratas"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "sí"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "no"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Falló"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Éxito"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Terminado"
+
+# translation auto-copied from project passwd, version 0.79, document passwd
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Error"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "Ejecutándose"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "Esperando"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Cancelado"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "No sincronizado"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "El repositorio se está sincronizando en la tarea %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "No se ha podido sincronizar el repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Repositorio creado"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "No se ha podido crear el repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Repositorio actualizado"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "No se ha podido actualizar el repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Repositorio borrado"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "No se ha podido borrar el repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Contenido del repositorio cargado"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "No se ha podido cargar el contenido"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+"Cargar archivo o directorio de archivos como contenido para un repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Archivo '%s' cargado correctamente."
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"No se ha podido cargar el archivo '%s' al repositorio. Verifique el archivo "
+"e inténtelo de nuevo."
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Manipular repositorios"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Nombre de vista de contenido"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Etiqueta de vista de contenido"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "La vista de contenido se está promoviendo mediante la tarea %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "No se ha podido promover la vista de contenido"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "Sincronizar estado"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Producto creado"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "No se ha podido crear el producto"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "ID de plan de sincronización"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "ID de llave GPG"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Solo lectura"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Borrable"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Nombre de repositorio"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Producto actualizado"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "No se ha podido actualizar el producto"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Producto destruido"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "No se ha podido destruir el producto"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Asignar plan de sincronización al producto."
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "Plan de sincronización asignado."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "No se ha podido asignar el plan de sincronización."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "Borrar plan de sincronización de la asignación y el producto."
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "Plan de sincronización eliminado."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "No se ha podido eliminar el plan de sincronización."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Manipular productos."
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Respuesta del servidor"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "FALLA"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Duración: %sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Mensaje: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Nombre de llave de activación para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Nombre de Capsule para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Nombre del host de contenido para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Nombre de  vista de contenido para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Nombre de llave GPG para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "Nombre de recopilación de hosts para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "Nombre del entorno de ciclo de vida para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Nombre de organización para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "Etiqueta de organización para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Nombre de producto para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Nombre de repositorio para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Nombre de set de repositorios para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Nombre de suscripción para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Nombre de plan de sincronización para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Nombre de la tarea para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Nombre de usuario para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Nombre del módulo Puppet para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Autor del módulo Puppet para realizar la búsqueda"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "UUID del módulo Puppet para realizar la búsqueda"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Nombre a buscar"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Inclusión"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Reglas"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Filtro creado"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "No se ha podido crear el filtro"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Filtro actualizado"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "No se ha podido actualizar el filtro"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Filtro borrado"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "No se ha podido borrar el filtro"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Anterior"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Ruta de ciclo de vida"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Biblioteca"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Entorno del ciclo de vida anterior"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Entorno creado"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "No se ha podido crear el entorno"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Entorno actualizado"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "No se ha podido actualizar el entorno"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Entorno eliminado"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "No se ha podido borrar el entorno"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Características"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Gestionar el contenido de Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "Entorno de ciclo de vida añadido correctamente a la Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "No se ha podido añadir el entorno del ciclo de vida a la Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "Entorno de ciclo de vida eliminado correctamente de Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "No se ha podido eliminar el entorno del ciclo de vida de Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "El contenido de Capsule se está sincronizando en la tarea %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "No se ha podido sincronizar el contenido de Capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Manipular Capsule"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author gguerrer
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author gguerrer
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author gguerrer
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author gguerrer
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/fr/hammer-cli-katello.po
+++ b/locale/fr/hammer-cli-katello.po
@@ -1,0 +1,1608 @@
+# Sam Friedmann <sfriedma@redhat.com>, 2012. #zanata
+# Sam Friedmann <sfriedma@redhat.com>, 2013. #zanata
+# jcarbone <jcarbone@redhat.com>, 2013. #zanata
+# Corina Roe <croe@redhat.com>, 2014. #zanata
+# Sam Friedmann <sfriedma@redhat.com>, 2014. #zanata
+# jcarbone <jcarbone@redhat.com>, 2014. #zanata
+# Sam Friedmann <sfriedma@redhat.com>, 2015. #zanata
+# jcarbone <jcarbone@redhat.com>, 2015. #zanata
+# jfenal <jfenal@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-28 08:27+0000\n"
+"Last-Translator: jcarbone <jcarbone@redhat.com>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Nom"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Limite"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Description"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Collection d'hôte créée"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "Impossible de créer la collection de l'hôte"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Hôtes de contenu total"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Hôtes de contenu maximum"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Collection d'hôte mise à jour"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "Impossible de mettre à jour la collection d'hôte"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Collection d'hôte supprimée"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "Impossible de supprimer la collection d'hôte"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "Le(s) hôte(s) de contenu a (ont) été ajouté(s)"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "Impossible d'ajouter le(s) hôte(s) de contenu"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "Le(s) hôte(s) de contenu a (ont) été supprimé(s)"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "Impossible de supprimer le(s) hôte(s) de contenu"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Manipuler les collections d'hôte"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Étiquette"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "URL du référentiel Red Hat"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Organisation mise à jour"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "Impossible de mettre à jour l'organisation"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Organisation créée"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "Impossible de créer l'organisation"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Organisation supprimée"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "Impossible de supprimer l'organisation"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Manipuler les organisations"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Type"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "Clé GPG"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Référentiels activés"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Arch"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Version"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Activé"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "Référentiel activé"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "Impossible d'activer le référentiel"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Référentiel désactivé"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "Impossible de désactiver le référentiel"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "ID de la règle"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "ID du filtre"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Version"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Version minimum"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Version maximum"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "ID d'errata"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Date de début"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Date de fin"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author Sam Friedmann
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Types"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Créé"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Mis à jour"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Règle de filtre créé"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "Impossible de créer la règle de filtre"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Règle de filtre mise à jour"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "Impossible de mettre à jour la règle de filtre"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Règle de filtre supprimée"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "Impossible de supprimer la règle de filtre"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "ID de l'affichage de contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Composite"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "ID de référentiel"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Organisation"
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author Sam Friedmann
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Référentiels"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Modules Puppet"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Auteur"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Environnements"
+
+# translation auto-copied from project PressGang CCMS topics, version BRMS_5.2.0_User_Guide, document Section-IDE
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Versions"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Publiées"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30481-632191, author Corina Roe
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Composants"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Affichage du contenu créé"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "Impossible de créer l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Créer un affichage du contenu composite"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Affichage de contenu mis à jour"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "Impossible de mettre à jour l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "L'affichage du contenu est en cours de suppression avec la tâche %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "Impossible de supprimer l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "L'affichage du contenu est en cours de publication avec la tâche %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "Impossible de publier l'affichage de contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr ""
+"L'affichage du contenu est en cours de suppression de l'environnement avec "
+"la tâche %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "Impossible de supprimer l'affichage du contenu de l'environnement"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Liste d'id de versions à supprimer séparée par des virgules"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Liste d'id d'environnements à supprimer séparée par des virgules"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr ""
+"Les objets d'affichage du contenu sont en cours de suppression de la tâche "
+"%{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "Impossible de supprimer les objets de l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "La version du composant a été ajoutée"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "Impossible d'ajouter la version"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "La version du composant a été supprimée"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "Impossible de supprimer la version"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Manipuler les affichages du contenu."
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Consommé"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "Environnement de cycle de vie"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Affichage du contenu"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} sur %{limit}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author Sam Friedmann
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Illimité"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Collections d'hôtes"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Clé d'activation activée"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "Impossible de créer la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Clé d'activation mise à jour"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "Impossible de mettre à jour la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Clé d'activation supprimée"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "Impossible de supprimer la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Répertorier les abonnements associés"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Abonnement ajouté à la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "Impossible d'ajouter l'abonnement à la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Supprimer l'abonnement"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Abonnement supprimé de la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "Impossible de supprimer l'abonnement de la clé d'activation"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Répertorier les collections d'hôtes associées"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Manipuler les clés d'activations"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Intervalle"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Créé le"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Mis à jour le"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "la fréquence à laquelle la synchronisation doit s'exécuter"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr ""
+"l'heure et la date de lancement de la synchronisation définies par défaut à "
+"maintenant "
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "Plan de synchronisation créé"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "Impossible de créer le plan de synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "l'heure et la date de lancement de la synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "Plan de synchronisation mis à jour"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "Impossible de mettre à jour le plan de synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "Plan de synchronisation détruit"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "Impossible de détruire le plan de synchronisation"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Manipuler les plans de synchronisation"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Dernier (actuellement %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Module Puppet ajouté à l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Impossible d'ajouter le module Puppet"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Module Puppet supprimé de l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "Impossible de supprimer le module puppet de l'affichage du contenu"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "Le référentiel a été associé"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "Impossible d'ajouter le référentiel"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "Le référentiel a été supprimé"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "Impossible de supprimer le référentiel"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "La collection d'hôte a été associée"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "Impossible d'ajouter la collection d'hôte"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "La collection d'hôte a été supprimée"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "Impossible de supprimer la collection d'hôte"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "L'hôte de contenu a été ajouté"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "Impossible d'ajouter l'hôte de contenu"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "L'hôte de contenu a été supprimé"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "Impossible de supprimer l'hôte de contenu"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Type de contenu"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Produit"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Contenu"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "Clé GPG créée"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "Impossible de créer la clé GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "Fichier de la clé GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "Clé GPG mise à jour"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "Impossible de mettre à jour la clé GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "Clé GPG supprimée"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "Impossible de supprimer la clé GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Contrat"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Compte"
+
+# translation auto-copied from project Customer Portal Translations, version ProductionSupportScopeofCoverage, document ProductionSupportScopeofCoverage.html, author jfenal
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Nous prenons en charge l'assistance à"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Quantité"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Attaché"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr ""
+"Le fichier manifeste est en cours de téléchargement dans la tâche %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Échec du téléchargement du manifeste "
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "Fichier manifeste d'abonnement"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "Le fichier manifeste est en cours de suppression dans la tâche %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Échec de la suppression du fichier manifeste"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "Le fichier manifeste est en cours d'actualisation dans la tâche %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Échec de l'actualisation du manifeste"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Statut"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Message d'état"
+
+# translation auto-copied from project control-center, version 3.8.6, document gnome-control-center-2.0
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Horodatage"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Manipuler les abonnements."
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID de l'hôte du contenu"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Localisation"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "État des droits d'accès"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Version de publication"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autoheal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Hôte du contenu créé"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "Impossible de créer l'hôte du contenu"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "Hôte du contenu mis à jour"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "Impossible de mettre à jour l'hôte du contenu"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "Hôte du contenu supprimé"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "Impossible de supprimer l'hôte du contenu"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Résumé"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Licence"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Page du projet"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Source"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Dépendances"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "Sommes de contrôle du fichier"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Liste des balises"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "Id"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Référentiel Red Hat"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Publier via HTTP"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Publié à"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Sync"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Dernière date de synchronisation"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Nombre de contenus"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Packages"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Groupes de packages"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Errata"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "oui"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "non"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Échec"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Réussite"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Terminé"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Erreur"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "En cours de fonctionnement"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "En attente"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Annulé"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "Pas synchronisé"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "Le référentiel est en cours de synchronisation dans la tâche %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "Impossible de synchroniser le référentiel"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Référentiel créé"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "Impossible de créer le référentiel"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Référentiel mis à jour"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "Impossible de mettre à jour le référentiel"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Référentiel supprimé"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "Impossible de supprimer le référentiel"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Contenu du référentiel téléchargé"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "Impossible de télécharger le contenu"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+"Télécharger le fichier ou le répertoire de fichiers en tant que contenu de "
+"référentiel"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Fichier '%s' téléchargé avec succès"
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"Échec de téléchargement du fichier '%s' sur le référentiel. Veuillez "
+"vérifier le fichier et essayer à nouveau."
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Manipuler les référentiels"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Nom de l'affichage de contenu"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Étiquette de l'affichage du contenu"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "L'affichage du contenu est en cours de promotion avec la tâche %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "Impossible de promouvoir l'affichage de contenu"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "État de synchronisation"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Produit créé"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "Impossible de créer le produit"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "ID du plan de synchronisation"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "ID de la clé GPG"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Lecture seule"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Supprimable"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Nom du référentiel"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Produit mis à jour"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "Impossible de mettre à jour le produit"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Produit détruit"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "Impossible de détruire le produit"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Attribuer le plan de synchronisation au produit."
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "Le plan de synchronisation a été attribué."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "Impossible d'attribuer le plan de synchronisation."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "Supprimer le produit et le plan de synchronisation de l'attribuation."
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "Plan de synchronisation supprimé."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "Impossible de supprimer le plan de synchronisation."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Manipuler les produits."
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Réponse du serveur"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "ÉCHEC"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Durée : %sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Message : %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Nom de la clé d'activation avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Nom de la capsule avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Nom de l'hôte du contenu avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Nom de l'affichage du contenu avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Nom de la clé Gpg avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "Nom de la collection d'hôte avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr ""
+"Nom de l'environnement du cycle de vie avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Nom de l'organisation avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr ""
+"Nom de l'étiquette de l'organisation avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Nom du produit avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Nom du référentiel avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Nom de l'ensemble du référentiel avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Nom de l'abonnement avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Nom du plan de synchronisation avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Nom de la tâche avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Nom d'utilisateur avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Nom du module Puppet avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Auteur du module Puppet avec lequel effectuer la recherche"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "UUID du module Puppet avec lequel effectuer la recherche"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Recherche par nom"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Inclusion"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Règles"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Filtre créé"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "Impossible de créer le filtre"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Filtre mis à jour"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "Impossible de mettre à jour le filtre"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Filtre supprimé"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "Impossible de supprimer le filtre"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Avant"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Chemin du cycle de vie"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Bibliothèque"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Environnement de cycle de vie antérieur"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Environnement Créé"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "Impossible de créer l'environnement"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Environnement mis à jour"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "Impossible de mettre à jour l'environnement"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Environnement supprimé"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "Impossible de supprimer l'environnement"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Fonctionnalités"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Gérer le contenu de la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "L'environnement du cycle de vie a été ajouté à la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "Impossible d'ajouter l'environnement du cycle de vie à la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "L'environnement du cycle de vie a été supprimé de la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "Impossible de supprimer l'environnement du cycle de vie de la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr ""
+"Le contenu de la capsule est en cours de synchronisation dans la tâche %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Impossible de synchroniser le contenu de la capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Manipuler la capsule"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author Sam Friedmann
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author jcarbone
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 14185-431341, author jcarbone
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author jcarbone
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author jcarbone
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/it/hammer-cli-katello.po
+++ b/locale/it/hammer-cli-katello.po
@@ -1,0 +1,1594 @@
+# fvalen <fvalen@redhat.com>, 2012. #zanata
+# fvalen <fvalen@redhat.com>, 2014. #zanata
+# fvalen <fvalen@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-28 01:06+0000\n"
+"Last-Translator: fvalen <fvalen@redhat.com>\n"
+"Language-Team: Italian\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Nome"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Limite"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Descrizione"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Insieme di host creato"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "Impossibile creare l'insieme di host"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Host di contenuto totale"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Host di contenuto massimo"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Insieme di host aggiornato"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "Impossibile aggiornare l'insieme di host"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Insieme di host rimosso"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "Impossibile rimuovere l'insieme di host"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "L'host di contenuto è stato aggiunto"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "Impossibile aggiungere l'host di contenuto"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "L'host di contenuto è stato rimosso"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "Impossibile rimuovere l'host di contenuto"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Manipolazione insiemi di host"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Etichetta"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "URL repositorio di Red Hat"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Organizzazione aggiornata"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "Impossibile aggiornare l'organizzazione"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Organizzazione creata"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "Impossibile creare l'organizzazione"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Organizzazione rimossa"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "Impossibile rimuovere l'organizzazione"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Manipolazione organizzazioni"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Tipo"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "Chiave GPG"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Repositori abilitati"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Arch"
+
+# translation auto-copied from project Katello, version 0.1v, document app, author fvalen
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Release"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "Repositorio abilitato"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "Impossibile abilitare il repositorio"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Repositorio disabilitato"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "Impossibile abilitare il repositorio"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "ID regola"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "ID filtro"
+
+# translation auto-copied from project Red Hat Satellite Installation Guide, version 6.0, document Prerequisites3
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Versione "
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Versione minima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Versione massima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "ID errata"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Data d'inizio"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Data di fine"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author fvalen
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Tipi"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Creato"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Aggiornato"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Regola filtro creata"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "Impossibile creare la regola per il filtro"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Regola filtro aggiornata"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "Impossibile aggiornare la regola per il filtro"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Regola filtro cancellata"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "Impossibile cancellare la regola del filtro"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "ID visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Composita"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "ID dei repositori"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Organizzazione"
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author fvalen
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Repositori"
+
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Moduli Puppet"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project nautilus, version 3.8.2, document nautilus
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Autore"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Ambienti"
+
+# translation auto-copied from project Cloudforms Cloud Engine User Guide, version 1.1, document topics/Supported_Instance_Operating_Systems1, author fvalen
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Versioni"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Pubblicato"
+
+# translation auto-copied from project Cloudforms Cloud Engine User Guide, version 1.1, document chap-Introduction, author fvalen
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Componenti"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Visualizzazione contenuto creata"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "Impossibile creare la visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Crea una visualizzazione del contenuto composita"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Visualizzazione contenuto aggiornata"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "Impossibile aggiornare la visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "Visualizzazione del contenuto rimossa con l'evento %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "Impossibile cancellare la visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "Visualizzazione del contenuto pubblicata con l'evento %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "Impossibile pubblicare la visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "Visualizzazione contenuto rimossa dall'ambiente con evento %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "Impossibile rimuovere la visualizzazione del contenuto dall'ambiente"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Elenco separato da virgole di id delle versioni da rimuovere"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Elenco separato da virgole di id degli ambienti da rimuovere"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "Elementi visualizzazione del contenuto rimossi dall'evento %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "Impossibile rimuovere gli elementi dalla visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "Aggiunta la versione del componente"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "Impossibile aggiungere la versione"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "La versione del componente è stata rimossa"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "Impossibile rimuovere la versione"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Manipolazione visualizzazioni dei contenuti"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Consumati"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "Ambiente ciclo di vita"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms, author fvalen
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} di %{limit}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author fvalen
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Illimitato"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Insiemi di host"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Chiave di attivazione creata"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "Impossibile creare la chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Chiave di attivazione aggiornata"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "Impossibile aggiornare la chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Chiave di attivazione rimossa"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "Impossibile cancellare la chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Elenca le sottoscrizioni associate"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Sottoscrizione aggiunta alla chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "Impossibile aggiungere la sottoscrizione alla chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Rimuovi sottoscrizione"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Sottoscrizione rimossa dalla chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "Impossibile rimuovere la sottoscrizione dalla chiave di attivazione"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Elenca gli insiemi di host associati"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Manipolazione chiavi di attivazione."
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Intervallo"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Creato"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Aggiornato"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "frequenza di esecuzione della sincronizzazione"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "Data e ora d'inizio dei default della sincronizzazione fino ad ora"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "Programmazione per la sincronizzazione creata"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "Impossibile creare la programmazione della sincronizzazione"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "data e ora d'inizio della sincronizzazione"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "Programmazione sincronizzazione aggiornata"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "Impossibile aggiornare la programmazione della sincronizzazione"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "Programmazione sincronizzazione eliminata"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "Impossibile eliminare la programmazione per la sincronizzazione"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Manipolazione programmazioni di sincronizzazione"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Ultimissimo (Corrente %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Modulo puppet aggiunto alla visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Impossibile aggiungere il modulo puppet"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Modulo puppet rimosso dalla visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr ""
+"Impossibile rimuovere il modulo puppet dalla visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "Il repositorio è stato associato"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "Impossibile aggiungere il repositorio"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "Il repositorio è stato rimosso"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "Impossibile rimuovere il repositorio"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "L'insieme di host è stato associato"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "Impossibile aggiungere l'insieme di host"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "L'insieme di host è stato rimosso"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "Impossibile rimuovere l'insieme di host"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "L'host di contenuto è stato aggiunto"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "Impossibile aggiungere l'host di contenuto"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "L'host di contenuto è stato rimosso"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "Impossibile rimuovere l'host di contenuto"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Tipo di contenuto"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Prodotto"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms, author fvalen
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Contenuto"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "Chiave GPG creata"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "Impossibile creare la chiave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "File chiave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "Chiave GPG aggiornata"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "Impossibile aggiornare la chiave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "Chiave GPG rimossa"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "Impossibile rimuovere la chiave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Contratto"
+
+# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author fvalen
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Account"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Supporto"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Quantità"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Allegato"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "Il manifesto è stato caricato nell'evento %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Caricamento manifesto fallito"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "File manifesto della sottoscrizione"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "Il manifesto nell'evento %{id} è stato rimosso"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Rimozione manifesto fallita"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "Il manifesto nell'evento %{id} è stato aggiornato"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Aggiornamento manifesto fallito"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Stato"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Messaggio sullo stato"
+
+# translation auto-copied from project control-center, version 3.8.6, document gnome-control-center-2.0
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Data"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Manipolazione sottoscrizioni."
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID host di contenuto"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Posizione"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "Stato entitlement"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Versione release"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autoheal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Host di contenutp creato"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "Impossibile creare l'host di contenuto"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "Host di contenuto aggiornato"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "Impossibile aggiornare l'host di contenuto"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "Host di contenutp rimosso"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "Impossibile rimuovere l'host di contenuto"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Sommario"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Licenza"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Pagina progetto"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8, author fvalen
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Sorgente"
+
+# translation auto-copied from project Katello, version 0.1v, document app, author fvalen
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Dipendenze"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "File checksum"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Elenco tag"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "Id"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat Repository"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Pubblica tramite HTTP"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Pubblicato su"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Sinc"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Data ultima sincronizzazione"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Conteggi contenuto"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Pacchetti"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Gruppi di pacchetti"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Errata"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "si"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "no"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Fallito"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Con successo"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Completato"
+
+# translation auto-copied from project passwd, version 0.79, document passwd
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Errore"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "In esecuzione"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "In attesa"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Annullato"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "Non sincronizzato"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "Il repositorio è stato sincronizzato nell'evento %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "Impossibile sincronizzare il repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Repositorio creato"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "Impossibile creare il repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Repositorio aggiornato"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "Impossibile aggiornare il repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Repositorio rimosso"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "Impossibile rimuovere il repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Contenuto repositorio caricato"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "Impossibile caricare il contenuto"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr "Carica i file o le directory come contenuto di un repositorio"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Caricato con successo il file '%s'."
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"Caricamento file '%s' sul repositorio fallito. Controllare il file e "
+"riprovare."
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Manipolazione repositori"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Nome visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Etichetta visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "Visualizzazione del contenuto avanzata con l'evento %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "Impossibile avanzare la visualizzazione del contenuto"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "Stato sincronizzazione"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Prodotto creato"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "Impoissibile creare il prodotto"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "ID programmazione sincronizzazione"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "ID chiave GPG"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Solo lettura"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Eliminabile"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Nome repositorio"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Prodotto aggiornato"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "Impossibile aggiornare il prodotto"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Prodotto eliminato"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "Impossibile eliminare il prodotto"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Assegna il programma di sincronizzazione al prodotto."
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "Programmazione sincronizzazione assegnata."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "Impossibile assegnare il programma di sincronizzazione."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr ""
+"Rimuovi assegnazione della programmazione di sincronizzazione e prodotto"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "Programmazione sincronizzazione rimossa."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "Impossibile rimuovere la programmazione della sincronizzazione."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Manipolazione prodotti."
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Risposta del server"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "FAIL"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Durata: %sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Messaggio: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Nome della chiave di attivazione per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Nome capsule per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Nome host di contenuto per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Nome visualizzazione del contenuto per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Nome della chiave gpg per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "nome insieme di host per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "Nome ambiente ciclo di vita per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Nome organizzazione per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "Etichetta organizzazione per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Nome del prodotto per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Nome repositorio per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Nome insiemi di repositori per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Nome sottoscrizione per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Nome programmazione sincronizzazione per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Nome evento per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Nome utente per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Nome modulo puppet per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Autore modulo puppet per la ricerca"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "UUID del modulo puppet per la ricerca"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Nome per la ricerca"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Inclusione"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Regole"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Filtro creato"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "Impossibile creare il filtro"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Filtro aggiornato"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "Impossibile aggiornare il filtro"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Filtro rimosso"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "Impossibile cancellare il filtro"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Precedente"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Percorso ciclo di vita"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Libreria "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Ambiente ciclo di vita precedente"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Ambiente creato"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "Impossibile creare un ambiente"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Ambiente aggiornato"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "Impossibile aggiornare l'ambiente"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Ambiente rimosso"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "Impossibile rimuovere l'ambiente"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Funzionalità"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Gestisci il contenuto di capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "Ambiente ciclo di vita aggiunto con successo al capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "Impossibile aggiungere l'ambiente ciclo di vita al capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "Ambiente ciclo di vita rimosso con successo dal capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "Impossibile rimuovere l'ambiente ciclo di vita dal capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Il contenuto di capsule è stato sincronizzato nell'evento %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Impossibile sincronizzare il contenuto di capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Manipolazione capsule"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author fvalen
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author fvalen
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author fvalen
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author fvalen
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+
+
+# translation auto-copied from project Katello, version 0.1v, document app, author fvalen
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/ja/hammer-cli-katello.po
+++ b/locale/ja/hammer-cli-katello.po
@@ -1,0 +1,1606 @@
+# nnakakit <nnakakit@redhat.com>, 2012. #zanata
+# kmoriguc <kmoriguc@redhat.com>, 2013. #zanata
+# noriko <noriko@redhat.com>, 2013. #zanata
+# tnagamot <tnagamot@redhat.com>, 2013. #zanata
+# Ykatabam <ykatabam@redhat.com>, 2014. #zanata
+# asasaki <asasaki@redhat.com>, 2014. #zanata
+# jito <jito@redhat.com>, 2014. #zanata
+# kmoriguc <kmoriguc@redhat.com>, 2014. #zanata
+# Ykatabam <ykatabam@redhat.com>, 2015. #zanata
+# asasaki <asasaki@redhat.com>, 2015. #zanata
+# myamamot <myamamot@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-27 06:30+0000\n"
+"Last-Translator: asasaki <asasaki@redhat.com>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "名前"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "制限"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker, author myamamot
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "説明"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "ホストコレクションが作成されました"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "ホストコレクションを作成できませんでした"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "コンテンツホストの合計"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "コンテンツホストの最大数"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "ホストコレクションが更新されました"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "ホストコレクションを更新できませんでした"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "ホストコレクションが削除されました"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "ホストコレクションを削除できませんでした"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "コンテンツホストが追加されました"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "コンテンツホストを追加できませんでした"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "コンテンツホストが削除されました"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "コンテンツホストを削除できませんでした"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "ホストコレクションの操作"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "ラベル"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Red Hat リポジトリー URL"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "組織が更新されました"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "組織を更新できませんでした"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "組織が作成されました"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "組織を作成できませんでした"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "組織が削除されました"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "組織を削除できませんでした"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "組織の操作"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 7698-743369, author Ykatabam
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "タイプ"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "GPG キー"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "有効にされたリポジトリー"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "アーキテクチャー"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "リリース"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "有効化"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "リポジトリーが有効にされました"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "リポジトリーを有効にできませんでした"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "リポジトリーが無効にされました"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "リポジトリーを無効にできませんでした"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "ルール ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "フィルター ID"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "バージョン"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "最小のバージョン"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "最大のバージョン"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "エラータ ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "開始日"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "終了日"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author noriko
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "タイプ"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 26789-635853, author tnagamot
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "作成"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "更新"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "フィルタールールが作成されました"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "フィルタールールを作成できませんでした"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "フィルタールールが更新されました"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "フィルタールールを更新できませんでした"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "フィルタールールが削除されました"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "フィルタールールを削除できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "コンテンツビュー ID"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "複合"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "リポジトリー ID"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "組織"
+
+# translation auto-copied from project JBoss SOA5.2 DS Metadata Repository Reference Guide, version 5.2, document content/jcr/configuration, author tnagamot
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "リポジトリー"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Puppet モジュール"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "作成者"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "環境"
+
+# translation auto-copied from project Customer Portal Translations, version 006_DrupalPO, document interface, author asasaki
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "バージョン"
+
+# translation auto-copied from project Customer Portal Translations, version 006_DrupalPO, document interface, author asasaki
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "公開"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30481-632191, author jito
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "コンポーネント"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "コンテンツビューが作成されました"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "コンテンツビューを作成できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "複合コンテンツビューの作成"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "コンテンツビューが更新されました"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "コンテンツビューを更新できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "タスク %{id} でコンテンツビューが削除されています"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "コンテンツビューを削除できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "タスク %{id} でコンテンツビューが公開されています"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "コンテンツビューを公開できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "タスク %{id} でコンテンツビューが環境から削除されています"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "コンテンツビューを環境から削除できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "削除するバージョン ID のコンマ区切りの一覧"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "削除する環境 ID のコンマ区切りの一覧"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "タスク %{id} でコンテンツビューのオブジェクトが削除されています"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "オブジェクトをコンテンツビューから削除できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "コンポーネントバージョンが追加されました"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "バージョンを追加できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "コンポーネントのバージョンが削除されました"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "バージョンを削除できませんでした"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "コンテンツビューの操作。"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "使用済み"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "ライフサイクル環境"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "コンテンツビュー"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} (合計: %{limit})"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author kmoriguc
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "無制限"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "ホストコレクション"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "アクティベーションキーが作成されました"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "アクティベーションキーを作成できませんでした"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "アクティベーションキーが更新されました"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "アクティベーションキーを更新できませんでした"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "アクティベーションキーが削除されました"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "アクティベーションキーを削除できませんでした"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "関連付けられたサブスクリプションの一覧表示"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "サブスクリプションがアクティベーションキーに追加されました"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "サブスクリプションをアクティベーションキーに追加できませんでした"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "サブスクリプションの削除"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "サブスクリプションがアクティベーションキーから削除されました"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "サブスクリプションをアクティベーションキーから削除できませんでした"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "関連付けられているホストコレクションの一覧"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "アクティベーションキーの操作。"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "間隔"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "作成:"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "更新:"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "同期を実行する頻度"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "同期の開始日時のデフォルトが「now」に設定されます"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "同期プランが作成されました"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "同期プランを作成できませんでした"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "同期の開始日時"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "同期プランが更新されました"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "同期プランを更新できませんでした"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "同期プランが破棄されました"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "同期プランを破棄できませんでした"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "同期プランの操作"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "最新 (現在: %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Puppet モジュールがコンテンツビューに追加されました"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Puppet モジュールを追加できませんでした"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Puppet モジュールがコンテンツビューから削除されました"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "Puppet モジュールをコンテンツビューから削除できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "リポジトリーが関連付けられました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "リポジトリーを追加できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "リポジトリーが削除されました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "リポジトリーを削除できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "ホストコレクションが関連付けられました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "ホストコレクションを追加できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "ホストコレクションが削除されました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "ホストコレクションを削除できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "コンテンツホストが追加されました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "コンテンツホストを追加できませんでした"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "コンテンツホストが削除されました"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "コンテンツホストを削除できませんでした"
+
+# translation auto-copied from project Customer Portal Translations, version 006_DrupalPO, document interface, author asasaki
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "コンテンツタイプ"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author asasaki
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "製品"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "コンテンツ"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "GPG キーが作成されました"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "GPG キーを作成できませんでした"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "GPG キーファイル"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "GPG キーが更新されました"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "GPG キーを更新できませんでした"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "GPG キーが削除されました"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "GPG キーを削除できませんでした"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "コントラクト"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "アカウント"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "サポート"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "数量"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author asasaki
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "割り当て済み"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "タスク %{id} でマニフェストがアップロードされています"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "マニフェストのアップロードが失敗しました"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "サブスクリプションのマニフェストファイル"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "タスク %{id} でマニフェストが削除されています"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "マニフェストの削除が失敗しました"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "タスク %{id} でマニフェストが更新されています"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "マニフェストの更新が失敗しました"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 6888-635853, author tnagamot
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "状態"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "状態メッセージ"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 10738-641496, author Ykatabam
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "時刻"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "サブスクリプションの操作。"
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "コンテンツホストの ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "ロケーション"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "エンタイトルメントの状態"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "リリースバージョン"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "自動修復"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "コンテンツホストが作成されました"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "コンテンツホストを作成できませんでした"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "コンテンツホストが更新されました"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "コンテンツホストを更新できませんでした"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "コンテンツホストが削除されました"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "コンテンツホストを削除できませんでした"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 7336-719185-122041, author Ykatabam
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "要約"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "ライセンス"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "プロジェクトページ"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "ソース"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "依存関係"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "ファイルのチェックサム"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "タグ一覧"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat リポジトリー"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "HTTP での公開"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "公開:"
+
+# translation auto-copied from project Katello, version 0.1v, document app
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "同期"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "最終同期日"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "コンテンツ数"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "パッケージ"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "パッケージグループ"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "エラータ"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "yes"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "no"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "失敗"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "成功"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "終了しました"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "エラー"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "実行中"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "待機中"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "キャンセル済み"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "同期しない"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "タスク %{id} でリポジトリーが同期されています"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "リポジトリーを同期できませんでした"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "リポジトリーが作成されました"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "リポジトリーを作成できませんでした"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "リポジトリーが更新されました"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "リポジトリーを更新できませんでした"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "リポジトリーが削除されました"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "リポジトリーを削除できませんでした"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "リポジトリーのコンテンツがアップロードされました"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "コンテンツをアップロードできませんでした"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+"ファイルまたはファイルのディレクトリーをリポジトリーのコンテンツとしてアップ"
+"ロード"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "ファイル '%s' が正常にアップロードされました。"
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"ファイル '%s' のリポジトリーへのアップロードに失敗しました。ファイルを確認し"
+"てからやり直してください。"
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "リポジトリーの操作。"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "コンテンツビュー名"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "コンテンツビューラベル"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "タスク %{id} でコンテンツビューがプロモートされています"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "コンテンツビューをプロモートできませんでした"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "同期の状態"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "製品が作成されました"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "製品を作成できませんでした"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "同期プラン ID "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "GPG キー ID"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "読み取り専用"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "削除可能"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "リポジトリー名"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "製品が更新されました"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "製品を更新できませんでした"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "製品が破棄されました"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "製品を破棄できませんでした"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "同期プランを製品に割り当てます。"
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "同期プランが割り当てられました。"
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "同期プランを割り当てることができませんでした。"
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "割り当て同期プランおよび製品を削除します。"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "同期プランが削除されました。"
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "同期プランを削除できませんでした。"
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "製品の操作。"
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "サーバーの応答"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "失敗"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "期間: %s (ミリ秒)"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "メッセージ: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "検索するアクティベーションキー名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "検索する Capsule 名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "検索するコンテンツホスト名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "検索するコンテンツビュー名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "検索する GPG  キー名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "検索するホストコレクション名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "検索するライフサイクル環境名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "検索する組織名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "検索する組織ラベル"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "検索する製品名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "検索するリポジトリー名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "検索するリポジトリーセット名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "検索するサブスクリプション名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "検索する同期プラン名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "検索するタスク名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "検索するユーザー名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "検索する Puppet モジュール名"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "検索する Puppet モジュールの作成者"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "検索する Puppet モジュールの UUID"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "検索する名前"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "組み込み"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "ルール"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "フィルターが作成されました"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "フィルターを作成できませんでした"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "フィルターが更新されました"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "フィルターを更新できませんでした"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "フィルターが削除されました"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "フィルターを削除できませんでした"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "以前の"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "ライフサイクルパス"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "ライブラリー"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "以前のライフサイクル環境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "環境が作成されました"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "環境を作成できませんでした"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "環境が更新されました"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "環境を更新できませんでした"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "環境が削除されました"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "環境を削除できませんでした"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 7935-743371-120503, author Ykatabam
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "機能"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Capsule コンテンツの管理"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "ライフサイクル環境が Capsule に正常に追加されました"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "ライフサイクル環境を Capsule に追加できませんでした"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "ライフサイクル環境が Capsule から正常に削除されました"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "ライフサイクル環境を Capsule から削除できませんでした"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "タスク %{id} で Capsule コンテンツが同期されています"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Capsule コンテンツを同期できませんでした"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Capsule の操作"
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project RHEL Virtualization Host Configuration and Guest Installation Guide, version 6.4, document Host_Installation, author kmoriguc
+
+
+# translation auto-copied from project RHEL Virtualization Host Configuration and Guest Installation Guide, version 6.4, document Host_Installation, author kmoriguc
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author asasaki
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author asasaki
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project Customer Portal Translations, version 006_DrupalPO, document interface, author asasaki
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author asasaki
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author asasaki
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author asasaki
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author asasaki
+
+# translation auto-copied from project RHELOSP Deploying Enterprise Env, version 5.0, document topics/Architecture6
+
+# translation auto-copied from project Red Hat Subscription Manager, version 1.0, document Distributors-RHSM, author nnakakit
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/ko/hammer-cli-katello.po
+++ b/locale/ko/hammer-cli-katello.po
@@ -1,0 +1,1588 @@
+# eukim <eukim@redhat.com>, 2012. #zanata
+# eukim <eukim@redhat.com>, 2013. #zanata
+# eukim <eukim@redhat.com>, 2014. #zanata
+# eukim <eukim@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-28 12:51+0000\n"
+"Last-Translator: eukim <eukim@redhat.com>\n"
+"Language-Team: Korean\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "이름 "
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "제한 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "설명 "
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "호스트 컬렉션이 생성되었습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "호스트 컬렉션을 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "총 컨텐츠 호스트 "
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "최대 컨텐츠 호스트 "
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "호스트 컬렉션이 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "호스트 컬렉션을 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "호스트 컬렉션이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "호스트 컬렉션을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "컨텐츠 호스트가 추가되었습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "컨텐츠 호스트를 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "컨텐츠 호스트가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "컨텐츠 호스트를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "호스트 컬렉션을 조정합니다 "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "레이블 "
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Red Hat 리포지터리 URL"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "조직이 업데이트되었습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "조직을 업데이트할 수 없습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "조직이 생성되었습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "조직을 생성할 수 없습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "조직이 삭제되었습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "조직을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "조직 조정 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "유형"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "GPG 키 "
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "활성화된 리포지터리 "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "아키텍처 "
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "릴리즈 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "활성화됨 "
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "리포지터리가 활성화됨 "
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "리포지터리를 활성화할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "리포지터리가 비활성화되었습니다 "
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "리포지터리를 비활성화할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "규칙 ID "
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "필터 ID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "버전 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "최소 버전 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "최대 버전 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "에라타 ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "시작 날짜 "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "종료 날짜  "
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author eukim
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "유형 "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "생성 일시 "
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "업데이트 일시 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "필터 규칙이 생성되었습니다 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "필터 규칙을 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "필터 규칙이 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "필터 규칙을 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "필터 규칙이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "필터 규칙을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "컨텐츠 뷰 ID"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "복합 "
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "리포지터리 ID"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "조직 "
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author eukim
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "리포지터리 "
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Puppet 모듈 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "저자 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "환경 "
+
+# translation auto-copied from project Cloudforms Cloud Engine User Guide, version 1.1, document topics/Supported_Instance_Operating_Systems1, author eukim
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "버전 "
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "공개 일시 "
+
+# translation auto-copied from project [RHEL] [CLUSTER] High Availability Add-On Overview  (was Cluster Suite Overview), version 5.9, document RHCS_Component_Summary
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "구성 요소"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "컨텐츠 뷰가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "컨텐츠 뷰를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "복합적인 컨텐츠 뷰 생성 "
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "컨텐츠 뷰가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "컨텐츠 뷰를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "컨텐츠 뷰가 태스크 %{id}로 삭제되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "컨텐츠 뷰를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "컨텐츠 뷰가 태스크 %{id}로 공개되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "컨텐츠 뷰를 공개할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "컨텐츠 뷰가 태스크 %{id}로 환경에서 삭제되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "환경에서 컨텐츠 뷰를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "콤마로 구분된 삭제할 버전 ID 목록 "
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "콤마로 구분된 삭제할 환경 ID 목록 "
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "컨텐츠 뷰 객체가 태스크 %{id}에서 삭제됩니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "컨텐츠 뷰에서 객체를 삭제할 수 없습니다."
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "구성 요소 버전이 추가되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "버전을 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "구성 요소 버전이 삭제되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "버전을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "컨텐츠 뷰 조정 "
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "사용됨 "
+
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "라이프사이클 환경 "
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author eukim
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "컨텐츠 뷰 "
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr " %{limit} 중 %{consumed}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author eukim
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "제한 없음 "
+
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "호스트 컬렉션 "
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "활성키가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "활성키를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "활성키가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "활성키를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "활성키가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "활성키를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "관련된 서브스크립션 목록 나열 "
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "활성키에 서브스크립션이 추가되었습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "활성키에 서브스크립션을 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "서브스크립션 삭제 "
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "활성키에서 서브스크립션이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "활성키에서 서브스크립션을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "관련된 호스트 컬렉션 목록 나열 "
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "활성키를 조정합니다."
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "간격 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "생성 일시 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "업데이트 일시 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "동기화 실행 빈도 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "동기화 시작 날짜 및 시간이 \"지금\"으로 기본값 설정됩니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "동기화 계획이 생성되었습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "동기화 계획을 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "동기화 시작 날짜 및 시간 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "동기화 계획이 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "동기화 계획을 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "동기화 계획이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "동기화 계획을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "동기화 계획 조정 "
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "최신 (현재 %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Puppet 모듈이 컨텐츠 뷰에 추가되었습니다 "
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "puppet 모듈을 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Puppet 모듈이 컨텐츠 뷰에서 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "컨텐츠 보기에서 puppet 모듈을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "리포지터리가 연결되어 있습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "리포지터리를 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "리포지터리가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "리포지터리를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "호스트 컬렉션이 연결되어 있습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "호스트 컬렉션을 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "호스트 컬렉션이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "호스트 컬렉션을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "컨텐츠 호스트가 추가되었습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "컨텐츠 호스트를 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "컨텐츠 호스트가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "컨텐츠 호스트를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "컨텐츠 유형 "
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "제품"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author eukim
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "컨텐츠"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "GPG 키가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "GPG 키를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "GPG 키 파일 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "GPG 키가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "GPG 키를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "GPG 키가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "GPG 키를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "계약 "
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "계정 "
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "지원"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "수량 "
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "첨부됨  "
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "매니페스트가 태스크 %{id}에서 업로드되어 있습니다"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "매니페스트 업로드를 실패했습니다 "
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "서브스크립션 매니페스트 파일 "
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "태스크 %{id}에서 매니페스트가 삭제되어 있습니다 "
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "매니페스트 삭제가 실패했습니다 "
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "매니페스트가 태스크 %{id}에서 새로 고침되어 있습니다"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "매니페스트 새로 고침에  실패했습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "상태 "
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "상태 메세지 "
+
+# translation auto-copied from project control-center, version 3.8.6, document gnome-control-center-2.0
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "시각"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "서브스크립션 조정 "
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "컨텐츠 호스트 ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "위치 "
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "인타이틀먼트 상태 "
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "릴리즈 버전 "
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autoheal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "컨텐츠 호스트가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "컨텐츠 호스트를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "컨텐츠 호스트가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "컨텐츠 호스트를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "컨텐츠 호스트가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "컨텐츠 호스트를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "요약"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "라이선스"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "프로젝트 페이지 "
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "소스 "
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "종속성 "
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "파일 체크섬 "
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "태그 목록 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID "
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat 리포지터리 "
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "HTTP를 통해 공개 "
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "공개 일시 "
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "동기화 "
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "마지막 동기화 날짜 "
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "컨텐츠 수 "
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "패키지 "
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "패키지 그룹 "
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "에라타 "
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "yes"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "no"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "실패 "
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "성공 "
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "마쳤음"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "오류 "
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "실행 중"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "기다리는 중"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "취소함"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "동기화되지 않았습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "리포지터리가 태스크 %{id}에서 동기화되어 있습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "리포지터리를 동기화할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "리포지터리가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "리포지터리를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "리포지터리가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "리포지터리를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "리포지터리를 삭제했습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "리포지터리를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "리포지터리 컨텐츠가 업로드되었습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "컨텐츠를 업로드할 수 없습니다 "
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr "리포지터리 컨텐츠로 파일 또는 파일 디렉토리 업로드 "
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "파일 '%s'이(가) 성공적으로 업로드되었습니다."
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"리포지터리에 파일 '%s'을(를) 업로드 실패했습니다. 파일을 확인한 후 다시 시도"
+"하십시오. "
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "리포지터리 조정 "
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "컨텐츠 뷰 이름 "
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "컨텐츠 뷰 레이블 "
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "컨텐츠 뷰가 태스크 %{id}로 승격되어 있습니다 "
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "컨텐츠 뷰를 승격할 수 없습니다 "
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "동기화 상태 "
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "제품이 생성되었습니다 "
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "제품을 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "동기화 계획 ID "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "GPG 키 ID"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "읽기 전용 "
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "삭제 가능 "
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "리포지터리 이름 "
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "제품이 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "제품을 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "제품이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "제품을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "제품에 동기화 계획을 할당합니다."
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "동기화 계획이 할당되었습니다. "
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "동기화 계획을 할당할 수 없습니다. "
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "할당 동기화 계획 및 제품을 삭제합니다. "
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "동기화 계획이 삭제되었습니다. "
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "동기화 계획을 삭제할 수 없습니다. "
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "제품을 조정합니다. "
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "서버 응답 "
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "실패 "
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "기간: %s (밀리초)"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "메세지: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "검색할 활성키 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "검색할 Capsule 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "검색할 컨텐츠 호스트 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "검색할 컨텐츠 뷰 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "검색할 Gpg 키 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "검색할 호스트 컬렉션 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "검색할 라이프사이클 환경 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "검색할 조직 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "검색할 조직 레이블 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "검색할 제품 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "검색할 리포지터리 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "검색할 리포지터리 설정 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "검색할 서브스크립션 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "검색할 동기화 계획 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "검색할 작업 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "검색할 사용자 이름 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "검색할 Puppet 모듈 이름  "
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "검색할 Puppet 모듈의 저자 "
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "검색할 Puppet 모듈의 UUID "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "검색할 이름 "
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "포함 사항 "
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld, author eukim
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "규칙 "
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "필터가 생성되었습니다 "
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "필터를 생성할 수 없습니다 "
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "필터가 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "필터를 업데이트할 수 없습니다 "
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "필터가 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "필터를 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "이전 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "라이프 사이클 경로 "
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author eukim
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "라이브러리"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "이전 라이프 사이클 환경 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "환경이 생성되었습니다 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "환경을 생성할 수 없습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "환경이 업데이트되었습니다 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "환경을 업데이트할 수 없습니다 "
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "환경이 삭제되었습니다 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "환경을 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "기능 "
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "capsule 컨텐츠 관리 "
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "라이프 사이클 환경이 capsule에 성공적으로 추가되었습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "라이프 사이클 환경이 capsule에 추가할 수 없습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "라이프 사이클 환경이 capsule에서 성공적으로 제거되었습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "라이프 사이클 환경을 capsule에서 삭제할 수 없습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Capsule 컨텐츠가 태스크 %{id}에서 동기화되어 있습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "capsule 컨텐츠를 동기화할 수 없습니다 "
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Capsule 조정 "
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author eukim
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author eukim
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author eukim
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/pt_BR/hammer-cli-katello.po
+++ b/locale/pt_BR/hammer-cli-katello.po
@@ -1,0 +1,1596 @@
+# gcintra <gcintra@redhat.com>, 2012. #zanata
+# gcintra <gcintra@redhat.com>, 2013. #zanata
+# gcintra <gcintra@redhat.com>, 2014. #zanata
+# ldelima <ldelima@redhat.com>, 2014. #zanata
+# gcintra <gcintra@redhat.com>, 2015. #zanata
+# ldelima <ldelima@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-27 11:58+0000\n"
+"Last-Translator: gcintra <gcintra@redhat.com>\n"
+"Language-Team: Portuguese (Brazil)\n"
+"Language: pt-BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Nome"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Limite"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Descrição"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Coleção do Host criada"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "Não foi possível criar a coleção do host"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Hosts de Conteúdo Total"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Maximo de Hosts de Conteúdo"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Coleção do Host atualizado"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "Não foi possível atualizar a coleção do host"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Coleção do Host removida"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "Não foi possível remover a coleção do host"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "O(s) host(s) de conteúdo foram adicionados"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "Não foi possível adicionar host de conteúdo"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "O(s) host(s) de conteúdo foram removidos"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "Não foi possível remover o(s) Host(s) de conteúdo"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Manipular as coleções de host"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Rótulo"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "URL do Repositório da Red Hat"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Organização atualizada"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "Não foi possível atualizar a organização"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Organização criada"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "Não foi possível criar a organização"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Organização removida"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "Não foi possível remover a organização"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Manipular Organizações"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Tipo"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "Chave GPG"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Repositórios habilitados "
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Arq"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Lançamento"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Habilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "O repositório foi habilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "Não foi possível habilitar repositório"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Repositório desabilitado"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "Não foi possível desabilitar repositório"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "Colocar regra em ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "Filtrar ID"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Versão"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Versão mínima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Versão máxima"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "Errata ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Data de Início"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Data de Término"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author gcintra
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Tipos"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Criado"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Atualizado"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Filtrar regra criada"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "Não foi possível criar a regra de filtro "
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Filtrar regra atualizada"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "Não foi possível atualizar a regra de filtro "
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Filtrar regra removida"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "Não foi possível remover a regra de filtro "
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "ID de Visualização de Conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Composição"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "IDs de repositório"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Organização"
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author gcintra
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Repositórios"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Módulos puppet"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Autor"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Ambientes"
+
+# translation auto-copied from project PressGang CCMS topics, version BRMS_5.2.0_User_Guide, document Section-IDE
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Versões"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Publicado"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30481-632191, author ldelima
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Componentes"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Visualização de Conteúdo criada"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "Ńão foi possível criar a visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Criar uma visualização de conteúdo de composição"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Visualização de Conteúdo atualizada"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "Ńão foi possível atualizar a visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "Visualização de conteúdo está sendo removida com a tarefa %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "Não foi possível remover a Visualização de Conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "Visualização de conteúdo está sendo publicada com a tarefa %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "Não foi possível publicarVisualização de Conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr ""
+"Visualização de conteúdo está sendo removida do ambiente com a tarefa %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "Não foi possível remover a exibição de conteúdo de um ambiente"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Lista separada por vírgulas de ids da versão a serem removidos."
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Lista separada por vírgulas de ids de ambiente a serem removidos."
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr ""
+"Objetos de Visualização de conteúdo estão sendo removidos com a tarefa %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "Não foi possível remover objetos da visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "A versão de componente foi adicionada"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "Não foi possível adicioanr versão"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "A versão de componente foi removida"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "Não foi possível remover versão"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Manipular visualizações de conteúdo"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Consumido"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups, author gcintra
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "Ambiente de Ciclo de Vida"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms, author gcintra
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Visualização de Conteúdo"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} de %{limit}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author gcintra
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Ilimitado"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard, author gcintra
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Coleções de Host"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Chave de Ativação criada"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "Não foi possível criar a chave de ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Chave de ativação atualizada"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "Não foi possível atualizar chave de ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Chave de ativação removida"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "Não foi possível remover chave de ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Listar subscrições associadas"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Foram adicionadas as subscrições  à Chave de Ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "Não foi possível adicionar uma subscrição à chave de ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Remover Subscrição "
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Subscrições removidas da Chave de Ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "Não foi possível remover uma subscrição da chave de ativação"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Listar coleções de host associadas"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Manipular chaves de ativação"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Intervalo"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Criado Em"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Atualizado Em"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "Com qual frequência deve acontecer a sincronização"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "o padrão da data Inicial e Horário da sincronização é agora"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "Plano de sinc criado"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "Não foi possível criar o plano de sinc"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "a data Inicial e Horário da sincronização"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "Plano de sinc atualizado"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "Não foi possível atualizar o plano de sinc"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "Plano de sincronização destruído"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "Não foi possível destruir o plano de sincronização"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Manipular plano de sinc"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Último (Atualmente %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Foi adicionado o módulo puppet à visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Não foi possível adicionar o módulo puppet"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Foi removido o módulo puppet da visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "Não foi possível remover o módulo puppet da visualização de conteúdo "
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "O repositório foi associado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "Não foi possível adicionar repositório"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "O repositório foi removido"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "Não foi possível remover repositório"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "A coleção de host foi associada"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "Não foi possível adicionar a coleção do host"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "A coleção do host foi removida"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "Não foi possível remover a coleção do host"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "O host de conteúdo foi adicionado"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "Não foi possível adicionar o host de conteúdo"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "O host de conteúdo foi removido"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "Não foi possível remover o host de conteúdo"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Tipo de Conteúdo"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gcintra
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Produto"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms, author gcintra
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Conteúdo"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "Chave de GPG criada"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "Não foi possível criar a Chave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "Arquivo de chave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "Chave GPG atualizada"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "Não foi possível atualizar a chave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "Chave GPG removida"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "Não foi possível remover a chave GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Contrato"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Conta"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Suporte"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Quantidade"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gcintra
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Conectado"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "Manifesto está sendo carregado na tarefa %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Carga do manifesto falhou"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "Arquivo de manifesto de subscrição"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "Manifesto está sendo removido na tarefa  %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Remoção do manifesto falhou"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "Manifesto está sendo atualizado na tarefa %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Atualização do manifesto falhou"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Estado"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Mensagem do Estado"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Hora"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Manipular Subscrições"
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID do host de conteúdo"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Local"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "Status de Direitos"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Versão de Lançamento"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autorrecuperação"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Host de conteúdo foi criado"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "Não foi possível criar o host de conteúdo"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "Host de conteúdo atualizado"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "Não foi possível atualizar o host de conteúdo"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "O Host de conteúdo foi removido"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "Não foi possível remover o host de conteúdo"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 31393-681179, author ldelima
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Sumário"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Licença"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Página do Projeto"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Fonte"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Dependências"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "Arquivar checksums"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Lista de Marcações"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "Id"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Repositório da Red Hat"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Publicar Via HTTP"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Publicado em"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Sinc"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Última Data de Sinc"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Contas de Conteúdo"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Pacotes"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Grupos de Pacote"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Errata"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "sim"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "não"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Falhou"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Sucesso"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Terminado"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Erro"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "Executando"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "Aguardando"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Cancelado"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "Não foi Sincronizado"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "Repositório está sendo sincronizado na tarefa %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "Não foi possível sincronizar o repositório"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Repositório criado"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "Não foi possível criar o repositório"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Repositório atualizado"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "Não foi possível atualizar repositório"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Repositório removido"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "Não foi possível remover repositório"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Conteúdo de repositório carregado"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "Não foi possível carregar conteúdo"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr ""
+"Carregar arquivo ou diretório de arquivos como conteúdo para um repositório"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Arquivo atualizado com sucesso '%s'"
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"Falha ao carregar o arquivo '%s'  no repositório. Por favor, verifique o "
+"arquivo e tente novamente. "
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Manipular Repositórios"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Nome de visualização de conteúdo"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Rótulo de Visualização de Conteúdo"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "Visualização de conteúdo está sendo promovida com a tarefa %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "Ńão foi possível promover a visualização de conteúdo"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "Estado do Sync"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Produto criado"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "Não foi possível criar o produto"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "ID de Plano de sincronização"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "ID de Chave GPG"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Somente leitura"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Removível"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Nome do Repo"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Produto atualizado"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "Não foi possível atualizar o produto"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Produto destruído"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "Não foi possível destruir o produto"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Atribuir Plano de sincronização ao produto"
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "Plano de sincronização atribuído."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "Não foi possível atribuir plano de sincronização."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "remover atribuição do plano de sinc e produto"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "Plano de sincronização removido."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "Não foi possível remover plano de sincronização."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Manipular produtos."
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Resposta do servidor"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "FAIL"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Duração: %sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Mensagem: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Nome da chave de ativação por quem procurar "
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Realizar busca por nome da capsula"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Realizar busca por nome do host de conteúdo"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Realizar busca por nome de visualização de conteúdo "
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Realizar busca por nome da chave Gpg "
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "Realizar busca por nome da coleção do host"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "Realizar busca por nome do ambiente de ciclo de vida"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Realizar busca por nome da Organização"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "Realizar busca por Etiqueta de Organização"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Realizar busca por Nome do Produto"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Realizar busca por Nome do Repositório"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Realizar busca por nome de conjutno de repositório"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Realizar busca por nome do Repositório"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Realizar busca por nome do plano de sinc"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Realizar busca por nome da tarefa"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Realizar busca por nome de usuário"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Realizar busca por nome de módulo puppet"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Realizar busca por autor do módulo puppet"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "Realizar busca por UUID do módulo puppet"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Realizar busca por nome"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Inclusão"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Regras"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Filtro criado"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "Não foi possível criar o filtro"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Filtro atualizado"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "Não foi possível atualizar o filtro"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Filtro removido"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "Não foi possível remover o filtro"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Anterior"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Caminho do Ciclo de vida"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms, author gcintra
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Biblioteca"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Ambiente de ciclo de vida anterior"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Ambiente criado"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "Não foi possível criar ambiente"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Ambiente atualizado"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "Não foi possível atualizar ambiente"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Ambiente removido"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "Não foi possível remover ambiente"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Recursos"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Gerenciar o conteúdo da capsula"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "Ambiente de ciclo de vida foi adicionado à capsula com sucesso"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "Não foi possível adicionar o ambiente de ciclo de vida à capsula."
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "Ambiente de ciclo de vida foi removido ocm sucesso da capsula"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "Não foi possível remover o ambiente de ciclo de vida da capsula."
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Conteúdo da capsula está sendo sincronizado na tarefa %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Não foi possível sincronizar o conteúdo da capsula"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Manipular a capsula"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author gcintra
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author gcintra
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author gcintra
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gcintra
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author gcintra
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gcintra
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/ru/hammer-cli-katello.po
+++ b/locale/ru/hammer-cli-katello.po
@@ -1,0 +1,1593 @@
+# ypoyarko <ypoyarko@redhat.com>, 2012. #zanata
+# ypoyarko <ypoyarko@redhat.com>, 2013. #zanata
+# ypoyarko <ypoyarko@redhat.com>, 2014. #zanata
+# ypoyarko <ypoyarko@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-28 04:55+0000\n"
+"Last-Translator: ypoyarko <ypoyarko@redhat.com>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "Имя"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "Лимит"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "Описание"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "Коллекция создана"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "Не удалось создать коллекцию"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "Всего узлов"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "Макс. узлов"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "Коллекция обновлена"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "Не удалось обновить коллекцию"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "Коллекция удалена"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "Не удалось удалить коллекцию"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "Узлы добавлены"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "Не удалось добавить узлы"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "Узлы удалены"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "Не удалось удалить узлы"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "Управление коллекциями узлов"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "Метка"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Адрес репозитория Red Hat"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "Организация обновлена"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "Не удалось обновить организацию"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "Организация создана"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "Не удалось создать организацию"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "Организация удалена"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "Не удалось удалить организацию"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "Управление организациями"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "Тип"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "Ключ GPG"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "Активные репозитории"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "Арх."
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "Выпуск"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "Включен"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "Репозиторий включен"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "Не удалось включить репозиторий"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "Репозиторий отключен"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "Не удалось отключить репозиторий"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "ID правила"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "ID фильтра"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "Версия"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "Мин. версия"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "Макс. версия"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "ID исправления"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "Дата начала"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "Срок действия"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author ypoyarko
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "Типы"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "Создан"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "Обновлено"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "Правило фильтрации создано"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "Не удалось создать правило фильтрации"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "Правило фильтрации обновлено"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "Не удалось обновить правило фильтрации"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "Правило фильтрации удалено"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "Не удалось удалить правило фильтрации"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "ID представления"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "Сложное"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "Идентификаторы репозиториев"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "Организация"
+
+# translation auto-copied from project Cloudforms System Engine User Guide, version 1.0, document Repositories, author ypoyarko
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "Репозитории"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Модули Puppet"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "Автор"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "Окружения"
+
+# translation auto-copied from project Cloudforms Cloud Engine User Guide, version 1.1, document topics/Supported_Instance_Operating_Systems1, author ypoyarko
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "Версия"
+
+# translation auto-copied from project Customer Portal Core Files, version 1, document interface, author ypoyarko
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "Опубликовано"
+
+# translation auto-copied from project [RHEL] [CLUSTER] High Availability Add-On Overview  (was Cluster Suite Overview), version 5.9, document RHCS_Component_Summary
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "Компоненты"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "Представление создано"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "Не удалось создать представление"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "Создать сложное представление"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "Представление обновлено"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "Не удалось обновить представление"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "Задача %{id} удалит представление"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "Не удалось удалить представление"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "Представление будет опубликовано задачей %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "Не удалось опубликовать представление"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "Задача %{id} удалит представление из окружения"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "Не удалось удалить представление из окружения"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "Список идентификаторов версий для удаления через запятую"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "Список идентификаторов окружений для удаления через запятую"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "Объекты представления будут удалены задачей %{id}"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "Не удалось удалить объекты из представления"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "Версия компонента добавлена"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "Не удалось добавить версию"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "Версия компонента удалена"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "Не удалось удалить версию"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "Управление представлениями"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "Занято"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Host_Groups, author ypoyarko
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "Окружение"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "Представление"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{consumed} из %{limit}"
+
+# translation auto-copied from project Customer Portal Translations, version RedHatCloudFormsLifeCycle, document RedHatCouldFormsLifeCycle.html, author ypoyarko
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "Не ограничено"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document Using_the_CloudForms_System_Engine_Dashboard, author ypoyarko
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "Коллекции узлов"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "Ключ активации создан"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "Не удалось создать ключ активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "Ключ активации обновлен"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "Не удалось обновить ключ активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "Ключ активации удален"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "Не удалось удалить ключ активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "Показать подписки"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "Подписка добавлена к ключу активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "Не удалось добавить подписку к ключу активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "Удалить подписку"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "Подписка удалена из ключа активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "Не удалось удалить подписку из ключа активации"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "Показать коллекции"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "Управление ключами активации"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "Интервал"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "Создан"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "Обновлен"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "частота синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr ""
+"по умолчанию текущее время определяет дату и время начала синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "План синхронизации создан"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "Не удалось создать план синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "дата и время синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "План синхронизации обновлен"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "Не удалось обновить план синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "План синхронизации удален"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "Не удалось удалить план синхронизации"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "Управление планами синхронизации"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "Последнее (на данный момент %s)"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Модуль Puppet добавлен в представление"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "Не удалось добавить модуль Puppet"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Модуль Puppet удален из представления"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "Не удалось удалить модуль Puppet из представления"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "Репозиторий назначен"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "Не удалось добавить репозиторий"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "Репозиторий удален"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "Не удалось удалить репозиторий"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "Коллекция хостов назначена"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "Не удалось добавить коллекцию хостов"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "Коллекция хостов удалена"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "Не удалось удалить коллекцию хостов"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "Хост содержимого добавлен"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "Не удалось добавить хост содержимого"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "Хост содержимого удален"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "Не удалось удалить хост содержимого"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "Тип содержимого"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "Продукт"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "Содержимое"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "Ключ создан"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "Не удалось создать ключ GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "Файл ключа GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "Ключ GPG обновлен"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "Не удалось обновить ключ GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "Ключ GPG удален"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "Не удалось удалить ключ GPG"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "Контракт"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "Учетная запись"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "Поддержка"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "Количество"
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "Добавлен"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "Добавление манифеста осуществляется в задаче %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "Не удалось отправить манифест"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "Файл манифеста подписок"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "Удаление манифеста осуществляется в задаче %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "Не удалось удалить манифест"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "Обновление манифеста осуществляется в задаче %{id}"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "Не удалось обновить манифест"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "Статус"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "Сообщение о состоянии"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "Время"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "Управление подписками"
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "ID хоста содержимого"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "Рабочий участок"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "Статус полномочий"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "Версия выпуска"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Автовосстановление"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "Узел создан"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "Не удалось создать узел содержимого"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "Узел содержимого обновлен"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "Не удалось создать узел содержимого"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "Узел содержимого удален"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "Не удалось удалить узел"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "Тема"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "Лицензия"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "Страница проекта"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "Источник"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "Зависимости"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "Контрольные суммы файлов"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "Список тегов"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Репозиторий Red Hat"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "Доступ HTTP"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "Опубликовано:"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "Синхронизация"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "Дата последней синхронизации"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "Счетчик представлений"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "Пакеты"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "Группы пакетов"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "Исправления"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "да"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "нет"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "Ошибка"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "Успешно"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "Готово"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "Ошибка"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "Работает"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "Ожидание"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "Отменена"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "Не синхронизирован"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "Синхронизация репозитория осуществляется в задаче %{id}"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "Не удалось синхронизировать репозиторий"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "Репозиторий создан"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "Не удалось создать репозиторий"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "Репозиторий обновлен"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "Не удалось обновить репозиторий"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "Репозиторий удален"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "Не удалось удалить репозиторий"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "Содержимое репозитория отправлено"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "Не удалось отправить содержимое"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr "Добавить файл или каталог в репозиторий"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "Файл «%s» успешно добавлен."
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr ""
+"Не удалось добавить «%s» в репозиторий. Проверьте файл и повторите попытку."
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "Управление репозиториями"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "Имя представления"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "Метка представления"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "Представление продвигается задачей %{id}"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "Не удалось продвинуть представление"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "Статус синхронизации"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "Продукт создан"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "Не удалось создать продукт"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "ID плана синхронизации"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "ID ключа GPG"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "Только чтение"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "Можно удалить"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "Имя репозитория"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "Продукт обновлен"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "Не удалось обновить продукт"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "Продукт удален"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "Не удалось удалить продукт"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "Назначить план синхронизации продукта"
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "План синхронизации назначен."
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "Не удалось назначить план синхронизации."
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "Удалить план синхронизации с продуктом"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "План синхронизации удален."
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "Не удалось удалить план синхронизации."
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "Управление продуктами"
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "Ответ сервера"
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt, author ypoyarko
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "ОШИБКА"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "Продолжительность: %sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "Сообщение: %s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "Имя искомого ключа активации"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "Имя искомой капсулы"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "Имя искомого узла содержимого"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "Имя искомого представления"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "Имя искомого ключа GPG"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "Имя искомой коллекции узлов"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "Имя искомого окружения"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "Имя искомой организации"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "Метка искомой организации"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "Имя искомого продукта"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "Имя искомого репозитория"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "Имя искомого набора репозиториев"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "Имя искомой подписки"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "Имя искомого плана синхронизации"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "Имя искомой задачи"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "Имя искомого пользователя"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "Имя искомого модуля Puppet"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "Имя автора искомого модуля Puppet"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "UUID искомого модуля Puppet"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "Искомое имя"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "Включение"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld, author ypoyarko
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "Правила"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "Фильтр создан"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "Не удалось создать фильтр"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "Фильтр обновлен"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "Не удалось обновить фильтр"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "Фильтр удален"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "Не удалось удалить фильтр"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "Предыдущее"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "Путь жизненного цикла"
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "Библиотека"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "Предыдущее окружение жизненного цикла"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "Окружение создано"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "Не удалось создать окружение"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "Окружение обновлено"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "Не удалось обновить окружение"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "Окружение удалено"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "Не удалось удалить окружение"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "Функции"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "Управление составом капсулы"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "Окружение добавлено в капсулу"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "Не удалось добавить окружение в капсулу"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "Окружение удалено из капсулы"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "Не удалось удалить окружение из капсулы"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Синхронизация состава капсулы осуществляется в задаче %{id}"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "Не удалось синхронизировать состав капсулы"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "Управление капсулой"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version 012_June_RHEL, document downloads.html, author ypoyarko
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author ypoyarko
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+# translation auto-copied from project RHEL Virtualization Deployment and Administration Guide, version 7.0, document App_Bridge_Device
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document chap-Configuring_Organizations_Locations_and_Lifecycle_Environments, author ypoyarko
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author ypoyarko
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/zh_CN/hammer-cli-katello.po
+++ b/locale/zh_CN/hammer-cli-katello.po
@@ -1,0 +1,1578 @@
+# Leah Liu <lliu@redhat.com>, 2013. #zanata
+# Leah Liu <lliu@redhat.com>, 2014. #zanata
+# Leah Liu <lliu@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-27 01:25+0000\n"
+"Last-Translator: Leah Liu <lliu@redhat.com>\n"
+"Language-Team: Chinese (China)\n"
+"Language: zh-CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Docker, version 6.1, document locale/foreman_docker
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "名称"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "限制"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "描述"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "已创建主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "无法创建主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "内容主机总数"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "最大内容主机数"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "已更新主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "无法更新主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "已删除主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "无法删除主机集合"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "已添加内容主机"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "无法添加内容主机"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "已删除内容主机"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "无法删除内容主机"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "修改主机集合"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "标签"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Red Hat 库 URL"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "已更新机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "无法更新机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "已生成机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "无法生成机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "已删除机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "无法删除机构"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "修改机构"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "类型"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "链接"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "GPG 密钥"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "已启用库"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "构架"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "发行本"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "已启用"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "已启用库"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "无法启用库"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "已禁用库"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "无法禁用库"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "规则 ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "过滤器 ID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "最小版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "最大版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "勘误 ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "起始日期"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "终止日期"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author Leah Liu
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "类型"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "已创建"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "更新"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "已创建过滤器规则"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "无法创建过滤器规则"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "已更新过滤器规则"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "无法更新过滤器规则"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "已删除过滤器规则"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "无法删除过滤器规则"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "内容查看 ID"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "组成"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "库 ID"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "机构"
+
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "库"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Puppet 模块"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "作者"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "环境"
+
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "版本"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "出版"
+
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "组件"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "已创建内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "无法创建内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "创建组件内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "已感谢您内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "无法更新内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "在任务 %{id} 中删除内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "无法删除内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "在任务 %{id} 中发布内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "无法发布内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "在任务 %{id} 中从环境中删除内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "无法从环境中删除内容查看"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "要删除的用逗号分开的版本 id 列表"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "要删除的用逗号分开的环境 id 列表"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "在任务 %{id} 中删除内容查看对象"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "无法从内容查看中删除对象"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "已添加组件版本"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "无法添加版本"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "已删除内容版本"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "无法删除版本"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "修改内容查看。"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "已消耗"
+
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "生命周期环境"
+
+# translation auto-copied from project nautilus, version 3.8.2, document nautilus
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "内容视图"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{limit} 中 %{consumed}"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "无限"
+
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "主机集合"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "已创建激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "无法创建激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "已更新激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "无法更新激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "已删除激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "无法删除激活码"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "列出关联的订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "添加到激活码中的订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "无法在激活码中添加订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "删除订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "从激活码中删除订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "无法从激活码中删除订阅"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "列出关联的主机集合"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "修改激活码。"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "间隔"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "创建于"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "更新于"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "同步的运行频率"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "同步的默认启动日期和时间为现在"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "已创建同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "无法创建同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "同步开始日期和时间"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "已更新同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "无法更新同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "已删除同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "无法删除同步计划"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "修改同步计划"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "最新（当前 %s）"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "在内容查看中添加的 Puppet 模块"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "无法添加 puppet 模块"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "从内容查看中删除的 puppet 模块"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "无法无法从内容查看中删除 puppet 模块"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "已关联该库"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "无法添加库"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "已删除库"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "无法删除库"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "已关联主机集合"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "无法添加主机集合"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "已删除主机集合"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "无法删除主机集合"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "已添加内容主机"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "无法添加内容主机"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "已删除内容主机"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "无法删除内容主机"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "内容类型"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "产品"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "内容"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "创建 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "无法创建 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "GPG 密钥文件"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "已更新 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "无法更新 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "已删除 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "无法删除 GPG 密钥"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "合同"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "账号"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "支持"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "数量"
+
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "已附加"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "在任务 %{id} 中上传清单"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "上传清单失败"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "订阅清单文件"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "在任务 %{id} 中删除清单"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "删除清单失败"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "在任务 %{id} 中刷新清单"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "刷新清单失败"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "状态"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "状态信息"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "时间"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "修改订阅。"
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "内容主机 ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "位置"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "权利状态"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "发行本版本"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autoheal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "无法创建内容"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "无法创建内容主机"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "已更新内容主机"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "无法更新内容主机"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "已删除内容主机"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "无法删除内容主机"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "概要"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "许可"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "项目页面"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "源"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "相依性"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "文件 checksums"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "标签列表"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "Id"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat 库"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "使用 HTTP 公布"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "出版"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "同步"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "上次同步日期"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "内容计数"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "软件包"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "软件包组"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "勘误"
+
+# translation auto-copied from project NetworkManager, version 0.9.9.0, document NetworkManager
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "是"
+
+# translation auto-copied from project firstboot, version 19.6, document firstboot, author Leah Liu
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "否"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "失败的"
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "成功"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "正在完成"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "错误"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "运行中"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "等候"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "已取消"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "未同步"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "在任务 %{id} 中同步库"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "无法同步库"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "已创建库"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "无法创建库"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "已更新库"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "无法更新库"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "已删除库"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "无法删除库"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "已上传库内容"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "无法上传内容"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr "将文件或者文件目录作为内容上传到库"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "成功上传文件 '%s'。"
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr "将 '%s' 上传到库失败。请检查该文件并再试一次。"
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "修改库"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "内容查看名称"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "内容查看标签"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "在任务 %{id} 中推广内容查看"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "无法推广内容查看"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "同步状态"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "已创建产品"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "无法创建产品"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "同步计划 ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "GPG 密钥 ID"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "只读"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "可删除"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "库名称"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "已更新产品"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "无法更新产品"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "已删除产品"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "无法删除产品"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "为产品分配同步计划。"
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "已分配同步计划。"
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "无法分配同步计划。"
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "删除分配同步计划和产品。"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "已删除同步计划。"
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "无法删除同步计划。"
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "修改产品。"
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "服务器响应 "
+
+# translation auto-copied from project libvirt, version 1.1.1, document libvirt
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "FAIL"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "周期：%sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "信息：%s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "根据其进行搜索的激活码名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "根据其进行搜索的 Capsule 名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "根据其进行搜索的内容主机名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "根据其进行搜索的内容查看名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "根据其进行搜索的 Gpg 密钥名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "根据其进行搜索的主机集合名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "根据其进行搜索的生命周期环境名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "根据其进行搜索的机构名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "根据其进行搜索的机构标签"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "根据其进行搜索的产品名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "根据其进行搜索的库名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "根据其进行搜索的库设置名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "根据其进行搜索的订阅名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "根据其进行搜索的同步计划名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "根据其进行搜索的任务名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "根据其进行搜索的用户名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "根据其进行搜索的 Puppet 模块名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "根据其进行搜索的 Puppet 模块作者名称"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "根据其进行搜索的 Puppet UUID 名称"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "根据其进行搜索的名称"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "包括"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld, author Leah Liu
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "规则"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "成功创建过滤器"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "无法创建过滤器"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "已更新过滤器"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "无法更新过滤器"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "已删除过滤器"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "无法删除过滤器"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "之前"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "生命周期路径"
+
+# translation auto-copied from project shotwell-core, version 0.14.1, document shotwell-core
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "媒体库"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "上一个生命周期环境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "已生成环境"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "无法创建环境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "已更新环境"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "无法更新环境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "已删除环境"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "无法删除环境"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "特性"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "管理 capule 内容"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "成功在 capule 中添加生命周期环境"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "无法在 capule 中添加生命周期环境"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "成功从 capule 中删除生命周期环境"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "无法从 capule 中删除生命周期环境"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "在任务 %{id} 中同步 capule 内容"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "无法同步 capule 内容"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "修改 capule"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author Leah Liu
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author Leah Liu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project webkitgtk3, version 2.0.3, document webkitgtk3, author Leah Liu
+
+# translation auto-copied from project Satellite6 Katello, version 6.1, document katello
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+

--- a/locale/zh_TW/hammer-cli-katello.po
+++ b/locale/zh_TW/hammer-cli-katello.po
@@ -1,0 +1,1573 @@
+# ccheng <ccheng@redhat.com>, 2014. #zanata
+# tchuang <tchuang@redhat.com>, 2014. #zanata
+# tchuang <tchuang@redhat.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: hammer-cli-katello 0.0.7.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-08-04 13:31+0200\n"
+"PO-Revision-Date: 2015-04-28 05:18+0000\n"
+"Last-Translator: tchuang <tchuang@redhat.com>\n"
+"Language-Team: Chinese (Taiwan)\n"
+"Language: zh-TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 3.6.0\n"
+
+#: lib/hammer_cli_katello/host_collection.rb:10
+msgid "Array of system ids to replace the content hosts in host collection"
+msgstr ""
+
+# translation auto-copied from project NetworkManager, version 0.9.9.0, document NetworkManager, author tchuang
+#: lib/hammer_cli_katello/host_collection.rb:26
+#: lib/hammer_cli_katello/host_collection.rb:60
+#: lib/hammer_cli_katello/repository_set.rb:9
+#: lib/hammer_cli_katello/repository_set.rb:21
+#: lib/hammer_cli_katello/repository_set.rb:29
+#: lib/hammer_cli_katello/content_view.rb:25
+#: lib/hammer_cli_katello/content_view.rb:36
+#: lib/hammer_cli_katello/content_view.rb:42
+#: lib/hammer_cli_katello/content_view.rb:51
+#: lib/hammer_cli_katello/content_view.rb:56
+#: lib/hammer_cli_katello/content_view.rb:62
+#: lib/hammer_cli_katello/activation_key.rb:11
+#: lib/hammer_cli_katello/activation_key.rb:49
+#: lib/hammer_cli_katello/activation_key.rb:59
+#: lib/hammer_cli_katello/activation_key.rb:100
+#: lib/hammer_cli_katello/activation_key.rb:173
+#: lib/hammer_cli_katello/sync_plan.rb:8
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:11
+#: lib/hammer_cli_katello/gpg_key.rb:10 lib/hammer_cli_katello/gpg_key.rb:20
+#: lib/hammer_cli_katello/gpg_key.rb:27
+#: lib/hammer_cli_katello/subscription.rb:21
+#: lib/hammer_cli_katello/content_host.rb:16
+#: lib/hammer_cli_katello/content_host.rb:30
+#: lib/hammer_cli_katello/puppet_module.rb:8
+#: lib/hammer_cli_katello/puppet_module.rb:19
+#: lib/hammer_cli_katello/repository.rb:24
+#: lib/hammer_cli_katello/repository.rb:38
+#: lib/hammer_cli_katello/repository.rb:45
+#: lib/hammer_cli_katello/content_view_version.rb:10
+#: lib/hammer_cli_katello/content_view_version.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:37
+#: lib/hammer_cli_katello/content_view_version.rb:43
+#: lib/hammer_cli_katello/content_view_version.rb:49
+#: lib/hammer_cli_katello/product.rb:8 lib/hammer_cli_katello/product.rb:37
+#: lib/hammer_cli_katello/filter.rb:30 lib/hammer_cli_katello/filter.rb:36
+#: lib/hammer_cli_katello/lifecycle_environment.rb:21
+#: lib/hammer_cli_katello/lifecycle_environment.rb:52
+#: lib/hammer_cli_katello/capsule.rb:44 lib/hammer_cli_katello/capsule.rb:60
+msgid "ID"
+msgstr "ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/host_collection.rb:27
+#: lib/hammer_cli_katello/host_collection.rb:61
+#: lib/hammer_cli_katello/repository_set.rb:11
+#: lib/hammer_cli_katello/repository_set.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:30
+#: lib/hammer_cli_katello/repository_set.rb:42
+#: lib/hammer_cli_katello/filter_rule.rb:14
+#: lib/hammer_cli_katello/filter_rule.rb:31
+#: lib/hammer_cli_katello/content_view.rb:14
+#: lib/hammer_cli_katello/content_view.rb:26
+#: lib/hammer_cli_katello/content_view.rb:37
+#: lib/hammer_cli_katello/content_view.rb:44
+#: lib/hammer_cli_katello/content_view.rb:52
+#: lib/hammer_cli_katello/content_view.rb:63
+#: lib/hammer_cli_katello/activation_key.rb:12
+#: lib/hammer_cli_katello/activation_key.rb:48
+#: lib/hammer_cli_katello/activation_key.rb:60
+#: lib/hammer_cli_katello/activation_key.rb:101
+#: lib/hammer_cli_katello/activation_key.rb:174
+#: lib/hammer_cli_katello/sync_plan.rb:9
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:13
+#: lib/hammer_cli_katello/gpg_key.rb:11 lib/hammer_cli_katello/gpg_key.rb:21
+#: lib/hammer_cli_katello/gpg_key.rb:28
+#: lib/hammer_cli_katello/subscription.rb:14
+#: lib/hammer_cli_katello/content_host.rb:17
+#: lib/hammer_cli_katello/content_host.rb:29
+#: lib/hammer_cli_katello/puppet_module.rb:9
+#: lib/hammer_cli_katello/puppet_module.rb:20
+#: lib/hammer_cli_katello/puppet_module.rb:41
+#: lib/hammer_cli_katello/repository.rb:9
+#: lib/hammer_cli_katello/repository.rb:25
+#: lib/hammer_cli_katello/repository.rb:39
+#: lib/hammer_cli_katello/repository.rb:46
+#: lib/hammer_cli_katello/content_view_version.rb:11
+#: lib/hammer_cli_katello/content_view_version.rb:27
+#: lib/hammer_cli_katello/content_view_version.rb:38
+#: lib/hammer_cli_katello/content_view_version.rb:44
+#: lib/hammer_cli_katello/content_view_version.rb:50
+#: lib/hammer_cli_katello/product.rb:9 lib/hammer_cli_katello/product.rb:38
+#: lib/hammer_cli_katello/filter.rb:14 lib/hammer_cli_katello/filter.rb:25
+#: lib/hammer_cli_katello/filter.rb:31 lib/hammer_cli_katello/filter.rb:37
+#: lib/hammer_cli_katello/lifecycle_environment.rb:22
+#: lib/hammer_cli_katello/lifecycle_environment.rb:53
+#: lib/hammer_cli_katello/capsule.rb:10 lib/hammer_cli_katello/capsule.rb:45
+#: lib/hammer_cli_katello/capsule.rb:61
+msgid "Name"
+msgstr "名稱"
+
+#: lib/hammer_cli_katello/host_collection.rb:28
+msgid "Limit"
+msgstr "限制"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/host_collection.rb:29
+#: lib/hammer_cli_katello/organization.rb:11
+#: lib/hammer_cli_katello/organization.rb:23
+#: lib/hammer_cli_katello/content_view.rb:29
+#: lib/hammer_cli_katello/activation_key.rb:50
+#: lib/hammer_cli_katello/sync_plan.rb:20
+#: lib/hammer_cli_katello/content_host.rb:31
+#: lib/hammer_cli_katello/puppet_module.rb:25
+#: lib/hammer_cli_katello/product.rb:10 lib/hammer_cli_katello/product.rb:40
+#: lib/hammer_cli_katello/lifecycle_environment.rb:55
+msgid "Description"
+msgstr "描述"
+
+#: lib/hammer_cli_katello/host_collection.rb:39
+#: lib/hammer_cli_katello/host_collection.rb:73
+msgid "Host collection created"
+msgstr "主機集已建立"
+
+#: lib/hammer_cli_katello/host_collection.rb:40
+#: lib/hammer_cli_katello/host_collection.rb:74
+msgid "Could not create the host collection"
+msgstr "無法建立主機集"
+
+#: lib/hammer_cli_katello/host_collection.rb:48
+msgid "Total Content Hosts"
+msgstr "內容主機總數"
+
+#: lib/hammer_cli_katello/host_collection.rb:49
+msgid "Max Content Hosts"
+msgstr "最大內容主機數量"
+
+#: lib/hammer_cli_katello/host_collection.rb:85
+msgid "Host collection updated"
+msgstr "主機集已更新"
+
+#: lib/hammer_cli_katello/host_collection.rb:86
+msgid "Could not update the the host collection"
+msgstr "無法更新主機集"
+
+#: lib/hammer_cli_katello/host_collection.rb:94
+msgid "Host collection deleted"
+msgstr "主機集已刪除"
+
+#: lib/hammer_cli_katello/host_collection.rb:95
+msgid "Could not delete the host collection"
+msgstr "無法刪除主機集"
+
+#: lib/hammer_cli_katello/host_collection.rb:104
+msgid "The content host(s) has been added"
+msgstr "主機集已新增"
+
+#: lib/hammer_cli_katello/host_collection.rb:105
+msgid "Could not add content host(s)"
+msgstr "無法新增主機集"
+
+#: lib/hammer_cli_katello/host_collection.rb:114
+msgid "The content host(s) has been removed"
+msgstr "主機集已移除"
+
+#: lib/hammer_cli_katello/host_collection.rb:115
+msgid "Could not remove content host(s)"
+msgstr "無法移除內容主機"
+
+#: lib/hammer_cli_katello/host_collection.rb:124
+msgid "Manipulate host collections"
+msgstr "操作主機集"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/organization.rb:10
+#: lib/hammer_cli_katello/organization.rb:22
+#: lib/hammer_cli_katello/repository_set.rb:26
+#: lib/hammer_cli_katello/content_view.rb:15
+#: lib/hammer_cli_katello/content_view.rb:27
+#: lib/hammer_cli_katello/content_view.rb:38
+#: lib/hammer_cli_katello/repository.rb:26
+#: lib/hammer_cli_katello/content_view_version.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:45
+#: lib/hammer_cli_katello/product.rb:39 lib/hammer_cli_katello/filter.rb:32
+#: lib/hammer_cli_katello/lifecycle_environment.rb:54
+msgid "Label"
+msgstr "標籤"
+
+#: lib/hammer_cli_katello/organization.rb:24
+msgid "Red Hat Repository URL"
+msgstr "Red Hat 軟體庫 URL"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:34
+msgid "Organization updated"
+msgstr "組織已更新"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:35
+msgid "Could not update the organization"
+msgstr "無法更新組織"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:43
+msgid "Organization created"
+msgstr "已建立組織"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:44
+msgid "Could not create the organization"
+msgstr "無法建立組織"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:54
+msgid "Organization deleted"
+msgstr "已刪除組織"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/organization.rb:55
+msgid "Could not delete the organization"
+msgstr "無法刪除組織"
+
+#: lib/hammer_cli_katello/organization.rb:65
+msgid "Manipulate organizations"
+msgstr "操作組織"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:10
+#: lib/hammer_cli_katello/repository_set.rb:23
+#: lib/hammer_cli_katello/filter.rb:15 lib/hammer_cli_katello/filter.rb:26
+msgid "Type"
+msgstr "類型"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:24
+#: lib/hammer_cli_katello/repository.rb:14
+#: lib/hammer_cli_katello/repository.rb:32
+#: lib/hammer_cli_katello/product.rb:68 lib/hammer_cli_katello/capsule.rb:11
+msgid "URL"
+msgstr "URL"
+
+#: lib/hammer_cli_katello/repository_set.rb:25
+#: lib/hammer_cli_katello/repository.rb:43
+#: lib/hammer_cli_katello/product.rb:51
+msgid "GPG Key"
+msgstr "GPG 金鑰"
+
+#: lib/hammer_cli_katello/repository_set.rb:28
+msgid "Enabled Repositories"
+msgstr "已啟用的軟體庫"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/repository_set.rb:44
+msgid "Arch"
+msgstr "架構"
+
+#: lib/hammer_cli_katello/repository_set.rb:45
+msgid "Release"
+msgstr "發行版"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository_set.rb:47
+msgid "Enabled"
+msgstr "已啟用"
+
+#: lib/hammer_cli_katello/repository_set.rb:67
+msgid "Repository enabled"
+msgstr "已啟用的軟體庫"
+
+#: lib/hammer_cli_katello/repository_set.rb:68
+msgid "Could not enable repository"
+msgstr "無法啟用軟體庫"
+
+#: lib/hammer_cli_katello/repository_set.rb:77
+msgid "Repository disabled"
+msgstr "軟體庫已停用"
+
+#: lib/hammer_cli_katello/repository_set.rb:78
+msgid "Could not disable repository"
+msgstr "無法停用軟體庫"
+
+#: lib/hammer_cli_katello/repository_set.rb:86
+msgid "manipulate repository sets on the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/filter_rule.rb:11
+#: lib/hammer_cli_katello/filter_rule.rb:28
+msgid "Rule ID"
+msgstr "規則 ID"
+
+#: lib/hammer_cli_katello/filter_rule.rb:12
+#: lib/hammer_cli_katello/filter_rule.rb:29
+#: lib/hammer_cli_katello/filter.rb:13 lib/hammer_cli_katello/filter.rb:24
+msgid "Filter ID"
+msgstr "篩選器 ID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:15
+#: lib/hammer_cli_katello/filter_rule.rb:32
+#: lib/hammer_cli_katello/content_view.rb:57
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:15
+#: lib/hammer_cli_katello/puppet_module.rb:11
+#: lib/hammer_cli_katello/puppet_module.rb:21
+#: lib/hammer_cli_katello/content_view_version.rb:12
+#: lib/hammer_cli_katello/content_view_version.rb:28
+#: lib/hammer_cli_katello/content_view_version.rb:52
+#: lib/hammer_cli_katello/filter.rb:38
+msgid "Version"
+msgstr "版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:16
+#: lib/hammer_cli_katello/filter_rule.rb:33
+#: lib/hammer_cli_katello/filter.rb:39
+msgid "Minimum Version"
+msgstr "最小版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:17
+#: lib/hammer_cli_katello/filter_rule.rb:34
+#: lib/hammer_cli_katello/filter.rb:40
+msgid "Maximum Version"
+msgstr "最大版本"
+
+#: lib/hammer_cli_katello/filter_rule.rb:18
+#: lib/hammer_cli_katello/filter_rule.rb:35
+#: lib/hammer_cli_katello/filter.rb:41
+msgid "Errata ID"
+msgstr "勘誤 ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:19
+#: lib/hammer_cli_katello/filter_rule.rb:36
+#: lib/hammer_cli_katello/sync_plan.rb:10 lib/hammer_cli_katello/filter.rb:42
+msgid "Start Date"
+msgstr "起始日期"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:20
+#: lib/hammer_cli_katello/filter_rule.rb:37
+#: lib/hammer_cli_katello/subscription.rb:20
+#: lib/hammer_cli_katello/filter.rb:43
+msgid "End Date"
+msgstr "結束日期"
+
+# translation auto-copied from project policycoreutils, version 2.1.14, document policycoreutils, author ccheng
+#: lib/hammer_cli_katello/filter_rule.rb:38
+#: lib/hammer_cli_katello/filter.rb:44
+msgid "Types"
+msgstr "類型"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/filter_rule.rb:39
+#: lib/hammer_cli_katello/content_view.rb:46
+#: lib/hammer_cli_katello/repository.rb:55 lib/hammer_cli_katello/filter.rb:45
+msgid "Created"
+msgstr "已建立"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/filter_rule.rb:40
+#: lib/hammer_cli_katello/content_view.rb:47
+#: lib/hammer_cli_katello/repository.rb:56 lib/hammer_cli_katello/filter.rb:46
+msgid "Updated"
+msgstr "已更新"
+
+#: lib/hammer_cli_katello/filter_rule.rb:47
+msgid "Filter rule created"
+msgstr "篩選器規則已建立"
+
+#: lib/hammer_cli_katello/filter_rule.rb:48
+msgid "Could not create the filter rule"
+msgstr "無法建立篩選器規則"
+
+#: lib/hammer_cli_katello/filter_rule.rb:54
+msgid "Filter rule updated"
+msgstr "篩選器規則已更新"
+
+#: lib/hammer_cli_katello/filter_rule.rb:55
+msgid "Could not update the filter rule"
+msgstr "無法更新篩選器規則"
+
+#: lib/hammer_cli_katello/filter_rule.rb:61
+msgid "Filter rule deleted"
+msgstr "篩選器規則已刪除"
+
+#: lib/hammer_cli_katello/filter_rule.rb:62
+msgid "Could not delete the filter rule"
+msgstr "無法刪除篩選器規則"
+
+#: lib/hammer_cli_katello/content_view.rb:13
+#: lib/hammer_cli_katello/content_view_version.rb:15
+#: lib/hammer_cli_katello/content_view_version.rb:31
+msgid "Content View ID"
+msgstr "內容視域 ID"
+
+#: lib/hammer_cli_katello/content_view.rb:16
+#: lib/hammer_cli_katello/content_view.rb:28
+msgid "Composite"
+msgstr "複合式"
+
+#: lib/hammer_cli_katello/content_view.rb:17
+msgid "Repository IDs"
+msgstr "軟體庫 ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_view.rb:32
+#: lib/hammer_cli_katello/gpg_key.rb:23
+#: lib/hammer_cli_katello/repository.rb:28
+#: lib/hammer_cli_katello/product.rb:13 lib/hammer_cli_katello/product.rb:56
+#: lib/hammer_cli_katello/lifecycle_environment.rb:57
+#: lib/hammer_cli_katello/capsule.rb:47 lib/hammer_cli_katello/capsule.rb:63
+msgid "Organization"
+msgstr "組織"
+
+#: lib/hammer_cli_katello/content_view.rb:35
+#: lib/hammer_cli_katello/puppet_module.rb:39
+#: lib/hammer_cli_katello/content_view_version.rb:42
+#: lib/hammer_cli_katello/product.rb:16 lib/hammer_cli_katello/filter.rb:29
+msgid "Repositories"
+msgstr "軟體庫"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:41
+#: lib/hammer_cli_katello/repository.rb:62
+#: lib/hammer_cli_katello/content_view_version.rb:48
+msgid "Puppet Modules"
+msgstr "Puppet 模組"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:43
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:12
+msgid "UUID"
+msgstr "UUID"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/content_view.rb:45
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:14
+#: lib/hammer_cli_katello/puppet_module.rb:10
+#: lib/hammer_cli_katello/puppet_module.rb:22
+#: lib/hammer_cli_katello/content_view_version.rb:51
+msgid "Author"
+msgstr "作者"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/content_view.rb:50
+#: lib/hammer_cli_katello/content_view_version.rb:36
+msgid "Environments"
+msgstr "環境"
+
+#: lib/hammer_cli_katello/content_view.rb:55
+msgid "Versions"
+msgstr "版本"
+
+#: lib/hammer_cli_katello/content_view.rb:58
+msgid "Published"
+msgstr "已發佈"
+
+#: lib/hammer_cli_katello/content_view.rb:61
+msgid "Components"
+msgstr "元件"
+
+#: lib/hammer_cli_katello/content_view.rb:71
+msgid "Content view created"
+msgstr "內容視域已建立"
+
+#: lib/hammer_cli_katello/content_view.rb:72
+msgid "Could not create the content view"
+msgstr "無法建立內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:74
+msgid "Create a composite content view"
+msgstr "建立複合式的內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:86
+msgid "Content view updated"
+msgstr "內容視域已更新"
+
+#: lib/hammer_cli_katello/content_view.rb:87
+msgid "Could not update the content view"
+msgstr "無法更新內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:98
+#: lib/hammer_cli_katello/content_view_version.rb:77
+msgid "Content view is being deleted with task %{id}"
+msgstr "內容視域正被刪除中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/content_view.rb:99
+#: lib/hammer_cli_katello/content_view_version.rb:78
+msgid "Could not delete the content view"
+msgstr "無法刪除內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:110
+msgid "Content view is being published with task %{id}"
+msgstr "內容視域正被發佈中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/content_view.rb:111
+msgid "Could not publish the content view"
+msgstr "無法發佈內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:123
+msgid "Content view is being removed from environment with task %{id}"
+msgstr "內容視域正從環境中移除（任務 %{id}）"
+
+#: lib/hammer_cli_katello/content_view.rb:124
+msgid "Could not remove the content view from environment"
+msgstr "無法從環境中移除內容視域"
+
+#: lib/hammer_cli_katello/content_view.rb:138
+msgid "Comma separated list of version ids to remove"
+msgstr "欲移除、以逗號隔開的一列版本 ID"
+
+#: lib/hammer_cli_katello/content_view.rb:140
+msgid "Comma separated list of environment ids to remove"
+msgstr "欲移除、以逗號隔開的一列環境 ID"
+
+#: lib/hammer_cli_katello/content_view.rb:150
+msgid "Content view objects are being removed task %{id}"
+msgstr "內容視域物件正被移除（任務 %{id}）"
+
+#: lib/hammer_cli_katello/content_view.rb:151
+msgid "Could not remove objects from content view"
+msgstr "無法從內容視域移除物件"
+
+#: lib/hammer_cli_katello/content_view.rb:166
+msgid "The component version has been added"
+msgstr "元件版本已新增"
+
+#: lib/hammer_cli_katello/content_view.rb:167
+msgid "Could not add version"
+msgstr "無法新增版本"
+
+#: lib/hammer_cli_katello/content_view.rb:180
+msgid "The component version has been removed"
+msgstr "元件版本已移除"
+
+#: lib/hammer_cli_katello/content_view.rb:181
+msgid "Could not remove version"
+msgstr "無法移除版本"
+
+#: lib/hammer_cli_katello/content_view.rb:202
+msgid "Manipulate content views."
+msgstr "操作內容視域。"
+
+#: lib/hammer_cli_katello/activation_key.rb:13
+#: lib/hammer_cli_katello/subscription.rb:19
+msgid "Consumed"
+msgstr "已消耗"
+
+#: lib/hammer_cli_katello/activation_key.rb:15
+#: lib/hammer_cli_katello/activation_key.rb:52
+#: lib/hammer_cli_katello/content_host.rb:34
+msgid "Lifecycle Environment"
+msgstr "生命週期環境"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author ccheng
+#: lib/hammer_cli_katello/activation_key.rb:18
+#: lib/hammer_cli_katello/activation_key.rb:55
+#: lib/hammer_cli_katello/content_host.rb:37
+msgid "Content View"
+msgstr "內容視域"
+
+#: lib/hammer_cli_katello/activation_key.rb:23
+msgid "%{consumed} of %{limit}"
+msgstr "%{limit} 之 %{consumed}"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/activation_key.rb:26
+#: lib/hammer_cli_katello/subscription.rb:28
+msgid "Unlimited"
+msgstr "無限制"
+
+# auto translated by TM merge from project: Satellite6 Katello Bastion, version: 6.0, DocId: katello
+#: lib/hammer_cli_katello/activation_key.rb:58
+msgid "Host Collections"
+msgstr "主機蒐集"
+
+#: lib/hammer_cli_katello/activation_key.rb:70
+msgid "Activation key created"
+msgstr "啟動金鑰已建立"
+
+#: lib/hammer_cli_katello/activation_key.rb:71
+msgid "Could not create the activation key"
+msgstr "無法建立啟動金鑰"
+
+#: lib/hammer_cli_katello/activation_key.rb:79
+msgid "Activation key updated"
+msgstr "啟動金鑰已更新"
+
+#: lib/hammer_cli_katello/activation_key.rb:80
+msgid "Could not update the activation key"
+msgstr "無法更新啟動金鑰"
+
+#: lib/hammer_cli_katello/activation_key.rb:88
+msgid "Activation key deleted"
+msgstr "啟動金鑰已刪除"
+
+#: lib/hammer_cli_katello/activation_key.rb:89
+msgid "Could not delete the activation key"
+msgstr "無法刪除啟動金鑰"
+
+#: lib/hammer_cli_katello/activation_key.rb:96
+msgid "List associated subscriptions"
+msgstr "列出相聯的訂閱"
+
+#: lib/hammer_cli_katello/activation_key.rb:104
+#: lib/hammer_cli_katello/activation_key.rb:123
+#: lib/hammer_cli_katello/activation_key.rb:149
+#: lib/hammer_cli_katello/activation_key.rb:177
+msgid "resource ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:124
+#: lib/hammer_cli_katello/activation_key.rb:150
+msgid "subscription ID"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:125
+msgid "subscription quantity"
+msgstr ""
+
+#: lib/hammer_cli_katello/activation_key.rb:139
+msgid "Subscription added to activation key"
+msgstr "訂閱已附加至啟動金鑰"
+
+#: lib/hammer_cli_katello/activation_key.rb:140
+msgid "Could not add subscription to activation key"
+msgstr "無法將訂閱附加至啟動金鑰"
+
+#: lib/hammer_cli_katello/activation_key.rb:146
+msgid "Remove subscription"
+msgstr "移除訂閱"
+
+#: lib/hammer_cli_katello/activation_key.rb:162
+msgid "Subscription removed from activation key"
+msgstr "訂閱已由啟動金鑰移除"
+
+#: lib/hammer_cli_katello/activation_key.rb:163
+msgid "Could not remove subscription from activation key"
+msgstr "無法由啟動金鑰移除訂閱"
+
+#: lib/hammer_cli_katello/activation_key.rb:169
+msgid "List associated host collections"
+msgstr "列出相聯的主機集"
+
+#: lib/hammer_cli_katello/activation_key.rb:197
+msgid "Manipulate activation keys."
+msgstr "操作啟動金鑰。"
+
+#: lib/hammer_cli_katello/sync_plan.rb:11
+msgid "Interval"
+msgstr "間隔"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:21 lib/hammer_cli_katello/capsule.rb:23
+msgid "Created at"
+msgstr "建立於"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/sync_plan.rb:22 lib/hammer_cli_katello/capsule.rb:24
+msgid "Updated at"
+msgstr "更新於"
+
+#: lib/hammer_cli_katello/sync_plan.rb:30
+#: lib/hammer_cli_katello/sync_plan.rb:49
+msgid "how often synchronization should run"
+msgstr "同步化程序執行的頻率"
+
+#: lib/hammer_cli_katello/sync_plan.rb:37
+msgid "start date and time of the synchronization defaults to now"
+msgstr "同步化起始日期和時間的預設值已設為現在"
+
+#: lib/hammer_cli_katello/sync_plan.rb:41
+msgid "Sync plan created"
+msgstr "同步計劃已建立"
+
+#: lib/hammer_cli_katello/sync_plan.rb:42
+msgid "Could not create the sync plan"
+msgstr "無法建立同步計劃"
+
+#: lib/hammer_cli_katello/sync_plan.rb:53
+msgid "start date and time of the synchronization"
+msgstr "同步化的起始日期和時間"
+
+#: lib/hammer_cli_katello/sync_plan.rb:56
+msgid "Sync plan updated"
+msgstr "同步計劃已更新"
+
+#: lib/hammer_cli_katello/sync_plan.rb:57
+msgid "Could not update the sync plan"
+msgstr "無法更新同步計劃"
+
+#: lib/hammer_cli_katello/sync_plan.rb:63
+msgid "Sync plan destroyed"
+msgstr "同步計劃已刪除"
+
+#: lib/hammer_cli_katello/sync_plan.rb:64
+msgid "Could not destroy the sync plan"
+msgstr "無法刪除同步計劃"
+
+#: lib/hammer_cli_katello/sync_plan.rb:73
+msgid "Manipulate sync plans"
+msgstr "操作同步計劃"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:22
+msgid "Latest(Currently %s)"
+msgstr "最新（目前為 %s）"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:33
+msgid "Puppet module added to content view"
+msgstr "Puppet 模組已新增至內容視域"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:34
+msgid "Could not add the puppet module"
+msgstr "無法新增 puppet 模組"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:42
+msgid "Puppet module removed from content view"
+msgstr "Puppet 模組已從內容視域中移除"
+
+#: lib/hammer_cli_katello/content_view_puppet_module.rb:43
+msgid "Couldn't remove puppet module from the content view"
+msgstr "無法從內容視域中移除 puppet 模組"
+
+#: lib/hammer_cli_katello/associating_commands.rb:12
+msgid "The repository has been associated"
+msgstr "軟體庫的相聯性已建立"
+
+#: lib/hammer_cli_katello/associating_commands.rb:13
+msgid "Could not add repository"
+msgstr "無法新增軟體庫"
+
+#: lib/hammer_cli_katello/associating_commands.rb:21
+msgid "The repository has been removed"
+msgstr "軟體庫已移除"
+
+#: lib/hammer_cli_katello/associating_commands.rb:22
+msgid "Could not remove repository"
+msgstr "無法移除軟體庫"
+
+#: lib/hammer_cli_katello/associating_commands.rb:34
+msgid "The host collection has been associated"
+msgstr "主機集的相聯性已建立"
+
+#: lib/hammer_cli_katello/associating_commands.rb:35
+msgid "Could not add host collection"
+msgstr "無法新增主機集"
+
+#: lib/hammer_cli_katello/associating_commands.rb:42
+msgid "The host collection has been removed"
+msgstr "主機集已被移除"
+
+#: lib/hammer_cli_katello/associating_commands.rb:43
+msgid "Could not remove host collection"
+msgstr "無法移除主機集"
+
+#: lib/hammer_cli_katello/associating_commands.rb:55
+msgid "The content host has been added"
+msgstr "內容主機已新增"
+
+#: lib/hammer_cli_katello/associating_commands.rb:56
+msgid "Could not add content host"
+msgstr "無法新增內容主機"
+
+#: lib/hammer_cli_katello/associating_commands.rb:63
+msgid "The content host has been removed"
+msgstr "內容主機已被移除"
+
+#: lib/hammer_cli_katello/associating_commands.rb:64
+msgid "Could not remove content host"
+msgstr "無法移除內容主機"
+
+#: lib/hammer_cli_katello/gpg_key.rb:29
+#: lib/hammer_cli_katello/repository.rb:13
+#: lib/hammer_cli_katello/repository.rb:31
+msgid "Content Type"
+msgstr "內容類型"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author ccheng
+#: lib/hammer_cli_katello/gpg_key.rb:31
+#: lib/hammer_cli_katello/subscription.rb:22
+#: lib/hammer_cli_katello/repository.rb:11
+#: lib/hammer_cli_katello/repository.rb:36
+msgid "Product"
+msgstr "產品"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author ccheng
+#: lib/hammer_cli_katello/gpg_key.rb:35 lib/hammer_cli_katello/product.rb:65
+msgid "Content"
+msgstr "內容"
+
+#: lib/hammer_cli_katello/gpg_key.rb:42
+msgid "GPG Key created"
+msgstr "GPG 金鑰已建立"
+
+#: lib/hammer_cli_katello/gpg_key.rb:43
+msgid "Could not create GPG Key"
+msgstr "無法建立 GPG 金鑰"
+
+#: lib/hammer_cli_katello/gpg_key.rb:46 lib/hammer_cli_katello/gpg_key.rb:57
+msgid "GPG Key file"
+msgstr "GPG 金鑰檔案"
+
+#: lib/hammer_cli_katello/gpg_key.rb:53
+msgid "GPG Key updated"
+msgstr "GPG 金鑰已更新"
+
+#: lib/hammer_cli_katello/gpg_key.rb:54
+msgid "Could not update GPG Key"
+msgstr "無法更新 GPG 金鑰"
+
+#: lib/hammer_cli_katello/gpg_key.rb:63
+msgid "GPG Key deleted"
+msgstr "GPG 金鑰已刪除"
+
+#: lib/hammer_cli_katello/gpg_key.rb:64
+msgid "Could not delete the GPG Key"
+msgstr "無法刪除 GPG 金鑰"
+
+#: lib/hammer_cli_katello/gpg_key.rb:73
+msgid "manipulate GPG Key actions on the server"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:15
+msgid "Contract"
+msgstr "合約"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:16
+msgid "Account"
+msgstr "帳號"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/subscription.rb:17
+msgid "Support"
+msgstr "支援"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/subscription.rb:18
+#: lib/hammer_cli_katello/subscription.rb:23
+msgid "Quantity"
+msgstr "數量"
+
+#: lib/hammer_cli_katello/subscription.rb:24
+msgid "Attached"
+msgstr "已連接"
+
+#: lib/hammer_cli_katello/subscription.rb:51
+msgid "Manifest is being uploaded in task %{id}"
+msgstr "清單正在上傳中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/subscription.rb:52
+msgid "Manifest upload failed"
+msgstr "清單上傳失敗"
+
+#: lib/hammer_cli_katello/subscription.rb:55
+msgid "Subscription manifest file"
+msgstr "訂閱清單檔案"
+
+#: lib/hammer_cli_katello/subscription.rb:66
+msgid "Manifest is being deleted in task %{id}"
+msgstr "清單正被刪除中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/subscription.rb:67
+msgid "Manifest deletion failed"
+msgstr "清單刪除失敗"
+
+#: lib/hammer_cli_katello/subscription.rb:80
+msgid "Manifest is being refreshed in task %{id}"
+msgstr "清單正被更新中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/subscription.rb:81
+msgid "Manifest refresh failed"
+msgstr "清單更新失敗"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/subscription.rb:91
+#: lib/hammer_cli_katello/repository.rb:51 lib/hammer_cli_katello/ping.rb:12
+#: lib/hammer_cli_katello/ping.rb:19 lib/hammer_cli_katello/ping.rb:26
+#: lib/hammer_cli_katello/ping.rb:33 lib/hammer_cli_katello/ping.rb:40
+#: lib/hammer_cli_katello/ping.rb:47
+msgid "Status"
+msgstr "狀態"
+
+#: lib/hammer_cli_katello/subscription.rb:92
+msgid "Status Message"
+msgstr "狀態訊息"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/subscription.rb:93
+msgid "Time"
+msgstr "時間"
+
+#: lib/hammer_cli_katello/subscription.rb:103
+msgid "Manipulate subscriptions."
+msgstr "操作訂閱。"
+
+#: lib/hammer_cli_katello/output/formatters.rb:11
+msgid "%s  %s"
+msgstr "%s  %s"
+
+#: lib/hammer_cli_katello/content_host.rb:7
+msgid "ID of the content host"
+msgstr "內容主機的 ID"
+
+# translation auto-copied from project Satellite6 Foreman Discovery, version 6.1, document foreman_discovery
+#: lib/hammer_cli_katello/content_host.rb:32
+msgid "Location"
+msgstr "位置"
+
+#: lib/hammer_cli_katello/content_host.rb:39
+msgid "Entitlement Status"
+msgstr "權利狀態"
+
+#: lib/hammer_cli_katello/content_host.rb:40
+msgid "Release Version"
+msgstr "發行版本"
+
+#: lib/hammer_cli_katello/content_host.rb:41
+msgid "Autoheal"
+msgstr "Autoheal"
+
+#: lib/hammer_cli_katello/content_host.rb:53
+msgid "Content host created"
+msgstr "內容主機已建立"
+
+#: lib/hammer_cli_katello/content_host.rb:54
+msgid "Could not create content host"
+msgstr "無法建立內容主機"
+
+#: lib/hammer_cli_katello/content_host.rb:77
+msgid "Content host updated"
+msgstr "內容主機已更新"
+
+#: lib/hammer_cli_katello/content_host.rb:78
+msgid "Could not update content host"
+msgstr "無法更新內容主機"
+
+#: lib/hammer_cli_katello/content_host.rb:88
+msgid "Content host deleted"
+msgstr "內容主機已刪除"
+
+#: lib/hammer_cli_katello/content_host.rb:89
+msgid "Could not delete content host"
+msgstr "無法刪除內容主機"
+
+#: lib/hammer_cli_katello/content_host.rb:107
+msgid "manipulate content hosts on the server"
+msgstr ""
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 10006-296435
+#: lib/hammer_cli_katello/puppet_module.rb:24
+msgid "Summary"
+msgstr "摘要"
+
+# translation auto-copied from project gtk3, version 3.8.2, document gtk30
+#: lib/hammer_cli_katello/puppet_module.rb:26
+msgid "License"
+msgstr "授權條款"
+
+#: lib/hammer_cli_katello/puppet_module.rb:27
+msgid "Project Page"
+msgstr "專案頁面"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/puppet_module.rb:28
+msgid "Source"
+msgstr "來源"
+
+#: lib/hammer_cli_katello/puppet_module.rb:30
+msgid "Dependencies"
+msgstr "相依性"
+
+#: lib/hammer_cli_katello/puppet_module.rb:33
+msgid "File checksums"
+msgstr "檔案 checksum"
+
+#: lib/hammer_cli_katello/puppet_module.rb:37
+msgid "Tag List"
+msgstr "標籤清單"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/puppet_module.rb:40
+#: lib/hammer_cli_katello/repository.rb:8 lib/hammer_cli_katello/capsule.rb:9
+msgid "Id"
+msgstr "ID"
+
+#: lib/hammer_cli_katello/repository.rb:30
+msgid "Red Hat Repository"
+msgstr "Red Hat 軟體庫"
+
+#: lib/hammer_cli_katello/repository.rb:33
+#: lib/hammer_cli_katello/repository.rb:131
+#: lib/hammer_cli_katello/repository.rb:147
+msgid "Publish Via HTTP"
+msgstr "透過 HTTP 發佈"
+
+#: lib/hammer_cli_katello/repository.rb:34
+msgid "Published At"
+msgstr "已發佈於"
+
+#: lib/hammer_cli_katello/repository.rb:50
+msgid "Sync"
+msgstr "同步"
+
+#: lib/hammer_cli_katello/repository.rb:52
+msgid "Last Sync Date"
+msgstr "最後同步日期"
+
+#: lib/hammer_cli_katello/repository.rb:58
+msgid "Content Counts"
+msgstr "內容計數"
+
+#: lib/hammer_cli_katello/repository.rb:59
+msgid "Packages"
+msgstr "套件"
+
+#: lib/hammer_cli_katello/repository.rb:60
+msgid "Package Groups"
+msgstr "套件群組"
+
+#: lib/hammer_cli_katello/repository.rb:61
+msgid "Errata"
+msgstr "勘誤"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "yes"
+msgstr "是"
+
+# translation auto-copied from project Satellite6 Hammer CLI, version 6.1, document hammer-cli
+#: lib/hammer_cli_katello/repository.rb:68
+#: lib/hammer_cli_katello/repository.rb:69
+msgid "no"
+msgstr "否"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/repository.rb:91
+msgid "Failed"
+msgstr "失敗"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:92
+msgid "Success"
+msgstr "成功"
+
+# translation auto-copied from project gnome-packagekit, version 3.8.2, document gnome-packagekit
+#: lib/hammer_cli_katello/repository.rb:93
+msgid "Finished"
+msgstr "已完成"
+
+# translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
+#: lib/hammer_cli_katello/repository.rb:94
+msgid "Error"
+msgstr "錯誤"
+
+# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+#: lib/hammer_cli_katello/repository.rb:95
+msgid "Running"
+msgstr "執行中"
+
+# translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
+#: lib/hammer_cli_katello/repository.rb:96
+msgid "Waiting"
+msgstr "正在等待"
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+#: lib/hammer_cli_katello/repository.rb:97
+msgid "Canceled"
+msgstr "已取消"
+
+#: lib/hammer_cli_katello/repository.rb:98
+msgid "Not Synced"
+msgstr "未同步"
+
+#: lib/hammer_cli_katello/repository.rb:119
+msgid "Repository is being synchronized in task %{id}"
+msgstr "軟體庫正在任務 %{id} 中同步化"
+
+#: lib/hammer_cli_katello/repository.rb:120
+msgid "Could not synchronize the repository"
+msgstr "無法同步軟體庫"
+
+#: lib/hammer_cli_katello/repository.rb:128
+msgid "Repository created"
+msgstr "軟體庫已建立"
+
+#: lib/hammer_cli_katello/repository.rb:129
+msgid "Could not create the repository"
+msgstr "無法建立軟體庫"
+
+#: lib/hammer_cli_katello/repository.rb:141
+msgid "Repository updated"
+msgstr "軟體庫已更新"
+
+#: lib/hammer_cli_katello/repository.rb:142
+msgid "Could not update the repository"
+msgstr "無法更新軟體庫"
+
+#: lib/hammer_cli_katello/repository.rb:155
+msgid "Repository deleted"
+msgstr "軟體庫已刪除"
+
+#: lib/hammer_cli_katello/repository.rb:156
+msgid "Could not delete the Repository"
+msgstr "無法刪除軟體庫"
+
+#: lib/hammer_cli_katello/repository.rb:197
+msgid "Repository content uploaded"
+msgstr "軟體庫內容已上傳"
+
+#: lib/hammer_cli_katello/repository.rb:198
+msgid "Could not upload the content"
+msgstr "無法上傳內容"
+
+#: lib/hammer_cli_katello/repository.rb:203
+msgid "Upload file or directory of files as content for a repository"
+msgstr "上傳檔案或目錄檔案作為軟體庫的內容"
+
+#: lib/hammer_cli_katello/repository.rb:227
+msgid "Successfully uploaded file '%s'."
+msgstr "已成功上傳檔案「%s」。"
+
+#: lib/hammer_cli_katello/repository.rb:230
+msgid ""
+"Failed to upload file '%s' to repository. Please check the file and try "
+"again."
+msgstr "上傳檔案「%s」至軟體庫失敗。請檢查檔案並重新嘗試。"
+
+#: lib/hammer_cli_katello/repository.rb:254
+msgid "Manipulate repositories"
+msgstr "操作軟體庫"
+
+#: lib/hammer_cli_katello/content_view_version.rb:16
+#: lib/hammer_cli_katello/content_view_version.rb:32
+msgid "Content View Name"
+msgstr "內容視域名稱"
+
+#: lib/hammer_cli_katello/content_view_version.rb:17
+#: lib/hammer_cli_katello/content_view_version.rb:33
+msgid "Content View Label"
+msgstr "內容視域標籤"
+
+#: lib/hammer_cli_katello/content_view_version.rb:65
+msgid "Content view is being promoted with task %{id}"
+msgstr "內容視域正被推送（任務 %{id}）"
+
+#: lib/hammer_cli_katello/content_view_version.rb:66
+msgid "Could not promote the content view"
+msgstr "無法推送內容視域"
+
+#: lib/hammer_cli_katello/product.rb:19 lib/hammer_cli_katello/product.rb:43
+msgid "Sync State"
+msgstr "同步狀態"
+
+#: lib/hammer_cli_katello/product.rb:28
+msgid "Product created"
+msgstr "產品已建立"
+
+#: lib/hammer_cli_katello/product.rb:29
+msgid "Could not create the product"
+msgstr "無法建立產品"
+
+#: lib/hammer_cli_katello/product.rb:46
+msgid "Sync Plan ID"
+msgstr "同步計劃 ID"
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+#: lib/hammer_cli_katello/product.rb:48
+msgid "GPG"
+msgstr "GPG"
+
+#: lib/hammer_cli_katello/product.rb:50
+msgid "GPG Key ID"
+msgstr "GPG 金鑰 ID"
+
+#: lib/hammer_cli_katello/product.rb:59
+msgid "Readonly"
+msgstr "唯讀"
+
+#: lib/hammer_cli_katello/product.rb:62
+msgid "Deletable"
+msgstr "可刪除"
+
+#: lib/hammer_cli_katello/product.rb:67
+msgid "Repo Name"
+msgstr "軟體庫名稱"
+
+#: lib/hammer_cli_katello/product.rb:77
+msgid "Product updated"
+msgstr "產品已更新"
+
+#: lib/hammer_cli_katello/product.rb:78
+msgid "Could not update the product"
+msgstr "無法更新產品"
+
+#: lib/hammer_cli_katello/product.rb:84
+msgid "Product destroyed"
+msgstr "產品已銷毀"
+
+#: lib/hammer_cli_katello/product.rb:85
+msgid "Could not destroy the product"
+msgstr "無法銷毀產品"
+
+#: lib/hammer_cli_katello/product.rb:91
+msgid "Assign sync plan to product."
+msgstr "為產品指定同步計劃。"
+
+#: lib/hammer_cli_katello/product.rb:94
+msgid "Synchronization plan assigned."
+msgstr "已指定同步化計劃。"
+
+#: lib/hammer_cli_katello/product.rb:95
+msgid "Could not assign synchronization plan."
+msgstr "無法指定同步化計劃。"
+
+#: lib/hammer_cli_katello/product.rb:101 lib/hammer_cli_katello/product.rb:116
+msgid "plan numeric identifier"
+msgstr ""
+
+#: lib/hammer_cli_katello/product.rb:106
+msgid "Delete assignment sync plan and product."
+msgstr "刪除指定同步計劃和產品。"
+
+#: lib/hammer_cli_katello/product.rb:109
+msgid "Synchronization plan removed."
+msgstr "同步化計劃已移除。"
+
+#: lib/hammer_cli_katello/product.rb:110
+msgid "Could not remove synchronization plan."
+msgstr "無法移除同步化計劃。"
+
+#: lib/hammer_cli_katello/product.rb:124
+msgid "Manipulate products."
+msgstr "操作產品。"
+
+#: lib/hammer_cli_katello/ping.rb:13 lib/hammer_cli_katello/ping.rb:20
+#: lib/hammer_cli_katello/ping.rb:27 lib/hammer_cli_katello/ping.rb:34
+#: lib/hammer_cli_katello/ping.rb:41 lib/hammer_cli_katello/ping.rb:48
+msgid "Server Response"
+msgstr "伺服器反應"
+
+#: lib/hammer_cli_katello/ping.rb:58
+msgid "FAIL"
+msgstr "失敗"
+
+#: lib/hammer_cli_katello/ping.rb:73
+msgid "Duration: %sms"
+msgstr "時間長度：%sms"
+
+#: lib/hammer_cli_katello/ping.rb:75
+msgid "Message: %s"
+msgstr "訊息：%s"
+
+#: lib/hammer_cli_katello/ping.rb:81
+msgid "get the status of the server"
+msgstr ""
+
+#: lib/hammer_cli_katello/id_resolver.rb:6
+msgid "Activation key name to search by"
+msgstr "用來進行搜尋的啟動金鑰名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:7
+msgid "Capsule name to search by"
+msgstr "用來進行搜尋的 Capsule 名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:8
+msgid "Content host name to search by"
+msgstr "用來進行搜尋的內容主機名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:9
+msgid "Content view name to search by"
+msgstr "用來進行搜尋的內容視域名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:10
+msgid "Gpg key name to search by"
+msgstr "用來進行搜尋的 GPG 金鑰名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:11
+msgid "Host collection name to search by"
+msgstr "用來進行搜尋的主機集名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:12
+msgid "Lifecycle environment name to search by"
+msgstr "用來進行搜尋的生命週期環境名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:13
+msgid "Organization name to search by"
+msgstr "用來進行搜尋的組織名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:14
+msgid "Organization label to search by"
+msgstr "用來進行搜尋的組織標籤"
+
+#: lib/hammer_cli_katello/id_resolver.rb:17
+msgid "Product name to search by"
+msgstr "用來進行搜尋的產品名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:18
+msgid "Repository name to search by"
+msgstr "用來進行搜尋的軟體庫名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:19
+msgid "Repository set name to search by"
+msgstr "用來進行搜尋的軟體庫集名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:20
+msgid "Subscription name to search by"
+msgstr "用來進行搜尋的訂閱名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:21
+msgid "Sync plan name to search by"
+msgstr "用來進行搜尋的同步計劃名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:22
+msgid "Task name to search by"
+msgstr "用來進行搜尋的任務名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:23
+msgid "User name to search by"
+msgstr "用來進行搜尋的使用者名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:25
+msgid "Puppet module name to search by"
+msgstr "用來進行搜尋的 Puppet 模組名稱"
+
+#: lib/hammer_cli_katello/id_resolver.rb:26
+msgid "Puppet module's author to search by"
+msgstr "用來進行搜尋的 Puppet 模組作者"
+
+#: lib/hammer_cli_katello/id_resolver.rb:27
+msgid "Puppet module's UUID to search by"
+msgstr "用來進行搜尋的 Puppet 模組 UUID"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/id_resolver.rb:31
+msgid "Name to search by"
+msgstr "欲使用來進行搜尋的名稱"
+
+#: lib/hammer_cli_katello/filter.rb:16 lib/hammer_cli_katello/filter.rb:27
+msgid "Inclusion"
+msgstr "包含"
+
+# translation auto-copied from project firewalld, version 0.3.8, document firewalld
+#: lib/hammer_cli_katello/filter.rb:35
+msgid "Rules"
+msgstr "規則"
+
+#: lib/hammer_cli_katello/filter.rb:54
+msgid "Filter created"
+msgstr "篩選器已建立"
+
+#: lib/hammer_cli_katello/filter.rb:55
+msgid "Could not create the filter"
+msgstr "無法建立篩選器"
+
+#: lib/hammer_cli_katello/filter.rb:61
+msgid "Filter updated"
+msgstr "篩選器已更新"
+
+#: lib/hammer_cli_katello/filter.rb:62
+msgid "Could not update the filter"
+msgstr "無法更新篩選器"
+
+#: lib/hammer_cli_katello/filter.rb:68
+msgid "Filter deleted"
+msgstr "篩選器已刪除"
+
+#: lib/hammer_cli_katello/filter.rb:69
+msgid "Could not delete the filter"
+msgstr "無法刪除篩選器"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:24
+msgid "Prior"
+msgstr "先前"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:36
+msgid "Lifecycle Path"
+msgstr "生命週期路徑"
+
+# translation auto-copied from project PressGang CCMS topics, version 1, document 30851-704293, author ccheng
+#: lib/hammer_cli_katello/lifecycle_environment.rb:59
+msgid "Library"
+msgstr "函示庫"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:61
+msgid "Prior Lifecycle Environment"
+msgstr "先前的生命週期環境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:71
+msgid "Environment created"
+msgstr "環境已建立"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:72
+msgid "Could not create environment"
+msgstr "無法建立環境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:80
+msgid "Environment updated"
+msgstr "環境已更新"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:81
+msgid "Could not update environment"
+msgstr "無法更新環境"
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/lifecycle_environment.rb:87
+msgid "Environment deleted"
+msgstr "環境已刪除"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:88
+msgid "Could not delete environment"
+msgstr "無法刪除環境"
+
+#: lib/hammer_cli_katello/lifecycle_environment.rb:97
+msgid "manipulate lifecycle_environments on the server"
+msgstr ""
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+#: lib/hammer_cli_katello/capsule.rb:22
+msgid "Features"
+msgstr "功能"
+
+#: lib/hammer_cli_katello/capsule.rb:37
+msgid "Manage the capsule content"
+msgstr "管理 capsule 內容"
+
+#: lib/hammer_cli_katello/capsule.rb:75
+msgid "Lifecycle environment successfully added to the capsule"
+msgstr "生命週期環境已成功新增至 capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:76
+msgid "Could not add the lifecycle environment to the capsule"
+msgstr "無法新增生命週期環境至 capsule"
+
+#: lib/hammer_cli_katello/capsule.rb:85
+msgid "Lifecycle environment successfully removed from the capsule"
+msgstr "生命週期環境已成功從 capsule 中移除"
+
+#: lib/hammer_cli_katello/capsule.rb:86
+msgid "Could not remove the lifecycle environment from the capsule"
+msgstr "無法從 capsule 中移除生命週期環境"
+
+#: lib/hammer_cli_katello/capsule.rb:95
+msgid "Capsule content is being synchronized in task %{id}"
+msgstr "Capsule 內容正被同步中（任務 %{id}）"
+
+#: lib/hammer_cli_katello/capsule.rb:96
+msgid "Could not synchronize capsule content"
+msgstr "無法同步 capsule 內容"
+
+#: lib/hammer_cli_katello/capsule.rb:107
+msgid "Manipulate capsule"
+msgstr "操作 capsule"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman, author tchuang
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author tchuang
+
+
+# translation auto-copied from project evolution, version 3.8.5, document evolution-3.8
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project Satellite6 Bastion Katello, version 6.1, document bastion_katello, author tchuang
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# translation auto-copied from project totem, version 3.8.2, document totem
+
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+
+
+
+# translation auto-copied from project subscription-manager, version 1.10.10, document keys
+


### PR DESCRIPTION
There is no comparison link, since this package is not yet
    moved to transifex. This pull request requires that
    https://github.com/Katello/hammer-cli-katello/pull/315 in order to test it.
