### PR TITLE
fixes #14203 - host-collection create: generating 'option_host_ids' error

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -41,7 +41,6 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
-      include UuidRequestable
       resource :host_collections, :create
       def request_params
         super.tap do |params|
@@ -53,7 +52,10 @@ module HammerCLIKatello
 
       success_message _("Host collection created")
       failure_message _("Could not create the host collection")
-      build_options :without => [:host_ids]
+      build_options do |o|
+        o.expand.except(:hosts)
+        o.without(:host_ids)
+      end
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand


### PR DESCRIPTION
This commit is to address an error during creation of a host collection.

Before:
-------
hammer> host-collection create --organization-id 1 --name cli-test-2
Could not create the host collection:
  Error: undefined local variable or method `option_host_ids' for #<HammerCLIKatello::HostCollection::CreateCommand:0x00000005567958>

After:
------
hammer> host-collection create --organization-id 1 --name cli-test-2
Host collection created