### PR TITLE
Fixes #15272 - Only show subscriptions added to...

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -142,39 +142,16 @@ module HammerCLIKatello
         field :account_number, _("Account")
       end
 
-      def extend_data(data)
-        limit = data["quantity"] == -1 ? _("Unlimited") : data["quantity"]
-
-        data["format_consumed"] = _("%{consumed} of %{limit}") %
-                                  {
-                                    :consumed => data["consumed"],
-                                    :limit => limit
-                                  }
-        data
-      end
-
-      option "--id", "ID", _("ID of activation key"),
-             :attribute_name => :option_activation_key_id
-      option "--name", "NAME", _("Name of activation key"),
-             :attribute_name => :option_activation_key_name
+      option '--id', "ACTIVATION_KEY_ID", _("ID of the activation key"),
+        attribute_name: :option_activation_key_id
+      option '--name', "ACTIVATION_KEY_NAME", _("Activation key name to search by"),
+        attribute_name: :option_activation_key_name
 
       validate_options do
         any(:option_activation_key_id, :option_activation_key_name).required
       end
 
-      build_options do |o|
-        o.expand.only(:organizations)
-        o.without(
-          :system_id,
-          :activation_key_id,
-          :full_results,
-          :search,
-          :order,
-          :sort,
-          :page,
-          :per_page
-        )
-      end
+      build_options
     end
 
     class AddSubscriptionsCommand < HammerCLIKatello::SingleResourceCommand

--- a/test/functional/activaton_key/subscriptions_test.rb
+++ b/test/functional/activaton_key/subscriptions_test.rb
@@ -1,0 +1,50 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/activation_key'
+
+module HammerCLIKatello
+  describe ActivationKeyCommand::SubscriptionsCommand do
+    it 'requires organization options' do
+      expected_error = "Could not find organization"
+      result = run_cmd(%w(activation-key subscriptions --id 1))
+      assert_equal(result.err[/#{expected_error}/], expected_error)
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:subscriptions, :index) { |par| par['organization_id'].to_i == 1 }
+
+      run_cmd(%w(activation-key subscriptions --id 1 --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:subscriptions, :index) { |par| par['organization_id'].to_i == 1 }
+
+      run_cmd(%w(activation-key subscriptions --id 1 --organization-label org1))
+    end
+
+    it 'lists subscriptions available for the activation key' do
+      api_expects(:subscriptions, :index) do |p|
+        p['available_for'] == 'activation_key'
+      end
+      run_cmd(%w(activation-key subscriptions --organization-id 1 --id 1
+                 --available-for activation_key))
+    end
+
+    it 'lists subscriptions used by the activation key' do
+      api_expects(:subscriptions, :index) { |p| p['activation_key_id'] == 1 }
+      run_cmd(%w(activation-key subscriptions --organization-id 1 --id 1))
+    end
+
+    it 'allows activation_key_name' do
+      api_expects(:activation_keys, :index) { |p| p['name'] == 'ak1' }
+        .returns(index_response([{'id' => 1}]))
+      api_expects(:subscriptions, :index) { |p| p['activation_key_id'] == 1 }
+      run_cmd(%w(activation-key subscriptions --organization-id 1 --name ak1))
+    end
+  end
+end

--- a/test/functional/subscription/list_test.rb
+++ b/test/functional/subscription/list_test.rb
@@ -1,26 +1,77 @@
-require File.join(File.dirname(__FILE__), '../test_helper')
+require_relative '../test_helper'
+require 'hammer_cli_katello/subscription'
 
-describe 'listing content-views' do
-  before do
-    @cmd = %w(subscription list)
-  end
-
-  let(:org_id) { 1 }
-
-  it "lists an organizations subscriptions" do
-    params = ["--organization-id=#{org_id}"]
-
-    ex = api_expects(:subscriptions, :index, 'Subscription list') do |par|
-      par['organization_id'] == org_id
+module HammerCLIKatello
+  describe SubscriptionCommand::ListCommand do
+    before do
+      @cmd = %w(subscription list)
     end
 
-    ex.returns(index_response([]))
+    let(:org_id) { 1 }
 
-    result = run_cmd(@cmd + params)
+    it "lists an organizations subscriptions" do
+      params = ["--organization-id=#{org_id}"]
 
-    fields = ['ID', 'UUID', 'NAME', 'CONTRACT', 'ACCOUNT', 'SUPPORT', 'QUANTITY', 'CONSUMED',
-              'END DATE', 'QUANTITY', 'ATTACHED']
-    expected_result = success_result(IndexMatcher.new([fields, []]))
-    assert_cmd(expected_result, result)
+      ex = api_expects(:subscriptions, :index, 'Subscription list') do |par|
+        par['organization_id'] == org_id
+      end
+
+      ex.returns(index_response([]))
+
+      result = run_cmd(@cmd + params)
+
+      fields = ['ID', 'UUID', 'NAME', 'CONTRACT', 'ACCOUNT', 'SUPPORT', 'QUANTITY', 'CONSUMED',
+                'END DATE', 'QUANTITY', 'ATTACHED']
+      expected_result = success_result(IndexMatcher.new([fields, []]))
+      assert_cmd(expected_result, result)
+    end
+
+    it 'requires organization options' do
+      expected_error = "Could not find organization"
+      result = run_cmd(%w(subscription list))
+      assert_equal(expected_error, result.err[/#{expected_error}/])
+    end
+
+    it 'allows organization name' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:subscriptions, :index) { |par| par['organization_id'].to_i == 1 }
+
+      run_cmd(%w(subscription list --organization org1))
+    end
+
+    it 'allows organization label' do
+      api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:subscriptions, :index) { |par| par['organization_id'].to_i == 1 }
+
+      run_cmd(%w(subscription list --organization-label org1))
+    end
+
+    it 'allows host id' do
+      api_expects(:subscriptions, :index) { |par| par['host_id'] == 1 }
+      run_cmd(%w(subscription list --organization-id 1 --host-id 1))
+    end
+
+    it 'allows host name' do
+      api_expects(:hosts, :index) { |par| par[:search] == "name = \"host1\"" }
+        .returns(index_response([{'id' => 1}]))
+      api_expects(:subscriptions, :index) { |par| par['host_id'] == 1 }
+      run_cmd(%w(subscription list --organization-id 1 --host host1))
+    end
+
+    it 'allows activation key id' do
+      api_expects(:subscriptions, :index) { |par| par['activation_key_id'] == 1 }
+      run_cmd(%w(subscription list --organization-id 1 --activation-key-id 1))
+    end
+
+    it 'allows activation key name' do
+      api_expects(:activation_keys, :index) { |par| par['name'] == "ak1" }
+        .returns(index_response([{'id' => 1}]))
+      api_expects(:subscriptions, :index) { |par| par['activation_key_id'] == 1 }
+      run_cmd(%w(subscription list --organization-id 1 --activation-key ak1))
+    end
   end
 end


### PR DESCRIPTION
Only show subscriptions added to the activation key specified.

- Add some rudimentary tests for the `activation-key subscriptions`
command.

- Add some rudimentary tests for `subscription list`

Related: #15410 - Requires https://github.com/Katello/katello/pull/6124