### PR TITLE
Fixes #15313 - Extend hostgroups create/update commands

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -126,4 +126,5 @@ module HammerCLIKatello
 
   # subcommands to hammer_cli_foreman commands
   require 'hammer_cli_katello/host'
+  require 'hammer_cli_katello/hostgroup'
 end

--- a/lib/hammer_cli_katello/hostgroup.rb
+++ b/lib/hammer_cli_katello/hostgroup.rb
@@ -1,0 +1,2 @@
+require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_katello/hostgroup_extensions'

--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -1,0 +1,21 @@
+require 'hammer_cli_foreman/hostgroup'
+
+module HammerCLIKatello
+  module HostgroupExtensions
+    ::HammerCLIForeman::Hostgroup::CreateCommand.instance_eval do
+      include HammerCLIKatello::ResolverCommons
+      option '--content-view-organization-id', 'ORGANIZATION_ID',
+        _('Organization ID to search by')
+      option '--lifecycle-environment-organization-id', 'ORGANIZATION_ID',
+        _('Organization ID to search by')
+    end
+
+    ::HammerCLIForeman::Hostgroup::UpdateCommand.instance_eval do
+      include HammerCLIKatello::ResolverCommons
+      option '--content-view-organization-id', 'ORGANIZATION_ID',
+        _('Organization ID to search by')
+      option '--lifecycle-environment-organization-id', 'ORGANIZATION_ID',
+        _('Organization ID to search by')
+    end
+  end
+end

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -6,13 +6,19 @@ module HammerCLIKatello
       :activation_key =>        [s_name(_("Activation key name to search by"))],
       :capsule =>               [s_name(_("Capsule name to search by"))],
       :content_host =>          [s_name(_("Content host name to search by"))],
-      :content_view =>          [s_name(_("Content view name to search by"))],
+      :content_view => [
+        s_name(_("Content view name to search by")),
+        s("organization_id", _("Organization ID"))
+      ],
       :gpg =>                   [s_name(_("Gpg key name to search by"))],
       :host_collection =>       [
         s_name(_("Host collection name to search by")),
         s("organization_id", _("Organization ID to search by"))
       ],
-      :lifecycle_environment => [s_name(_("Lifecycle environment name to search by"))],
+      :lifecycle_environment => [
+        s_name(_("Lifecycle environment name to search by")),
+        s("organization_id", _("Organization ID"))
+      ],
       :organization =>          [s_name(_("Organization name to search by")),
                                  s("label", _("Organization label to search by"),
                                    :editable => false)

--- a/lib/hostgroup.rb
+++ b/lib/hostgroup.rb
@@ -1,0 +1,2 @@
+require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_katello/hostgroup_extensions'

--- a/test/functional/hostgroup/create_test.rb
+++ b/test/functional/hostgroup/create_test.rb
@@ -1,0 +1,55 @@
+require_relative '../test_helper'
+require 'hammer_cli_foreman/hostgroup'
+
+module HammerCLIForeman
+  describe Hostgroup do
+    # These tests are only for the extensions Katello adds to the hostgroup command
+    # See hammer-cli-foreman for the core hostgroup tests
+    describe CreateCommand do
+      it 'allows content source id' do
+        api_expects(:hostgroups, :create) do |p|
+          p['hostgroup']['name'] == 'hg1' && p['hostgroup']['content_source_id'] == 1
+        end
+        run_cmd(%w(hostgroup create --name hg1 --content-source-id 1))
+      end
+
+      it 'allows content view id' do
+        api_expects(:hostgroups, :create) do |p|
+          p['hostgroup']['name'] == 'hg1' && p['hostgroup']['content_view_id'] == 1
+        end
+        run_cmd(%w(hostgroup create --name hg1 --content-view-id 1))
+      end
+
+      it 'allows content view name' do
+        ex = api_expects(:content_views, :index) do |p|
+          p[:search] = "name = \"cv1\"" && p['organization_id'] == '1'
+        end
+        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:hostgroups, :create) do |p|
+          p['hostgroup']['content_view_id'] == 1 && p['hostgroup']['name'] == 'hg1'
+        end
+        run_cmd(%w(hostgroup create --name hg1 --content-view cv1 --content-view-organization-id 1))
+      end
+
+      it 'allows lifecycle environment id' do
+        api_expects(:hostgroups, :create) do |p|
+          p['hostgroup']['name'] == 'hg1' && p['hostgroup']['lifecycle_environment_id'] == 1 &&
+            p['hostgroup']['organization_ids'] == %w(1 2)
+        end
+        run_cmd(%w(hostgroup create --name hg1 --lifecycle-environment-id 1 --organization-ids 1,2))
+      end
+
+      it 'allows lifecycle environment name' do
+        ex = api_expects(:lifecycle_environments, :index) do |p|
+          p[:name] = 'le1' && p['organization_id'] == '1'
+        end
+        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:hostgroups, :create) do |p|
+          p['hostgroup']['name'] == 'hg1' && p['hostgroup']['lifecycle_environment_id'] == 1
+        end
+        run_cmd(%w(hostgroup create --name hg1 --lifecycle-environment le1
+                   --lifecycle-environment-organization-id 1 --organization-ids 1,2))
+      end
+    end
+  end
+end

--- a/test/functional/hostgroup/update_test.rb
+++ b/test/functional/hostgroup/update_test.rb
@@ -1,0 +1,55 @@
+require_relative '../test_helper'
+require 'hammer_cli_foreman/hostgroup'
+
+module HammerCLIForeman
+  describe Hostgroup do
+    # These tests are only for the extensions Katello adds to the hostgroup command
+    # See hammer-cli-foreman for the core hostgroup tests
+    describe UpdateCommand do
+      it 'allows content source id' do
+        api_expects(:hostgroups, :update) do |p|
+          p['id'] == '1' && p['hostgroup']['content_source_id'] == 1
+        end
+        run_cmd(%w(hostgroup update --id 1 --content-source-id 1))
+      end
+
+      it 'allows content view id' do
+        api_expects(:hostgroups, :update) do |p|
+          p['id'] == '1' && p['hostgroup']['content_view_id'] == 1
+        end
+        run_cmd(%w(hostgroup update --id 1 --content-view-id 1))
+      end
+
+      it 'allows content view name' do
+        ex = api_expects(:content_views, :index) do |p|
+          p[:search] = "name = \"cv1\"" && p['organization_id'] == '1'
+        end
+        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:hostgroups, :update) do |p|
+          p['id'] == '1' && p['hostgroup']['content_view_id'] == 1
+        end
+        run_cmd(%w(hostgroup update --id 1 --content-view cv1 --content-view-organization-id 1))
+      end
+
+      it 'allows lifecycle environment id' do
+        api_expects(:hostgroups, :update) do |p|
+          p['id'] == '1' && p['hostgroup']['lifecycle_environment_id'] == 1 &&
+            p['hostgroup']['organization_ids'] == %w(1 2)
+        end
+        run_cmd(%w(hostgroup update --id 1 --lifecycle-environment-id 1 --organization-ids 1,2))
+      end
+
+      it 'allows lifecycle environment name' do
+        ex = api_expects(:lifecycle_environments, :index) do |p|
+          p[:name] = 'le1' && p['organization_id'] == '1'
+        end
+        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:hostgroups, :update) do |p|
+          p['id'] == '1' && p['hostgroup']['lifecycle_environment_id'] == 1
+        end
+        run_cmd(%w(hostgroup update --id 1 --lifecycle-environment le1
+                   --lifecycle-environment-organization-id 1 --organization-ids 1,2))
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add hostgroups create tests for hammer-cli-katello extensions
- Add hostgroups update tests for hammer-cli-katello extensions
- Extend hammer-cli-foreman to accept an organization_id when searching for a
  lifecycle_environment in the hostgroups subcommand
- Extend hammer-cli-foreman to accept an organization_id when searching for a
  content_view in the hostgroups subcommand