### PR TITLE
Fixes #14853 - Support organization options in host-collections

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -47,7 +47,7 @@ module HammerCLIKatello
         field :total_hosts, _("Total Hosts")
       end
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     class HostsCommand < HammerCLIKatello::ListCommand
@@ -63,26 +63,30 @@ module HammerCLIKatello
     end
 
     class CopyCommand < HammerCLIKatello::CreateCommand
-      resource :host_collections, :copy
-
       action :copy
       command_name "copy"
+      desc _("Copy a host collection")
 
-      success_message _("Host collection created")
-      failure_message _("Could not create the host collection")
+      option "--new-name", "NEW_NAME", _("New host collection name"), required: true
 
-      validate_options do
-        all(:option_name).required unless option(:option_id).exist?
+      success_message _("New host collection created")
+      failure_message _("Could not create the new host collection")
+
+      def request_params
+        params = super
+        # This is a hack to keep Hammer consistent without changing the inconsistent API V2
+        params['name'] = options[HammerCLI.option_accessor_name('new_name')] if params['id']
+        params
       end
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
       success_message _("Host collection updated")
       failure_message _("Could not update the the host collection")
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
@@ -91,7 +95,7 @@ module HammerCLIKatello
       success_message _("Host collection deleted")
       failure_message _("Could not delete the host collection")
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     class AddHostCommand < HammerCLIKatello::SingleResourceCommand
@@ -101,7 +105,7 @@ module HammerCLIKatello
       success_message _("The host(s) has been added")
       failure_message _("Could not add host(s)")
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     class RemoveHostCommand < HammerCLIKatello::SingleResourceCommand
@@ -111,7 +115,7 @@ module HammerCLIKatello
       success_message _("The host(s) has been removed")
       failure_message _("Could not remove host(s)")
 
-      build_options
+      build_options { |o| o.expand(:all).including(:organizations) }
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -8,7 +8,10 @@ module HammerCLIKatello
       :content_host =>          [s_name(_("Content host name to search by"))],
       :content_view =>          [s_name(_("Content view name to search by"))],
       :gpg =>                   [s_name(_("Gpg key name to search by"))],
-      :host_collection =>       [s_name(_("Host collection name to search by"))],
+      :host_collection =>       [
+        s_name(_("Host collection name to search by")),
+        s("organization_id", _("Organization ID to search by"))
+      ],
       :lifecycle_environment => [s_name(_("Lifecycle environment name to search by"))],
       :organization =>          [s_name(_("Organization name to search by")),
                                  s("label", _("Organization label to search by"),

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -53,6 +53,13 @@ module HammerCLIKatello
       create_search_options_without_katello_api(options, api.resource(:hosts))
     end
 
+    def create_host_collections_search_options(options)
+      options[HammerCLI.option_accessor_name("organization_id")] ||= organization_id(
+        scoped_options("organization", options)
+      )
+      create_search_options_with_katello_api(options, api.resource(:host_collections))
+    end
+
     def create_search_options_with_katello_api(options, resource)
       search_options = {}
       searchables(resource).each do |s|

--- a/test/functional/host_collection/add_host_test.rb
+++ b/test/functional/host_collection/add_host_test.rb
@@ -1,0 +1,57 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::AddHostCommand do
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :add_hosts)
+      run_cmd(%w(host-collection add-host --id 1))
+    end
+
+    it 'requires organization options if name is specified' do
+      result = run_cmd(%w(host-collection add-host --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :add_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection add-host --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :add_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection add-host --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :add_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection add-host --name hc1 --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/copy_test.rb
+++ b/test/functional/host_collection/copy_test.rb
@@ -1,0 +1,64 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::CopyCommand do
+    it 'requires a new name' do
+      result = run_cmd(%w(host-collection copy --id 1))
+      expected_error = "option '--new-name' is required"
+      assert_equal(result.exit_code, HammerCLI::EX_USAGE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :copy)
+      run_cmd(%w(host-collection copy --id 1 --new-name foo))
+    end
+
+    it 'requires organization options if name is specified' do
+      result = run_cmd(%w(host-collection copy --name hc1 --new-name foo))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :copy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection copy --name hc1 --organization-id 1 --new-name foo))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :copy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection copy --name hc1 --organization org1 --new-name foo))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :copy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection copy --name hc1 --organization-label org1 --new-name foo))
+    end
+  end
+end

--- a/test/functional/host_collection/create_test.rb
+++ b/test/functional/host_collection/create_test.rb
@@ -1,0 +1,43 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::CreateCommand do
+    it 'requires organization options' do
+      result = run_cmd(%w(host-collection create --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :create) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection create --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :create) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection create --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :create) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection create --name hc1 --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/delete_test.rb
+++ b/test/functional/host_collection/delete_test.rb
@@ -1,0 +1,57 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::DeleteCommand do
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :destroy)
+      run_cmd(%w(host-collection delete --id 1))
+    end
+
+    it 'requires organization options if name is specified' do
+      result = run_cmd(%w(host-collection delete --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :destroy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection delete --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :destroy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection delete --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :destroy) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection delete --name hc1 --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/info_test.rb
+++ b/test/functional/host_collection/info_test.rb
@@ -1,0 +1,57 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::InfoCommand do
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :show)
+      run_cmd(%w(host-collection info --id 1))
+    end
+
+    it 'requires organization options if id is not specified' do
+      result = run_cmd(%w(host-collection info --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :show) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection info --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :show) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection info --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :show) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection info --name hc1 --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/list_test.rb
+++ b/test/functional/host_collection/list_test.rb
@@ -1,0 +1,42 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::ListCommand do
+    it 'does not require organization options' do
+      api_expects(:host_collections, :index)
+
+      run_cmd(%w(host-collection list))
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection list --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection list --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) do |par|
+        par['organization_id'].to_i == 1
+      end
+
+      run_cmd(%w(host-collection list --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/remove_host_test.rb
+++ b/test/functional/host_collection/remove_host_test.rb
@@ -1,0 +1,57 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::RemoveHostCommand do
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :remove_hosts)
+      run_cmd(%w(host-collection remove-host --id 1))
+    end
+
+    it 'requires organization options if name is specified' do
+      result = run_cmd(%w(host-collection remove-host --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :remove_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection remove-host --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :remove_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection remove-host --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :remove_hosts) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection remove-host --name hc1 --organization-label org1))
+    end
+  end
+end

--- a/test/functional/host_collection/update_test.rb
+++ b/test/functional/host_collection/update_test.rb
@@ -1,0 +1,57 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/host_collection'
+
+module HammerCLIKatello
+  describe HostCollection::UpdateCommand do
+    it 'does not require organization options if id is specified' do
+      api_expects(:host_collections, :update)
+      run_cmd(%w(host-collection update --id 1))
+    end
+
+    it 'requires organization options if name is specified' do
+      result = run_cmd(%w(host-collection update --name hc1))
+      expected_error = "Could not find organization"
+      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization id' do
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :update) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection update --name hc1 --organization-id 1))
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :update) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection update --name hc1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :index) { |par| par['organization_id'].to_i == 1 }
+        .returns(index_response([{'id' => 2}]))
+
+      api_expects(:host_collections, :update) do |par|
+        par['id'].to_i == 2
+      end
+
+      run_cmd(%w(host-collection update --name hc1 --organization-label org1))
+    end
+  end
+end


### PR DESCRIPTION
As usual, we require organization only when a host collection name is specified
rather than an ID. This is not true of `host-collection list` command, as it
will list all host collections across all organizations if no organization
options are given.

In addition, the host-collection copy interface is updated to be consistent with
the rest of hammer, allowing searching for a host collection by name if
the organization is also specified. The new host collection name is now specified
with --new-name rather than --name.

Note that I added test files for the broken content-host subcommand and created
a BZ for fixing the broken commands [#15289](http://projects.theforeman.org/issues/15289).

There is also another broken command `host-collection hosts`. The bug report to fix that
is [#15290](http://projects.theforeman.org/issues/15290).

The host-collection add-host/remove-host commands are broken as well, always
reporting success even when the hosts in question were not found: [#15291](http://projects.theforeman.org/issues/15291)
addresses this bug.