### PR TITLE
Fixes #14821: remove description from content host.

### DIFF
--- a/lib/hammer_cli_katello/content_host.rb
+++ b/lib/hammer_cli_katello/content_host.rb
@@ -32,7 +32,6 @@ module HammerCLIKatello
         field :name, _("Name")
         field :uuid, _("ID")
         field :katello_agent_installed, _("Katello Agent Installed"), Fields::Boolean
-        field :description, _("Description")
         field :location, _("Location")
         from :environment do
           field :name, _("Lifecycle Environment")


### PR DESCRIPTION
Viewing/updating description on content host is no longer supported
as viewing/updating the comment field on host replaces this field.
This commit removes the description field output from hammer for
content hosts.

http://projects.theforeman.org/issues/14821