### PR TITLE
bump version to 0.0.23

### DIFF
--- a/lib/hammer_cli_katello/version.rb
+++ b/lib/hammer_cli_katello/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIKatello
   def self.version
-    @version ||= Gem::Version.new('0.0.22')
+    @version ||= Gem::Version.new('0.0.23')
   end
 end


### PR DESCRIPTION
I thought an additional change was needed, but it turns out this was it.

```
# katello-bats content
 ✓ create a product
 ✓ create package repository
 ✓ upload package
 ✓ sync repository
 ✓ create puppet repository
 ✓ upload puppet module
 ✓ create lifecycle environment
 ✓ create content view
 ✓ add repo to content view
 ✓ add puppet module to content view
 ✓ publish content view
 ✓ promote content view
 ✓ create activation key
 ✓ disable auto-attach
 ✓ add subscription to activation key
 ✓ install subscription manager
 ✓ register subscription manager
 ✓ check content host is registered
 ✓ enable content view repo
 ✓ install katello-agent
 ✓ start katello-agent
 ✓ install package remotely (katello-agent)
 ✓ install package locally
 - add puppetclass to host (skipped)
 - puppet run applies dummy module (skipped)
 ✓ collect important logs

```