### PR TITLE
fixes #11968: add content name to repository information returned

### DIFF
--- a/lib/hammer_cli_katello/repository_set.rb
+++ b/lib/hammer_cli_katello/repository_set.rb
@@ -39,7 +39,7 @@ module HammerCLIKatello
       command_name "available-repositories"
 
       output do
-        field :repo_name, _("Name")
+        field :name, _("Name")
         from :substitutions do
           field :basearch, _("Arch")
           field :releasever, _("Release")


### PR DESCRIPTION
Currently, when a user invokes the 'repository-set available-repositories'
command, the 'name' field is displayed simmilar to the following:
  Red Hat Enterprise Linux 6 Server RPMs x86_64 6Server

The above includes the architecture and release version; however, that
information is also returned as separate attributes.  Since the name
can be used for operations such as enable, disable, info, it would
be better to return the name similar to the following:
  Red Hat Enterprise Linux 6 Server (RPMs)

This commit displays the 'name' vs the 'repo_name' attribute returned.