### PR TITLE
Fixes #14994 - Add simplecov with 46% minimum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :test do
   gem 'thor'
   gem 'minitest', '4.7.4'
   gem 'minitest-spec-context'
-  gem 'simplecov'
   gem 'mocha'
+  gem 'coveralls', require: false
 end
 
 # load local gemfile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hammer-cli-katello ![Travis # Status](https://travis-ci.org/Katello/hammer-cli-katello.svg?branch=master)
+# hammer-cli-katello ![Travis # Status](https://travis-ci.org/Katello/hammer-cli-katello.svg?branch=master) [![Coverage Status](https://coveralls.io/repos/github/Katello/hammer-cli-katello/badge.svg?branch=master)](https://coveralls.io/github/Katello/hammer-cli-katello?branch=master)
 
 Next-gen CLI tool for [Katello](http://katello.org) (Katello-specific commands)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,16 @@
+if RUBY_VERSION > "2.2"
+  # Coverage - Keep these two lines at the top of this file
+  require 'simplecov'
+  require 'coveralls'
+  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+  SimpleCov.start do
+    minimum_coverage 46
+    refuse_coverage_drop
+    track_files "lib/**/*.rb"
+    add_filter '/test/'
+  end
+end
+
 require File.join(File.dirname(__FILE__), './task_helper.rb')
 require 'minitest/autorun'
 require 'minitest/spec'


### PR DESCRIPTION
Request for comments.

Simplecov is [even more popular](https://www.ruby-toolbox.com/categories/code_metrics) in the Ruby community than Rubocop in the category of code metrics.

When you run your tests,  you will see the coverage summary print on one line of text. For more details, you can view a file-by-file summary that is generated in HTML at coverage/index.html. I've used simplecov in the past and been very happy with it.

The current coverage is 52%. I encourage people to raise the minimum defined in the test_helper as the coverage increases.