### PR TITLE
Fixes #14708 - Content-view remove properly works.

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -15,6 +15,7 @@ module HammerCLIKatello
   require 'hammer_cli_katello/output/formatters'
   require 'hammer_cli_katello/katello_environment_name_resolvable'
   require 'hammer_cli_katello/lifecycle_environment_name_resolvable'
+  require 'hammer_cli_katello/lifecycle_environment_names_resolvable'
   require 'hammer_cli_katello/repository_scoped_to_product'
   require "hammer_cli_katello/commands"
   require "hammer_cli_katello/associating_commands"

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -181,6 +181,7 @@ module HammerCLIKatello
     end
 
     class RemoveCommand < HammerCLIKatello::SingleResourceCommand
+      include LifecycleEnvironmentNamesResolvable
       include HammerCLIForemanTasks::Async
 
       # command to remove content view environments and versions from a content view.
@@ -192,14 +193,6 @@ module HammerCLIKatello
              _("Comma separated list of version ids to remove")
       option ["--environment-ids"], "ENVIRONMENT_IDS",
              _("Comma separated list of environment ids to remove")
-
-      def request_params
-        super.tap do |opts|
-          %w(content_view_version_ids environment_ids).each do |key|
-            opts[key] = opts[key].split(",") if opts[key]
-          end
-        end
-      end
 
       success_message _("Content view objects are being removed task %{id}")
       failure_message _("Could not remove objects from content view")

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -52,7 +52,7 @@ module HammerCLIKatello
     end
 
     def system_id(options)
-      options[HammerCLI.option_accessor_name("id")] || find_resource(:systems, options)['uuid']
+      options[HammerCLI.option_accessor_name("id")] || find_resource(:systems, options)["uuid"]
     end
 
     def environment_id(options)
@@ -60,16 +60,16 @@ module HammerCLIKatello
     end
 
     def environment_ids(options)
-      unless options['option_lifecycle_environment_ids'].nil?
-        return options['option_lifecycle_environment_ids']
+      unless options['option_environment_ids'].nil?
+        return options['option_environment_ids']
       end
 
-      key_names = HammerCLI.option_accessor_name 'lifecycle_environment_names'
+      key_names = HammerCLI.option_accessor_name 'environment_names'
       key_organization_id = HammerCLI.option_accessor_name 'organization_id'
       options[key_organization_id] ||= organization_id(scoped_options 'organization', options)
 
       find_resources(:lifecycle_environments, options)
-        .select { |repo| options[key_names].include? repo['name'] }.map { |repo| repo['id'] }
+        .select { |repo| options[key_names].include? repo["name"] }.map { |repo| repo["id"] }
     end
 
     def repository_id(options)

--- a/lib/hammer_cli_katello/lifecycle_environment_names_resolvable.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment_names_resolvable.rb
@@ -1,0 +1,22 @@
+module HammerCLIKatello
+  module LifecycleEnvironmentNamesResolvable
+    def lifecycle_environments_resolve_options(options)
+      {
+        HammerCLI.option_accessor_name("names") => options['option_environment_names'],
+        HammerCLI.option_accessor_name("ids") => options['options_environment_ids'],
+        HammerCLI.option_accessor_name("organization_id") => options["option_organization_id"],
+        HammerCLI.option_accessor_name("organization_name") => options["option_organization_name"]
+      }
+    end
+
+    def all_options
+      result = super.clone
+      if result['option_environment_names'] && result['option_environment_ids'].nil?
+        result['option_environment_ids'] =  resolver.lifecycle_environment_ids(
+            lifecycle_environments_resolve_options(result))
+        @all_options = result
+      end
+      result
+    end
+  end
+end

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -15,11 +15,13 @@ module HammerCLIKatello
 
     def create_lifecycle_environments_search_options(options)
       name = options[HammerCLI.option_accessor_name("name")]
+      names = options[HammerCLI.option_accessor_name("names")]
+      names ||= options[HammerCLI.option_accessor_name("environment_names")]
       organization_id = options[HammerCLI.option_accessor_name("organization_id")]
 
       search_options = {}
       search_options['name'] = name if name
-      if options['option_lifecycle_environment_names'] || name
+      if options['option_lifecycle_environment_names'] || name || names
         search_options['organization_id'] = organization_id
       end
       search_options


### PR DESCRIPTION
This fixes content-view remove, to test create a content-view with and promote a life cycle to a version you'd like to test. Then try removing it with hammer. Right now it cannot resolve the 'names' of content-view-versions. However this is being solved by #14604 by @akofink. The name is going to be  to be [name of content-view] [major-version].[minor-version].