### PR TITLE
Fixes #14604 - Add ID resolution to CV add-version

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -29,7 +29,10 @@ module HammerCLIKatello
         s("author", _("Puppet module's author to search by")),
         s("uuid", _("Puppet module's UUID to search by"))
       ],
-      :content_view_version => [s("version", _("Content view version number"))]
+      :content_view_version => [
+        s("version", _("Content view version number")),
+        s("content_view_id", _("Content view to search by"))
+      ]
     }.freeze
 
     DEFAULT_SEARCHABLES = [s_name(_("Name to search by"))].freeze

--- a/test/functional/content_view/add_content_view_version_test.rb
+++ b/test/functional/content_view/add_content_view_version_test.rb
@@ -1,0 +1,34 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/content_view'
+
+module HammerCLIKatello
+  describe ContentView::AddContentViewVersionCommand do
+    it 'allows minimal options' do
+      ex = api_expects(:content_views, :show) do |p|
+        p[:id] == '1'
+      end
+      ex.returns('id' => 1, 'component_ids' => [1, 3])
+      api_expects(:content_views, :update) do |p|
+        p['id'] == '1' && p['component_ids'] == %w(1 3 6)
+      end
+      run_cmd(%w(content-view add-version --id 1 --content-view-version-id 6))
+    end
+
+    it 'resolves content view version ID' do
+      ex = api_expects(:content_view_versions, :index) do |p|
+        p['content_view_id'] == '3' && p['version'] == '2.1'
+      end
+      ex.returns(index_response([{'id' => 6}]))
+      ex.returns('id' => 1, 'component_ids' => [1, 3])
+      ex = api_expects(:content_views, :show) do |p|
+        p[:id] == '1'
+      end
+      ex.returns('id' => 1, 'component_ids' => [1, 3])
+      api_expects(:content_views, :update) do |p|
+        p['id'] == '1' && p['component_ids'] == %w(1 3 6)
+      end
+      run_cmd(%w(content-view add-version --id 1 --content-view-version-content-view-id 3
+                 --content-view-version 2.1))
+    end
+  end
+end

--- a/test/functional/content_view/remove_content_view_version_test.rb
+++ b/test/functional/content_view/remove_content_view_version_test.rb
@@ -1,0 +1,34 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/content_view'
+
+module HammerCLIKatello
+  describe ContentView::RemoveContentViewVersionCommand do
+    it 'allows minimal options' do
+      ex = api_expects(:content_views, :show) do |p|
+        p[:id] == '1'
+      end
+      ex.returns('id' => 1, 'component_ids' => [1, 3, 6])
+      api_expects(:content_views, :update) do |p|
+        p['id'] == '1' && p['component_ids'] == %w(1 3)
+      end
+      run_cmd(%w(content-view remove-version --id 1 --content-view-version-id 6))
+    end
+
+    it 'resolves content view version ID' do
+      ex = api_expects(:content_view_versions, :index) do |p|
+        p['content_view_id'] == '3' && p['version'] == '2.1'
+      end
+      ex.returns(index_response([{'id' => 6}]))
+      ex.returns('id' => 1, 'component_ids' => [1, 3, 6])
+      ex = api_expects(:content_views, :show) do |p|
+        p[:id] == '1'
+      end
+      ex.returns('id' => 1, 'component_ids' => [1, 3])
+      api_expects(:content_views, :update) do |p|
+        p['id'] == '1' && p['component_ids'] == %w(1 3)
+      end
+      run_cmd(%w(content-view remove-version --id 1 --content-view-version-content-view-id 3
+                 --content-view-version 2.1))
+    end
+  end
+end


### PR DESCRIPTION
- ContentViewVersions can now be added to a ContentView via ContentView
ID and ContentViewVersion version.

Like this:

```sh
hammer content-view add-version --id 2 --content-view-version 1.0 --content-view-version-content-view-id 3
hammer content-view remove-version --id 2 --content-view-version 1.0 --content-view-version-content-view-id 3
```