### PR TITLE
Fixes #14970 - LifecycleEnvironment will be called for once.

### DIFF
--- a/lib/hammer_cli_katello/katello_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/katello_environment_name_resolvable.rb
@@ -23,9 +23,10 @@ module HammerCLIKatello
 
     def all_options
       result = super.clone
-      if result['option_environment_name']
+      if result['option_environment_name'] && result['option_environment_id'].nil?
         result['option_environment_id'] = resolver.lifecycle_environment_id(
           lifecycle_environment_resolve_options(result))
+        @all_options = result
       end
       result
     end

--- a/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
@@ -11,9 +11,10 @@ module HammerCLIKatello
 
     def all_options
       result = super.clone
-      if result['option_environment_name']
+      if result['option_environment_name'] && result['option_environment_id'].nil?
         result['option_environment_id'] = resolver.lifecycle_environment_id(
           lifecycle_environment_resolve_options(result))
+        @all_options = result
       end
       result
     end

--- a/test/functional/activaton_key/list_test.rb
+++ b/test/functional/activaton_key/list_test.rb
@@ -50,7 +50,7 @@ ID | NAME | HOST LIMIT | LIFECYCLE ENVIRONMENT | CONTENT VIEW
   it "lists the activation-keys belonging to a lifecycle environment by name" do
     params = ["--organization-id=#{org_id}", '--lifecycle-environment=test']
 
-    expect_lifecycle_environment_search(org_id, 'test', lifecycle_env_id).at_least_once
+    expect_lifecycle_environment_search(org_id, 'test', lifecycle_env_id)
 
     ex = api_expects(:activation_keys, :index, 'lifecycle activation-key list') do |par|
       par['organization_id'] == org_id && par['page'] == 1 &&

--- a/test/functional/content_view/list_test.rb
+++ b/test/functional/content_view/list_test.rb
@@ -49,7 +49,7 @@ CONTENT VIEW ID | NAME | LABEL | COMPOSITE | REPOSITORY IDS
   it "lists the content-views belonging to a lifecycle-environment by name" do
     params = ["--organization-id=#{org_id}", '--lifecycle-environment=test']
 
-    expect_lifecycle_environment_search(org_id, 'test', lifecycle_env_id).at_least_once
+    expect_lifecycle_environment_search(org_id, 'test', lifecycle_env_id)
 
     ex = api_expects(:content_views, :index, 'lifecycles content-views list') do |par|
       par['organization_id'] == org_id && par['page'] == 1 &&


### PR DESCRIPTION
To test just try calling for a list of content-views with a --lifecycle-environment [name] as an option with the -vd flags. You should only see one api call to environments be made.  