### PR TITLE
Fixes #11161 - Upload content as multipart/form-data

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -203,7 +203,7 @@ module HammerCLIKatello
       end
 
       def request_headers
-        {:content_type => 'multipart/form-data', :multipart => true}
+        {:content_type => 'multipart/form-data'}
       end
 
       def execute
@@ -238,10 +238,12 @@ module HammerCLIKatello
 
         offset = 0
         while (content = file.read(CONTENT_CHUNK_SIZE))
-          params = {:offset => offset,
-                    :id => upload_id,
-                    :content => content,
-                    :repository_id => repo_id
+          params = {
+            :offset => offset,
+            :id => upload_id,
+            :content => content,
+            :repository_id => repo_id,
+            :multipart => true
           }
 
           content_upload_resource.call(:update, params, request_headers)


### PR DESCRIPTION
```shell
# Check size
$ du -h jdk-8u77-linux-x64.rpm 
153M    jdk-8u77-linux-x64.rpm

# Before
$ time bundle exec ruby bin/hammer -v repository upload-content --product product-1 --id 8 --path jdk-8u77-linux-x64.rpm 
Successfully uploaded file 'jdk-8u77-linux-x64.rpm'.

real    4m59.957s
user    3m46.345s
sys     0m1.199s

# Now
$ time bundle exec ruby bin/hammer -v repository upload-content --product product-1 --id 8 --path jdk-8u77-linux-x64.rpm
Successfully uploaded file 'jdk-8u77-linux-x64.rpm'.

real    0m29.514s
user    0m14.482s
sys     0m0.685s
```
It also seems to lower hammer's cpu usage while uploading files quite a bit since it now doesn't try to encode the payload as `application/x-www-form-urlencoded`