### PR TITLE
Refs #12570 -  Hammer commands for repo and CVV export

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -182,6 +182,16 @@ module HammerCLIKatello
       end
     end
 
+    class ExportCommand < HammerCLIKatello::Command
+      action :export
+      command_name "export"
+
+      success_message _("Export complete")
+      failure_message _("Could not export")
+
+      build_options
+    end
+
     autoload_subcommands
   end
 end

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -290,6 +290,16 @@ module HammerCLIKatello
       build_options :without => ["uuids"]
     end
 
+    class ExportCommand < HammerCLIKatello::Command
+      resource :repositories, :export
+      command_name "export"
+
+      success_message _("Exported repository")
+      failure_message _("Could not export repository")
+
+      build_options
+    end
+
     autoload_subcommands
   end
 end


### PR DESCRIPTION
This adds two commands to hammer which support repo and CVV export.