### PR TITLE
Fixes #14333 - Makes --unlimited-hosts a flag for update on an activation key.

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -106,6 +106,8 @@ module HammerCLIKatello
       success_message _("Activation key updated")
       failure_message _("Could not update the activation key")
 
+      option "--unlimited-hosts", :flag, "set hosts max to unlimited"
+
       validate_options do
         all(:option_unlimited_hosts, :option_max_hosts).rejected
       end


### PR DESCRIPTION
This will make specifying unlimited-hosts in the update command the same as specifying it in the create command. It shoud be a flag because there would never be a time where someone would specify      --unlimited-hosts= false. 