### PR TITLE
Fixes #15013 - Repository commands can accept organization flags.

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -128,7 +128,7 @@ module HammerCLIKatello
       end
 
       build_options do |o|
-        o.expand.including(:products)
+        o.expand.including(:products, :organizations)
       end
     end
 
@@ -143,7 +143,7 @@ module HammerCLIKatello
       failure_message _("Could not synchronize the repository")
 
       build_options do |o|
-        o.expand.including(:products)
+        o.expand.including(:products, :organizations)
       end
     end
 
@@ -223,7 +223,7 @@ module HammerCLIKatello
       failure_message _("Could not upload the content")
 
       build_options(:without => [:content]) do |o|
-        o.expand.including(:products)
+        o.expand.including(:products, :organizations)
       end
       option "--path", "PATH", _("Upload file or directory of files as content for a repository"),
              :attribute_name => :option_content,

--- a/test/functional/content_view/version/incremental_update_test.rb
+++ b/test/functional/content_view/version/incremental_update_test.rb
@@ -26,7 +26,8 @@ describe 'content-view version incremental-update' do
 
     expect_foreman_task('3')
 
-    run_cmd(@cmd + params)
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
   end
 
   it "performs incremental update with update all hosts" do
@@ -43,7 +44,8 @@ describe 'content-view version incremental-update' do
 
     expect_foreman_task('3')
 
-    run_cmd(@cmd + params)
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
   end
 
   it "performs incremental update with no environment" do
@@ -59,7 +61,8 @@ describe 'content-view version incremental-update' do
 
     expect_foreman_task('3')
 
-    run_cmd(@cmd + params)
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
   end
 
   it "performs incremental update with names" do
@@ -82,6 +85,7 @@ describe 'content-view version incremental-update' do
 
     expect_foreman_task('3')
 
-    run_cmd(@cmd + params)
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
   end
 end

--- a/test/functional/product/product_helpers.rb
+++ b/test/functional/product/product_helpers.rb
@@ -1,0 +1,8 @@
+module ProductHelpers
+  def expect_product_search(org_id, name, id)
+    ex = api_expects(:products, :index, 'Find the Product') do |par|
+      par['name'] == name && par['organization_id'] == org_id
+    end
+    ex.returns(index_response([{'id' => id}]))
+  end
+end

--- a/test/functional/repository/info_test.rb
+++ b/test/functional/repository/info_test.rb
@@ -1,0 +1,46 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), '../product/product_helpers')
+require File.join(File.dirname(__FILE__), './repository_helpers')
+
+describe "get repository info" do
+  include ProductHelpers
+  include RepositoryHelpers
+
+  before do
+    @cmd = %w(repository info)
+  end
+
+  let(:org_id) { 1 }
+  let(:product_id) { 2 }
+  let(:repo_id) { 3 }
+
+  it "Shows information about a repository" do
+    params = ["--id=#{repo_id}"]
+
+    ex = api_expects(:repositories, :show, "Get info") do |par|
+      par["id"] == repo_id.to_s
+    end
+
+    ex.returns({})
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+  end
+
+  it "Shows information about a repository with organization-id and product name" do
+    params = ["--name=test_repo", "--product=test_product", "--organization-id=#{org_id}"]
+
+    expect_product_search(org_id, 'test_product', product_id)
+
+    expect_repository_search(org_id, product_id, 'test_repo', repo_id)
+
+    ex2 = api_expects(:repositories, :show, "Get info") do |par|
+      par["id"] == repo_id
+    end
+
+    ex2.returns({})
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+  end
+end

--- a/test/functional/repository/repository_helpers.rb
+++ b/test/functional/repository/repository_helpers.rb
@@ -1,0 +1,9 @@
+module RepositoryHelpers
+  def expect_repository_search(org_id, product_id, name, id)
+    ex = api_expects(:repositories, :index, 'Find a repository') do |par|
+      par['name'] == name && par['organization_id'] == org_id &&
+        par['product_id'] == product_id
+    end
+    ex.returns(index_response([{'id' => id}]))
+  end
+end

--- a/test/functional/repository/synchronize_test.rb
+++ b/test/functional/repository/synchronize_test.rb
@@ -1,0 +1,57 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), '../product/product_helpers')
+require File.join(File.dirname(__FILE__), './repository_helpers')
+
+describe 'Synchronize a repository' do
+  include ForemanTaskHelpers
+  include ProductHelpers
+  include RepositoryHelpers
+
+  before do
+    @cmd = %w(repository synchronize)
+  end
+
+  let(:org_id) { 1 }
+  let(:repo_id) { 2 }
+  let(:product_id) { 3 }
+  let(:sync_response) do
+    {
+      'id' => repo_id,
+      'state' => 'planned'
+    }
+  end
+
+  it "synchronizes a repository" do
+    params = ["--id=#{repo_id}"]
+
+    ex = api_expects(:repositories, :sync, 'Repository is synced') do |par|
+      par['id'] == repo_id.to_s
+    end
+
+    ex.returns(sync_response)
+
+    expect_foreman_task('3')
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+  end
+
+  it "synchronizes a repository with a repository name" do
+    params = ["--name=test_repo", "--product=test_product", "--organization-id=#{org_id}"]
+
+    expect_product_search(org_id, "test_product", product_id)
+
+    expect_repository_search(org_id, product_id, "test_repo", repo_id)
+
+    ex = api_expects(:repositories, :sync, 'Repository is synced') do |par|
+      par['id'] == repo_id
+    end
+
+    ex.returns(sync_response)
+
+    expect_foreman_task('3')
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+  end
+end

--- a/test/functional/repository/upload_test.rb
+++ b/test/functional/repository/upload_test.rb
@@ -1,0 +1,86 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), '../product/product_helpers')
+require File.join(File.dirname(__FILE__), './repository_helpers')
+
+describe 'upload repository' do
+  include ProductHelpers
+  include RepositoryHelpers
+
+  before do
+    @cmd = %w(repository upload-content)
+  end
+
+  let(:org_id) { 1 }
+  let(:product_id) { 2 }
+  let(:repo_id) { 3 }
+  let(:path) { "./test.rpm" }
+  let(:upload_id) { "1234" }
+  let(:_href) { "/pulp/api/v2/content/uploads/#{upload_id}" }
+  let(:upload_response) do
+    {
+      "upload_id" => upload_id,
+      "_href" => _href
+    }
+  end
+
+  it "uploads a package" do
+    File.new("test.rpm", "w")
+
+    params = ["--id=#{repo_id}", "--path=#{path}"]
+
+    ex = api_expects(:content_uploads, :create, "Create upload for content") do |par|
+      par[:repository_id] == repo_id.to_s
+    end
+
+    ex.returns(upload_response)
+
+    ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload') do |par|
+      par[:id] == repo_id.to_s && par[:upload_ids] == ['1234']
+    end
+
+    ex2.returns("")
+
+    ex3 = api_expects(:content_uploads, :destroy, "Delete the upload") do |par|
+      par[:id] == upload_id && par[:repository_id] == repo_id.to_s
+    end
+
+    ex3.returns("")
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+    File.delete("test.rpm")
+  end
+
+  it "uploads a package with an organization-id" do
+    File.new("test.rpm", "w")
+
+    params = ["--name=test_repo", "--product=test_product", "--organization-id=#{org_id}",
+              "--path=#{path}"]
+
+    expect_product_search(org_id, 'test_product', product_id)
+
+    expect_repository_search(org_id, product_id, 'test_repo', repo_id)
+
+    ex = api_expects(:content_uploads, :create, "Create upload for content") do |par|
+      par[:repository_id] == repo_id
+    end
+
+    ex.returns(upload_response)
+
+    ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload') do |par|
+      par[:id] == repo_id && par[:upload_ids] == ['1234']
+    end
+
+    ex2.returns("")
+
+    ex3 = api_expects(:content_uploads, :destroy, "Delete the upload") do |par|
+      par[:id] == upload_id && par[:repository_id] == repo_id
+    end
+
+    ex3.returns("")
+
+    result = run_cmd(@cmd + params)
+    assert(result.exit_code, 0)
+    File.delete("test.rpm")
+  end
+end

--- a/test/task_helper.rb
+++ b/test/task_helper.rb
@@ -1,6 +1,7 @@
 module ForemanTaskHelpers
   def expect_foreman_task(task_id)
     ex = api_expects(:foreman_tasks, :show, 'Show task')
-    ex.returns('id' => task_id, 'state' => 'stopped')
+    ex.returns('id' => task_id, 'state' => 'stopped', 'progress' => 1,
+               'humanized' => {'output' => '', 'errors' => ''})
   end
 end


### PR DESCRIPTION
The repository upload, info and sync command now can accepts organization as flags if the repository-id needs to be looked up.