### PR TITLE
Fixes #14860 - Eratta apply has a success message that follows async command format.

### DIFF
--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -7,7 +7,7 @@ module HammerCLIKatello
       include HammerCLIForemanTasks::Async
       resource :host_errata, :apply
       command_name "apply"
-      success_message _("Errata applied successfully")
+      success_message _("Errata is being applied with task %{id}")
       failure_message _("Could not apply errata")
 
       build_options

--- a/test/functional/content_view/version/incremental_update_test.rb
+++ b/test/functional/content_view/version/incremental_update_test.rb
@@ -6,6 +6,7 @@ require File.join(File.dirname(__FILE__),
 describe 'content-view version incremental-update' do
   include OrganizationHelpers
   include LifecycleEnvironmentHelpers
+  include ForemanTaskHelpers
 
   before do
     @cmd = %w(content-view version incremental-update)
@@ -23,8 +24,7 @@ describe 'content-view version incremental-update' do
     end
     ex.returns('id' => '3', 'state' => 'stopped')
 
-    ex2 = api_expects(:foreman_tasks, :show, 'Show task')
-    ex2.returns('id' => '3', 'state' => 'stopped')
+    expect_foreman_task('3')
 
     run_cmd(@cmd + params)
   end
@@ -41,8 +41,7 @@ describe 'content-view version incremental-update' do
     end
     ex.returns('id' => '3', 'state' => 'stopped')
 
-    ex2 = api_expects(:foreman_tasks, :show, 'Show task')
-    ex2.returns('id' => '3', 'state' => 'stopped')
+    expect_foreman_task('3')
 
     run_cmd(@cmd + params)
   end
@@ -58,8 +57,7 @@ describe 'content-view version incremental-update' do
     end
     ex.returns('id' => '3', 'state' => 'stopped')
 
-    ex2 = api_expects(:foreman_tasks, :show, 'Show task')
-    ex2.returns('id' => '3', 'state' => 'stopped')
+    expect_foreman_task('3')
 
     run_cmd(@cmd + params)
   end
@@ -82,8 +80,7 @@ describe 'content-view version incremental-update' do
     end
     ex.returns('id' => '3', 'state' => 'stopped')
 
-    ex2 = api_expects(:foreman_tasks, :show, 'Show task')
-    ex2.returns('id' => '3', 'state' => 'stopped')
+    expect_foreman_task('3')
 
     run_cmd(@cmd + params)
   end

--- a/test/functional/host/errata/apply_test.rb
+++ b/test/functional/host/errata/apply_test.rb
@@ -1,0 +1,46 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+require 'hammer_cli_katello/content_view_puppet_module'
+
+describe 'apply an errata' do
+  include ForemanTaskHelpers
+
+  before do
+    @cmd = %w(host errata apply)
+  end
+
+  let(:errata_id) { "RHEA-1111:1111" }
+  let(:host_id) { 1 }
+  let(:task_id) { 5 }
+  let(:response) do {
+    'id' => task_id,
+    'state' => 'stopped'
+  }
+  end
+
+  it "applies an errata to a host" do
+    params = ["--errata-ids=#{errata_id}", "--host-id=#{host_id}"]
+
+    ex = api_expects(:host_errata, :apply, 'Host errata apply') do |par|
+      par['errata_ids'] == [errata_id] && par['host_id'] == host_id
+    end
+
+    ex.returns(response)
+
+    expect_foreman_task(task_id)
+
+    run_cmd(@cmd + params)
+  end
+
+  it "applies an errata to a host with async flag" do
+    params = ["--errata-ids=#{errata_id}", "--host-id=#{host_id}", "--async"]
+
+    ex = api_expects(:host_errata, :apply, 'Host errata apply') do |par|
+      par['errata_ids'] == [errata_id] && par['host_id'] == host_id
+    end
+
+    ex.returns(response)
+
+    run_cmd(@cmd + params)
+  end
+end

--- a/test/task_helper.rb
+++ b/test/task_helper.rb
@@ -1,0 +1,6 @@
+module ForemanTaskHelpers
+  def expect_foreman_task(task_id)
+    ex = api_expects(:foreman_tasks, :show, 'Show task')
+    ex.returns('id' => task_id, 'state' => 'stopped')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
+require File.join(File.dirname(__FILE__), './task_helper.rb')
 require 'minitest/autorun'
 require 'minitest/spec'
-require "mocha/setup"
-
+require 'mocha/setup'
 require 'hammer_cli'
 require 'hammer_cli_foreman/commands'
 


### PR DESCRIPTION
To test just try to apply an errata to a content-host with the --async flag. It should response with the Errata is being applied with task [task-id].