### PR TITLE
Fixes #14065 - call correct command in capsule content test

### DIFF
--- a/test/functional/capsule/content/info_test.rb
+++ b/test/functional/capsule/content/info_test.rb
@@ -56,7 +56,7 @@ describe 'capsule content info' do
   end
 
   it "is mounted under proxy too" do
-    result = run_cmd(['proxy', 'content', 'list', '-h'])
+    result = run_cmd(['proxy', 'content', 'info', '-h'])
     assert_exit_code_equal(HammerCLI::EX_OK, result.exit_code)
   end
 end


### PR DESCRIPTION
One of the tests called `hammer proxy content list` instead of `hammer proxy content info` by mistake.

```
  1) Failure:
capsule content info#test_0003_is mounted under proxy too [/hammer-cli-katello/test/functional/capsule/content/info_test.rb:60]:
The exit code was expected to be EX_OK (0), but it was EX_USAGE (64)
```
