### PR TITLE
Fixes #15889 - Resolve IDs when there are names

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -105,8 +105,11 @@ module HammerCLIKatello
       unless options['option_product_name'].nil?
         options[key_product_id] ||= product_id(scoped_options('product', options))
       end
-      find_resources(:repositories, options)
-        .select { |repo| options[key_names].include? repo['name'] }.map { |repo| repo['id'] }
+
+      if options[key_names].any?
+        find_resources(:repositories, options)
+          .select { |repo| options[key_names].include? repo['name'] }.map { |repo| repo['id'] }
+      end
     end
 
     def content_view_version_id(options)

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -14,7 +14,7 @@ module HammerCLIKatello
     describe '#repository_ids' do
       it 'accepts nil repository_names' do
         id_resolver.stubs(:find_resources).returns([])
-        id_resolver.repository_ids({}).must_equal([])
+        id_resolver.repository_ids({}).must_equal(nil)
       end
 
       it 'accepts repository_ids' do


### PR DESCRIPTION
Resolve repository_ids only when there are repository_names

I expect upstream tests to fail, but the `id_resolver_test` should pass.