### PR TITLE
Fixes #15949 - Drop Ruby 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
 before_install:


### PR DESCRIPTION
co-requisite: https://github.com/Katello/hammer-cli-katello/pull/433