### PR TITLE
Fixes #14656 - Capsule Content synchronization now uses Katello's ID resolver instead of Foreman's ID resolver.

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -70,7 +70,7 @@ module HammerCLIKatello
         build_options
       end
 
-      class SyncCommand < HammerCLIForemanTasks::AsyncCommand
+      class SyncCommand < HammerCLIKatello::AsyncCommand
         include LifecycleEnvironmentNameResolvable
         resource :capsule_content, :sync
         command_name "synchronize"

--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -29,6 +29,10 @@ module HammerCLIKatello
     end
   end
 
+  class AsyncCommand < HammerCLIForemanTasks::AsyncCommand
+    include HammerCLIKatello::ResolverCommons
+  end
+
   class Command < HammerCLIForeman::Command
     include HammerCLIKatello::ResolverCommons
   end


### PR DESCRIPTION
The capsule content synchronization command was not properly resolving any capsule names because it's resolver was not the correct one.

To test just synchronize a capsule from hammer and pass it the name of the capsule instead of the ID.