### PR TITLE
Fixes #15067 - Use Hammer-CLI-Foreman current repo instead of version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
+gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
 
 group :test do
   gem 'rake', '~> 10.1.0'

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -141,7 +141,7 @@ module HammerCLIKatello
 
     def search_and_rescue(search_function, resource, options)
       self.send(search_function, scoped_options(resource, options))
-    rescue HammerCLIForeman::MissingSeachOptions # rubocop:disable HandleExceptions
+    rescue HammerCLIForeman::MissingSearchOptions # rubocop:disable HandleExceptions
       # Intentionally suppressing the exception,
       # These are not always required.
     end


### PR DESCRIPTION
Updated to use gemspec, and fix MissingSeachOptions.

This issue is breaking bats, because it is using the  Hammer-CLI-Foreman's current repository, so we should also use the repository when testing.