### PR TITLE
fixes #12001 - update puppet-modules list to support repository name

### DIFF
--- a/lib/hammer_cli_katello/puppet_module.rb
+++ b/lib/hammer_cli_katello/puppet_module.rb
@@ -12,7 +12,7 @@ module HammerCLIKatello
       end
 
       build_options do |o|
-        o.expand(:all).including(:organizations, :content_views)
+        o.expand(:all).including(:organizations, :products, :content_views)
       end
     end
 


### PR DESCRIPTION
Minor update to support:

hammer> puppet-module list --organization 'Default Organization' --product 'puppet' --repository 'puppet 1'
---|------|------------|--------
ID | NAME | AUTHOR     | VERSION
---|------|------------|--------
2  | dns  | theforeman | 1.3.0
1  | dns  | theforeman | 1.4.0
---|------|------------|--------

This is to be consistent with the corresponding package and erratum
commands.