### PR TITLE
Fixes #15419 - Only require hammer_cli and...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ gemspec
 
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
-gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
+
+group :development, :test do
+  gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
+  gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'
+end
 
 group :test do
   gem 'rake', '~> 10.1.0'


### PR DESCRIPTION
Only require hammer_cli and hammer_cli_foreman from git in development
and test groups in the Gemfile