### PR TITLE
fixes #14174 - content-view add-repository should require user to provide repo info

### DIFF
--- a/lib/hammer_cli_katello/associating_commands.rb
+++ b/lib/hammer_cli_katello/associating_commands.rb
@@ -28,6 +28,11 @@ module HammerCLIKatello
         command_name 'add-repository'
         associated_resource :repositories
 
+        def validate_options
+          super
+          validator.any(:option_repository_id, :option_repository_name).required
+        end
+
         success_message _("The repository has been associated")
         failure_message _("Could not add repository")
       end
@@ -37,6 +42,11 @@ module HammerCLIKatello
         include RepositoryScopedToProduct
         command_name 'remove-repository'
         associated_resource :repositories
+
+        def validate_options
+          super
+          validator.any(:option_repository_id, :option_repository_name).required
+        end
 
         success_message _("The repository has been removed")
         failure_message _("Could not remove repository")


### PR DESCRIPTION
This commit addresses the issue that if the user was attempting to add
a repository to a content view, but did not specify the repository parameters,
the command would succeed indicating "The repository has been associated".

The update behavior is:

hammer> content-view add-repository --name zoo2 --organization-id 3
Could not add repository:
  Error: At least one of options --repository-id, --repository is required