### PR TITLE
Fixes #14466 - add support for Gemfile.local.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/version_tmp
 tmp
 Gemfile.lock
 Gemfile.local
+Gemfile.local.rb
 rubocop.xml
 
 # YARD artifacts

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,7 @@ group :test do
 end
 
 # load local gemfile
-local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
-self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|
+  local_gemfile = File.join(File.dirname(__FILE__), file_name)
+  self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo "hammer" > .ruby-gemset
 cd ..; cd -
 ```
 
-Before we bundle, we need to setup our local Gemfile. Edit `Gemfile.local` in your hammer-cli-katello directory to point to the local projects instead of using the gems. Enter the following:
+Before we bundle, we need to setup our local Gemfile. Edit `Gemfile.local.rb` in your hammer-cli-katello directory to point to the local projects instead of using the gems. Enter the following:
 
 ```ruby
 # vim:ft=ruby


### PR DESCRIPTION
The change keeps backward compatibility with `Gemfile.local`