### PR TITLE
fixes #14871 - capsule content synchronize - fix error on using name

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -70,7 +70,8 @@ module HammerCLIKatello
         build_options
       end
 
-      class SyncCommand < HammerCLIForemanTasks::AsyncCommand
+      class SyncCommand < HammerCLIKatello::SingleResourceCommand
+        include HammerCLIForemanTasks::Async
         include LifecycleEnvironmentNameResolvable
         resource :capsule_content, :sync
         command_name "synchronize"


### PR DESCRIPTION
Before:
```
hammer> capsule content synchronize --name katello.example.com
Could not synchronize capsule content:
    Error: undefined method `[]' for nil:NilClass
```
After:
```
hammer> capsule content synchronize --name katello.example.com
Could not synchronize capsule content:
    This request may only be performed on a Capsule that has the Pulp Node feature.
```