### PR TITLE
Fixes #15142 - Replace improper assert() usage

### DIFF
--- a/test/functional/content_view/version/incremental_update_test.rb
+++ b/test/functional/content_view/version/incremental_update_test.rb
@@ -27,7 +27,7 @@ describe 'content-view version incremental-update' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 
   it "performs incremental update with update all hosts" do
@@ -45,7 +45,7 @@ describe 'content-view version incremental-update' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 
   it "performs incremental update with no environment" do
@@ -62,7 +62,7 @@ describe 'content-view version incremental-update' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 
   it "performs incremental update with names" do
@@ -86,6 +86,6 @@ describe 'content-view version incremental-update' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 end

--- a/test/functional/repository/info_test.rb
+++ b/test/functional/repository/info_test.rb
@@ -24,7 +24,7 @@ describe "get repository info" do
     ex.returns({})
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 
   it "Shows information about a repository with organization-id and product name" do
@@ -41,6 +41,6 @@ describe "get repository info" do
     ex2.returns({})
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 end

--- a/test/functional/repository/synchronize_test.rb
+++ b/test/functional/repository/synchronize_test.rb
@@ -33,7 +33,7 @@ describe 'Synchronize a repository' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 
   it "synchronizes a repository with a repository name" do
@@ -52,6 +52,6 @@ describe 'Synchronize a repository' do
     expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
   end
 end

--- a/test/functional/repository/upload_test.rb
+++ b/test/functional/repository/upload_test.rb
@@ -47,7 +47,7 @@ describe 'upload repository' do
     ex3.returns("")
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
     File.delete("test.rpm")
   end
 
@@ -80,7 +80,7 @@ describe 'upload repository' do
     ex3.returns("")
 
     result = run_cmd(@cmd + params)
-    assert(result.exit_code, 0)
+    assert_equal(result.exit_code, 0)
     File.delete("test.rpm")
   end
 end


### PR DESCRIPTION
These methods come from MiniTest.

- `assert(x, msg)` asserts that x is true and prints msg when false.
- `assert_equal(x, y)` asserts that x and y are equal