### PR TITLE
Fixes #15395 - Repository name searches include organization-id.

### DIFF
--- a/lib/hammer_cli_katello/filter.rb
+++ b/lib/hammer_cli_katello/filter.rb
@@ -53,6 +53,15 @@ module HammerCLIKatello
       success_message _("Filter created")
       failure_message _("Could not create the filter")
 
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_repository_names).exist? || option(:option_content_view_name).exist?
+          any(*organization_options).required
+        end
+      end
+
       build_options
     end
 

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -1,14 +1,26 @@
 module HammerCLIKatello
   module SearchOptionsCreators
+    def create_repository_search_options(options)
+      name = options[HammerCLI.option_accessor_name("name")]
+      organization_id = options[HammerCLI.option_accessor_name("organization_id")]
+
+      search_options = {}
+      search_options['name'] = name if name
+      search_options['organization_id'] = organization_id if organization_id
+      search_options
+    end
+
     def create_repositories_search_options(options)
       name = options[HammerCLI.option_accessor_name("name")]
       names = options[HammerCLI.option_accessor_name("names")]
       product_id = options[HammerCLI.option_accessor_name("product_id")]
+      organization_id = options[HammerCLI.option_accessor_name("organization_id")]
 
       search_options = {}
       search_options['name'] = name if name
       search_options['names'] = names if names
       search_options['product_id'] = product_id if product_id
+      search_options['organization_id'] = organization_id if organization_id
       search_options
     end
 

--- a/test/functional/activaton_key/list_test.rb
+++ b/test/functional/activaton_key/list_test.rb
@@ -1,8 +1,6 @@
 require File.join(File.dirname(__FILE__), '../test_helper')
 require File.join(File.dirname(__FILE__), '../lifecycle_environment/lifecycle_environment_helpers')
 
-require 'hammer_cli_katello/content_view_puppet_module'
-
 describe 'listing activation-keys' do
   include LifecycleEnvironmentHelpers
 

--- a/test/functional/content_view/create_test.rb
+++ b/test/functional/content_view/create_test.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '../test_helper')
+require_relative '../test_helper'
 
 # Workaround for issue #14289
 require 'hammer_cli_katello/content_view_puppet_module'

--- a/test/functional/content_view/filter/create_test.rb
+++ b/test/functional/content_view/filter/create_test.rb
@@ -1,0 +1,63 @@
+require_relative '../../test_helper'
+require_relative '../../repository/repository_helpers'
+
+describe 'content-view filter create' do
+  include RepositoryHelpers
+  before do
+    @cmd = %w(content-view filter create)
+    @base_params = ["--organization-id=#{org_id}", "--name=#{filter_name}", \
+                    "--content-view-id=#{content_view_id}", "--type=rpm"]
+  end
+
+  let(:org_id) { 1 }
+  let(:filter_name) { 'test_filter' }
+  let(:content_view_id) { 1 }
+  let(:repositories) do
+    [
+      {'name' => 'repo-1', 'id' => 1},
+      {'name' => 'repo-2', 'id' => 2},
+      {'name' => 'repo-3', 'id' => 3}
+    ]
+  end
+  let(:repo_ids) { repositories.map { |repo| repo['id'] } }
+  let(:repo_names) { repositories.map { |repo| repo['name'] } }
+
+  it 'creates a content-view filter with repository ids' do
+    ids = repo_ids.join(',')
+    params = %W(--repository-ids=#{ids})
+
+    ex = api_expects(:content_view_filters, :create, 'Create content-view filter') do |par|
+      par['name'] == filter_name && par['repository_ids'] == repo_ids
+      true
+    end
+
+    ex.returns({})
+
+    expected_result = success_result("Filter created\n")
+    result = run_cmd(@cmd + @base_params + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it 'creates a content-view filter with repository names' do
+    params = %W(--repositories=#{repo_names.join(',')})
+
+    expect_repositories_search(org_id, repo_names, repo_ids)
+
+    api_expects(:content_view_filters, :create, "Create content-view filter") do |par|
+      par['name'] == filter_name && par['repository_ids'] == repo_ids &&
+        par['type'] == 'rpm'
+    end
+
+    expected_result = success_result("Filter created\n")
+    result = run_cmd(@cmd + @base_params + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it 'should fail with no organization specified' do
+    ids = repo_ids.join(',')
+    params = ["--repositories=#{ids}", "--name=#{filter_name}", \
+              "--content-view-id=#{content_view_id}", "--type=rpm"]
+    result = run_cmd(@cmd + params)
+    assert(result.err[/--organization-id, --organization, --organization-label is required/])
+  end
+end

--- a/test/functional/repository/repository_helpers.rb
+++ b/test/functional/repository/repository_helpers.rb
@@ -6,4 +6,11 @@ module RepositoryHelpers
     end
     ex.returns(index_response([{'id' => id}]))
   end
+
+  def expect_repositories_search(org_id, names, ids)
+    ex = api_expects(:repositories, :index, 'Find repositories') do |par|
+      par['names'] == names && par['organization_id'] == org_id
+    end
+    ex.returns(index_response(ids.zip(names).map { |id, name| { 'id' => id, 'name' => name } }))
+  end
 end

--- a/test/unit/search_options_creators_test.rb
+++ b/test/unit/search_options_creators_test.rb
@@ -20,6 +20,20 @@ describe HammerCLIKatello::SearchOptionsCreators do
     resource.stubs(:singular_name).returns('')
   end
 
+  describe '#create_repository_search_options' do
+    it 'handles a repository' do
+      search_options_creators.create_repository_search_options(
+        'option_name' => 'repo1'
+      )['name'].must_equal 'repo1'
+    end
+
+    it 'handles an organization_id' do
+      search_options_creators.create_repository_search_options(
+        'option_organization_id' => 2
+      )['organization_id'].must_equal 2
+    end
+  end
+
   describe '#create_repositories_search_options' do
     it 'handles an array of names' do
       search_options_creators.create_repositories_search_options(
@@ -37,6 +51,12 @@ describe HammerCLIKatello::SearchOptionsCreators do
       search_options_creators.create_repositories_search_options(
         'option_product_id' => 3
       )['product_id'].must_equal 3
+    end
+
+    it 'handles an organization_id' do
+      search_options_creators.create_repositories_search_options(
+        'option_organization_id' => 4
+      )['organization_id'].must_equal 4
     end
   end
 


### PR DESCRIPTION
To test, try creating a content-view filter using repository names.