### PR TITLE
Fixes #15458: allow org id for activation key host collections.

### DIFF
--- a/lib/hammer_cli_katello/associating_commands.rb
+++ b/lib/hammer_cli_katello/associating_commands.rb
@@ -59,6 +59,11 @@ module HammerCLIKatello
         command_name 'add-host-collection'
         associated_resource :host_collections
 
+        def request_params
+          all_options['option_host_collection_organization_id'] ||= option_organization_id
+          super
+        end
+
         success_message _("The host collection has been associated")
         failure_message _("Could not add host collection")
       end
@@ -66,6 +71,11 @@ module HammerCLIKatello
       class RemoveHostCollectionCommand < HammerCLIKatello::RemoveAssociatedCommand
         command_name 'remove-host-collection'
         associated_resource :host_collections
+
+        def request_params
+          all_options['option_host_collection_organization_id'] ||= option_organization_id
+          super
+        end
 
         success_message _("The host collection has been removed")
         failure_message _("Could not remove host collection")

--- a/test/unit/associating_commands/add_host_collection_command_test.rb
+++ b/test/unit/associating_commands/add_host_collection_command_test.rb
@@ -1,0 +1,24 @@
+require_relative '../../test_helper'
+require 'hammer_cli_katello/associating_commands'
+
+module HammerCLIKatello
+  module AssociatingCommands
+    module HostCollection
+      describe AddHostCollectionCommand do
+        let(:api) { mock('api') }
+        let(:command) { AddHostCollectionCommand.new api }
+
+        before(:each) do
+          command.class.superclass.any_instance.stubs(:all_options).returns({})
+          command.class.superclass.any_instance.stubs(:request_params)
+          command.stubs(:option_organization_id).returns(1)
+        end
+
+        it 'sets host-collection-organization-id to organization-id if not present' do
+          command.request_params
+          command.all_options['option_host_collection_organization_id'].must_equal(1)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/associating_commands/remove_host_collection_command_test.rb
+++ b/test/unit/associating_commands/remove_host_collection_command_test.rb
@@ -1,0 +1,24 @@
+require_relative '../../test_helper'
+require 'hammer_cli_katello/associating_commands'
+
+module HammerCLIKatello
+  module AssociatingCommands
+    module HostCollection
+      describe RemoveHostCollectionCommand do
+        let(:api) { mock('api') }
+        let(:command) { RemoveHostCollectionCommand.new api }
+
+        before(:each) do
+          command.class.superclass.any_instance.stubs(:all_options).returns({})
+          command.class.superclass.any_instance.stubs(:request_params)
+          command.stubs(:option_organization_id).returns(1)
+        end
+
+        it 'sets host-collection-organization-id to organization-id if not present' do
+          command.request_params
+          command.all_options['option_host_collection_organization_id'].must_equal(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The add/remove host collection commands were not allowing
--organization-id.  This commit ensures that all organization related
parameters are accepted.

http://projects.theforeman.org/issues/15458