### PR TITLE
fixes #12363 - capsule: add/remove-lifecycle-environment & synchronize by env name

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -2,6 +2,26 @@ module HammerCLIKatello
   class Capsule < HammerCLIForeman::Command
     resource :capsules
 
+    module LifecycleEnvironmentNameResolvable
+      def lifecycle_environment_resolve_options(options)
+        {
+          HammerCLI.option_accessor_name("name") => options['option_environment_name'],
+          HammerCLI.option_accessor_name("id") => options['option_environment_id'],
+          HammerCLI.option_accessor_name("organization_id") => options["option_organization_id"],
+          HammerCLI.option_accessor_name("organization_name") => options["option_organization_name"]
+        }
+      end
+
+      def all_options
+        result = super.clone
+        if result['option_environment_name']
+          result['option_environment_id'] =  resolver.lifecycle_environment_id(
+              lifecycle_environment_resolve_options(result))
+        end
+        result
+      end
+    end
+
     class ListCommand < HammerCLIKatello::ListCommand
       action :index
 
@@ -69,32 +89,47 @@ module HammerCLIKatello
       end
 
       class AddLifecycleEnvironmentCommand < HammerCLIKatello::Command
+        include LifecycleEnvironmentNameResolvable
         resource :capsule_content, :add_lifecycle_environment
         command_name 'add-lifecycle-environment'
 
         success_message _("Lifecycle environment successfully added to the capsule")
         failure_message _("Could not add the lifecycle environment to the capsule")
 
+        option "--organization-id", "ID", _("Organization ID"),
+               :attribute_name => :option_organization_id
+        option "--organization", "NAME", _("Organization name"),
+               :attribute_name => :option_organization_name
         build_options
       end
 
       class RemoveLifecycleEnvironmentCommand < HammerCLIKatello::Command
+        include LifecycleEnvironmentNameResolvable
         resource :capsule_content, :remove_lifecycle_environment
         command_name 'remove-lifecycle-environment'
 
         success_message _("Lifecycle environment successfully removed from the capsule")
         failure_message _("Could not remove the lifecycle environment from the capsule")
 
+        option "--organization-id", "ID", _("Organization ID"),
+               :attribute_name => :option_organization_id
+        option "--organization", "NAME", _("Organization name"),
+               :attribute_name => :option_organization_name
         build_options
       end
 
       class SyncCommand < HammerCLIForemanTasks::AsyncCommand
+        include LifecycleEnvironmentNameResolvable
         resource :capsule_content, :sync
         command_name "synchronize"
 
         success_message _("Capsule content is being synchronized in task %{id}")
         failure_message _("Could not synchronize capsule content")
 
+        option "--organization-id", "ID", _("Organization ID"),
+               :attribute_name => :option_organization_id
+        option "--organization", "NAME", _("Organization name"),
+               :attribute_name => :option_organization_name
         build_options
       end
 

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -39,6 +39,10 @@ module HammerCLIKatello
 
   class IdResolver < HammerCLIForeman::IdResolver
 
+    def capsule_content_id(options)
+      smart_proxy_id(options)
+    end
+
     def system_id(options)
       options[HammerCLI.option_accessor_name("id")] || find_resource(:systems, options)['uuid']
     end
@@ -123,6 +127,14 @@ module HammerCLIKatello
 
     def create_organizations_search_options(options)
       create_search_options_without_katello_api(options, api.resource(:organizations))
+    end
+
+    def create_smart_proxies_search_options(options)
+      create_search_options_without_katello_api(options, api.resource(:smart_proxies))
+    end
+
+    def create_capsules_search_options(options)
+      create_search_options_without_katello_api(options, api.resource(:smart_proxies))
     end
 
     def create_search_options_with_katello_api(options, resource)

--- a/lib/hammer_cli_katello/lifecycle_environment.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment.rb
@@ -9,7 +9,7 @@ module HammerCLIKatello
         base.option(
           "--prior",
           "PRIOR",
-          _("Name of the prior enviroment")
+          _("Name of the prior environment")
         )
         base.validate_options do
           any(:option_prior, :option_prior_id).required


### PR DESCRIPTION
This commit fixes the issues raised by 12363.  This includes:

- support the following commands using environment name:

  capsule content add-lifecycle-environment --id <id> --organization-id <id> --environment <name>
  capsule content remove-lifecycle-environment --id <id> --organization-id <id> --environment <name>
  capsule content synchronize --id <id> --organization-id <id> --environment <name>

  - note: in order to support retrieving the environment, the user must also
    specify the organization

- support the following command using capsule name:

  capsule content lifecycle-environment --name <name> --organization-id <id>