### PR TITLE
Fixes #14139 - remove deprecated hammer content-view --id

### DIFF
--- a/lib/hammer_cli_katello/content_view_puppet_module.rb
+++ b/lib/hammer_cli_katello/content_view_puppet_module.rb
@@ -29,14 +29,9 @@ module HammerCLIKatello
     class CreateCommand < HammerCLIKatello::CreateCommand
       command_name "add"
 
-      option "--id", "ID", _("(deprecated) id of the puppet module to associate"),
-        :attribute_name => "option_uuid",
-        :deprecated => _("This option will be removed in Katello 2.5, Use --uuid")
-
       success_message _("Puppet module added to content view")
       failure_message _("Could not add the puppet module")
 
-      #build_options :without => :uuid
       build_options
     end
 

--- a/lib/hammer_cli_katello/puppet_module.rb
+++ b/lib/hammer_cli_katello/puppet_module.rb
@@ -9,6 +9,7 @@ module HammerCLIKatello
         field :name, _("Name")
         field :author, _("Author")
         field :version, _("Version")
+        field :uuid, _("Uuid")
       end
 
       build_options do |o|
@@ -22,6 +23,7 @@ module HammerCLIKatello
         field :name, _("Name")
         field :version, _("Version")
         field :author, _("Author")
+        field :uuid, _("Uuid")
 
         field :summary, _("Summary")
         field :description, _("Description")


### PR DESCRIPTION
Removing --id since it has been deprecated. --id still works with our API, but when you add a puppet module to a content view with --id
``` hammer content-view puppet-module add --organization-id 1 --content-view-id 19 --id 1```
and then list content view puppet modules
```hammer -r content-view puppet-module list --organization-id 1 --content-view-id 19```
```
-----|---------|------------|--------
UUID | NAME    | AUTHOR     | VERSION
-----|---------|------------|--------
1    | openssl | camptocamp |
-----|---------|------------|--------
```
the uuid is not a valid uuid, but rather the active record id of the puppet module

when you add using --uuid
```hammer content-view puppet-module remove --organization-id 1 --content-view-id 18 --uuid  b9175fc3-14a0-4d1d-90ee-403f5b0941c2```
and return the list
```hammer -r content-view puppet-module list --organization-id 1 --content-view-id 18```
```
-------------------------------------|---------|------------|--------
UUID                                 | NAME    | AUTHOR     | VERSION
-------------------------------------|---------|------------|--------
b9175fc3-14a0-4d1d-90ee-403f5b0941c2 | openssl | camptocamp | 1.6.1  
-------------------------------------|---------|------------|--------
```
a valid list is returned.

listing puppet-modules in hammer did not show their uuids, so I added that since the user will need the uuid to add a puppet module to a content view.

An issue will have to be opened in Katello to fix the api which now can take an AR id to add a puppet module to a content view, but will return the AR id of the puppet module in the "uuid" field when listing content view puppet modules, which is incorrect.