### PR TITLE
Fixes #15032 - Fixing repository list test

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -2,7 +2,7 @@ module HammerCLIKatello
 
   RESOURCE_NAME_MAPPING = {
     :system => :content_host
-  }
+  }.freeze
 
   module ResolverCommons
 
@@ -23,7 +23,7 @@ module HammerCLIKatello
       end
 
       def resource_name_mapping
-        HammerCLIKatello::RESOURCE_NAME_MAPPING
+        HammerCLIKatello::RESOURCE_NAME_MAPPING.dup
       end
 
     end

--- a/test/functional/repository/list_test.rb
+++ b/test/functional/repository/list_test.rb
@@ -47,7 +47,7 @@ ID | NAME | PRODUCT | CONTENT TYPE | URL
   end
 
   it "lists the repositories belonging to a lifecycle-environment by name" do
-    params = ['--organization-id=1', '--lifecycle-environment=test']
+    params = ['--organization-id=1', '--environment=test']
 
     expect_lifecycle_environment_search(org_id, 'test', lifecycle_env_id)
 


### PR DESCRIPTION
The repository list command doesn't have a `--lifecycle-environment` option. It's because the hash is getting modified somehow when running tests but not the hammer command. Perhaps it's a different load order? Regardless, freezing the hash fixes it.