### PR TITLE
Refs #15585 - hosts#index doesn't call parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
 before_install:

--- a/test/functional/host/extensions/info_test.rb
+++ b/test/functional/host/extensions/info_test.rb
@@ -14,11 +14,6 @@ describe 'host info' do
     json_file = File.join(File.dirname(__FILE__), 'data', 'host.json')
     ex.returns(JSON.parse(File.read(json_file)))
 
-    param_ex = api_expects(:parameters, :index, 'Parameter index') do |par|
-      par[:host_id] == 1
-    end
-    param_ex.returns(index_response([]))
-
     result = run_cmd(@cmd + params)
 
     expected_fields = [['Lifecycle Environment', 'Library'],


### PR DESCRIPTION
`hammer host info` used to make a call to /hosts/:id/parameters, but
now it doesn't.

Regression caused by https://github.com/theforeman/hammer-cli-foreman/pull/249

Co-requisite: https://github.com/Katello/hammer-cli-katello/pull/434