### PR TITLE
Fixes #15540 - Allow repo name in remove-content

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -83,10 +83,14 @@ module HammerCLIKatello
     def repository_id(options)
       key_id = HammerCLI.option_accessor_name("id")
       key_product_id = HammerCLI.option_accessor_name("product_id")
+      key_product_name = HammerCLI.option_accessor_name("product_name")
 
       return options[key_id] if options[key_id]
 
-      options[key_product_id] ||= product_id(scoped_options("product", options))
+      unless options[key_product_name].nil?
+        options[key_product_id] ||= product_id(scoped_options("product", options))
+      end
+
       find_resource(:repositories, options)['id']
     end
 

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -273,27 +273,13 @@ module HammerCLIKatello
     end
 
     class RemoveContentCommand < HammerCLIKatello::SingleResourceCommand
-      include RepositoryScopedToProduct
-
       resource :repositories, :remove_content
       command_name "remove-content"
-
-      option ["--content-ids"], "CONTENT_IDS",
-        _("package IDs, puppet module IDs, and/or docker manifest IDs"),
-        :format => HammerCLI::Options::Normalizers::List.new, :required => true
-
-      def request_params
-        super.tap do |params|
-          params[:ids] = option_content_ids
-          params[:uuids] = option_content_ids
-        end
-      end
 
       success_message _("Repository content removed")
       failure_message _("Could not remove content")
 
-      # ``uuids`` is deprecated
-      build_options :without => %w(uuids ids)
+      build_options
     end
 
     class ExportCommand < HammerCLIKatello::SingleResourceCommand

--- a/test/functional/repository/remove_content_test.rb
+++ b/test/functional/repository/remove_content_test.rb
@@ -1,0 +1,18 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/repository'
+
+module HammerCLIKatello
+  describe Repository::RemoveContentCommand do
+    it 'allows minimal parameters' do
+      api_expects(:repositories, :remove_content) { |p| p['id'] == '1' && p['ids'] == %w(1) }
+      run_cmd(%w(repository remove-content --ids 1 --id 1))
+    end
+
+    it 'resolves repository id' do
+      api_expects(:repositories, :index) { |p| p['name'] == 'repo1' }
+        .returns(index_response([{'id' => '1'}]))
+      api_expects(:repositories, :remove_content) { |p| p['id'] == '1' && p['ids'] == %w(1) }
+      run_cmd(%w(repository remove-content --ids 1 --name repo1))
+    end
+  end
+end

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -6,10 +6,12 @@ module HammerCLIKatello
     let(:api) { mock('api') }
     let(:searchables) { mock('searchables') }
     let(:id_resolver) { IdResolver.new api, searchables }
+
+    before(:each) do
+      api.stubs(:resources).returns([])
+    end
+
     describe '#repository_ids' do
-      before(:each) do
-        api.stubs(:resources).returns([])
-      end
       it 'accepts repository_ids' do
         id_resolver.repository_ids(
           'option_repository_ids' => [1, 2]
@@ -26,6 +28,14 @@ module HammerCLIKatello
         id_resolver.repository_ids(
           'option_names' => %w(repo1 repo2)
         ).must_equal [1, 2]
+      end
+    end
+
+    describe '#repository_id' do
+      it 'resolves ID from name' do
+        id_resolver.expects(:find_resource).with(:repositories, name: 'repo1').returns('id' => 5)
+        options = {name: 'repo1'}
+        id_resolver.repository_id(options).must_equal 5
       end
     end
   end


### PR DESCRIPTION
- The `--name` option now resolves the repository id when removing content
from a custom repository.
- The ID resolver for repository_id no longer requires product options.