### PR TITLE
fixes #14365 - host-collection create|update - fix to support host input

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -3,22 +3,6 @@ module HammerCLIKatello
   class HostCollection < HammerCLIKatello::Command
     resource :host_collections
 
-    module UuidRequestable
-      def self.included(base)
-        base.option("--host-collection-ids",
-          "HOST_COLLECTION_IDS",
-          _("Array of host ids to replace the hosts in host collection"),
-          :format => HammerCLI::Options::Normalizers::List.new)
-      end
-
-      def request_params
-        params = super
-        params['host_ids'] = option_host_ids unless option_host_ids.nil?
-        params.delete('host_ids') if params.keys.include? 'host_ids'
-        params
-      end
-    end
-
     module LimitFieldDataExtension
       def extend_data(data)
         data['_limit'] = data['unlimited_hosts'] ? 'None' : data['max_hosts']
@@ -52,10 +36,8 @@ module HammerCLIKatello
 
       success_message _("Host collection created")
       failure_message _("Could not create the host collection")
-      build_options do |o|
-        o.expand.except(:hosts)
-        o.without(:host_ids)
-      end
+
+      build_options
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
@@ -98,11 +80,10 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
-      include UuidRequestable
       success_message _("Host collection updated")
       failure_message _("Could not update the the host collection")
 
-      build_options :without => [:host_ids]
+      build_options
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -37,6 +37,7 @@ module HammerCLIKatello
 
   end
 
+  # rubocop:disable ClassLength
   class IdResolver < HammerCLIForeman::IdResolver
 
     def capsule_content_id(options)
@@ -135,6 +136,10 @@ module HammerCLIKatello
 
     def create_capsules_search_options(options)
       create_search_options_without_katello_api(options, api.resource(:smart_proxies))
+    end
+
+    def create_hosts_search_options(options)
+      create_search_options_without_katello_api(options, api.resource(:hosts))
     end
 
     def create_search_options_with_katello_api(options, resource)


### PR DESCRIPTION
Prior to host-unification, users could provide a list of content hosts
as inputs to the host-collection create and update commands.  This
commit should now allow them to provide a list of 'hosts'.

The following are a few valid scenarios:

hammer> host-collection create --organization-id 1 --name with-hosts --host-ids 1
Host collection created

hammer> host-collection create --organization-id 1 --name with-hosts-by-name --hosts "rhel7-client.test"
Host collection created

hammer> host-collection update --id 4 --host-ids 1
Host collection updated

hammer> host-collection update --id 5 --hosts 'rhel7-client.test'
Host collection updated