### PR TITLE
Fixes #15604 - Handle nil repo list in repo_ids

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -99,6 +99,9 @@ module HammerCLIKatello
 
       key_names = HammerCLI.option_accessor_name 'names'
       key_product_id = HammerCLI.option_accessor_name 'product_id'
+
+      options[key_names] ||= []
+
       unless options['option_product_name'].nil?
         options[key_product_id] ||= product_id(scoped_options('product', options))
       end

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -12,6 +12,11 @@ module HammerCLIKatello
     end
 
     describe '#repository_ids' do
+      it 'accepts nil repository_names' do
+        id_resolver.stubs(:find_resources).returns([])
+        id_resolver.repository_ids({}).must_equal([])
+      end
+
       it 'accepts repository_ids' do
         id_resolver.repository_ids(
           'option_repository_ids' => [1, 2]


### PR DESCRIPTION
This change allows the `repository_ids` ID resolver to handle a nil
collection of repository names.