### PR TITLE
[WIP] Fixes #15689 - Specify environment with lifecycle

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -192,7 +192,7 @@ module HammerCLIKatello
         if options.key?(HammerCLI.option_accessor_name(:lifecycle_environment_names)) ||
            options.key?(HammerCLI.option_accessor_name(:lifecycle_environment_ids))
           params[:content_view_version_environments][0][:environment_ids] =
-            resolver.environment_ids(options)
+            resolver.lifecycle_environment_ids(options)
         end
 
         add_content = {}

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -63,11 +63,7 @@ module HammerCLIKatello
       options[HammerCLI.option_accessor_name("id")] || find_resource(:systems, options)['uuid']
     end
 
-    def environment_id(options)
-      lifecycle_environment_id(options)
-    end
-
-    def environment_ids(options)
+    def lifecycle_environment_ids(options)
       unless options['option_lifecycle_environment_ids'].nil?
         return options['option_lifecycle_environment_ids']
       end

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -13,6 +13,32 @@ module HammerCLIKatello
         field :url, _("URL")
       end
 
+      option '--environment', 'LIFECYCLE_ENVIRONMENT',
+        _("Lifecycle environment name to search by"),
+        attribute_name: 'option_lifecycle_environment_name'
+      option '--environment-id', 'LIFECYCLE_ENVIRONMENT_ID',
+        _("Lifecycle environment name to search by"),
+        attribute_name: 'option_lifecycle_environment_id'
+
+      def all_options
+        all_opts = super
+
+        if all_opts['option_organization_name']
+          all_opts['option_organization_id'] ||= resolver.organization_id(
+            resolver.scoped_options('organization', all_opts))
+        end
+
+        lifecycle_org_id_key = 'option_lifecycle_environment_organization_id'
+        all_opts[lifecycle_org_id_key] = all_opts['option_organization_id']
+
+        if all_opts['option_lifecycle_environment_name']
+          all_opts['option_lifecycle_environment_id'] ||= resolver.lifecycle_environment_id(
+            resolver.scoped_options('lifecycle_environment', all_opts))
+        end
+
+        all_opts
+      end
+
       build_options
     end
 


### PR DESCRIPTION
`hammer hostgroups create --environment puppetenv1 --name hg1` ceases to
incorrectly use the lifecycle_environment_id resolver and instead
creates the environment_id resolver on the fly using `define_id_finders`
in hammer-cli-foreman's id_resolver