### PR TITLE
Fixes #9669 - Attach/Remove sub actions for host

### DIFF
--- a/lib/hammer_cli_katello/host_subscription.rb
+++ b/lib/hammer_cli_katello/host_subscription.rb
@@ -27,6 +27,71 @@ module HammerCLIKatello
       end
     end
 
+    class AddSubscriptions < HammerCLIKatello::SingleResourceCommand
+      resource :host_subscriptions, :add_subscriptions
+      command_name "attach"
+      success_message _("Subscription attached to the host successfully")
+      failure_message _("Failed to attach subscriptions to the host")
+
+      option "--subscription-id", "SUBSCRIPTION_ID", _("ID of subscription"),
+             :attribute_name => :option_subscription_id, :required => true
+
+      option "--quantity", "Quantity", _("Quantity of this subscriptions to add. Defaults to 1"),
+             :attribute_name => :option_quantity, :required => false
+
+      def request_params
+        params = super
+        params[:subscriptions] = [
+          {
+            :id => option_subscription_id,
+            :quantity => option_quantity || 1
+          }
+        ]
+        params
+      end
+
+      build_options do |o|
+        o.expand.except(:subscriptions)
+        o.without(:subscriptions)
+      end
+    end
+
+    class AutoAttachSubscriptions < HammerCLIKatello::SingleResourceCommand
+      resource :host_subscriptions, :auto_attach
+      command_name "auto-attach"
+      success_message _("Auto attached subscriptions to the host successfully")
+      failure_message _("Failed to auto attach subscriptions to the host")
+
+      build_options
+    end
+
+    class RemoveSubscriptions < HammerCLIKatello::SingleResourceCommand
+      resource :host_subscriptions, :remove_subscriptions
+      command_name "remove"
+      success_message _("Subscription removed from the host successfully")
+      failure_message _("Failed to remove subscriptions from the host")
+
+      option "--subscription-id", "SUBSCRIPTION_ID", _("ID of subscription"),
+             :attribute_name => :option_subscription_id, :required => true
+
+      option "--quantity", "Quantity",
+             _("Remove the first instance of a subscription with matching id and quantity"),
+             :attribute_name => :option_quantity, :required => false
+
+      def request_params
+        params = super
+        subs = { :id => option_subscription_id }
+        subs[:quantity] = option_quantity if option_quantity
+        params[:subscriptions] = [subs]
+        params
+      end
+
+      build_options do |o|
+        o.expand.except(:subscriptions)
+        o.without(:subscriptions)
+      end
+    end
+
     autoload_subcommands
   end
 end

--- a/test/functional/host/subscription/attach_test.rb
+++ b/test/functional/host/subscription/attach_test.rb
@@ -1,0 +1,54 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require File.join(File.dirname(__FILE__), '../host_helpers')
+
+describe 'host subscription attach' do
+  include HostHelpers
+
+  before do
+    @cmd = %w(host subscription attach)
+  end
+  it "attach a subscription to a host No Quantity" do
+    params = ['--host-id=3', '--subscription-id=100']
+    ex = api_expects(:host_subscriptions, :add_subscriptions, "attach host") do |par|
+      par['host_id'] == 3 && par[:subscriptions][0][:id].to_s == '100' &&
+        par[:subscriptions][0][:quantity].to_s == '1'
+    end
+    ex.returns({})
+
+    expected_result = success_result(
+      'Subscription attached to the host successfully
+'
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "attach a subscription to a host with Quantity" do
+    params = ['--host-id=3', '--subscription-id=100', "--quantity=10"]
+    ex = api_expects(:host_subscriptions, :add_subscriptions, "attach host") do |par|
+      par['host_id'] == 3 && par[:subscriptions][0][:id].to_s == '100' &&
+        par[:subscriptions][0][:quantity].to_s == '10'
+    end
+    ex.returns({})
+
+    expected_result = success_result(
+      'Subscription attached to the host successfully
+'
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "resolves id from name" do
+    params = ['--host=boo', '--subscription-id=100']
+    api_expects(:host_subscriptions, :add_subscriptions, "attach host") do |par|
+      par['host_id'].to_s == "3" && par[:subscriptions][0][:id].to_s == '100' &&
+        par[:subscriptions][0][:quantity].to_s == '1'
+    end
+    expect_host_search('boo', '3')
+
+    run_cmd(@cmd + params)
+  end
+end

--- a/test/functional/host/subscription/auto_attach_test.rb
+++ b/test/functional/host/subscription/auto_attach_test.rb
@@ -1,0 +1,35 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require File.join(File.dirname(__FILE__), '../host_helpers')
+
+describe 'host subscription auto-attach' do
+  include HostHelpers
+
+  before do
+    @cmd = %w(host subscription auto-attach)
+  end
+  it "auto-attach to a host" do
+    params = ['--host-id=3']
+    ex = api_expects(:host_subscriptions, :auto_attach, "auto-attach subs host") do |par|
+      par['host_id'] == 3
+    end
+    ex.returns({})
+
+    expected_result = success_result(
+      'Auto attached subscriptions to the host successfully
+'
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "resolves id from name" do
+    params = ['--host=boo']
+    api_expects(:host_subscriptions, :auto_attach, "auto-attach subs host") do |par|
+      par['host_id'].to_s == "3"
+    end
+    expect_host_search('boo', '3')
+
+    run_cmd(@cmd + params)
+  end
+end

--- a/test/functional/host/subscription/remove_test.rb
+++ b/test/functional/host/subscription/remove_test.rb
@@ -1,0 +1,52 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require File.join(File.dirname(__FILE__), '../host_helpers')
+
+describe 'host subscription remove' do
+  include HostHelpers
+
+  before do
+    @cmd = %w(host subscription remove)
+  end
+  it "remove a subscription to a host No Quantity" do
+    params = ['--host-id=3', '--subscription-id=100']
+    ex = api_expects(:host_subscriptions, :remove_subscriptions, "remove subs host") do |par|
+      par['host_id'] == 3 && par[:subscriptions][0][:id].to_s == '100'
+    end
+    ex.returns({})
+
+    expected_result = success_result(
+      'Subscription removed from the host successfully
+'
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "remove a subscription to a host with Quantity" do
+    params = ['--host-id=3', '--subscription-id=100', "--quantity=10"]
+    ex = api_expects(:host_subscriptions, :remove_subscriptions, "remove subs host") do |par|
+      par['host_id'] == 3 && par[:subscriptions][0][:id].to_s == '100' &&
+        par[:subscriptions][0][:quantity].to_s == '10'
+    end
+    ex.returns({})
+
+    expected_result = success_result(
+      'Subscription removed from the host successfully
+'
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "resolves id from name" do
+    params = ['--host=boo', '--subscription-id=100']
+    api_expects(:host_subscriptions, :remove_subscriptions, "remove subs host") do |par|
+      par['host_id'].to_s == "3" && par[:subscriptions][0][:id].to_s == '100'
+    end
+    expect_host_search('boo', '3')
+
+    run_cmd(@cmd + params)
+  end
+end


### PR DESCRIPTION
This commit adds functionality for the following calls
hammer host subscription attach --subscription-id=1000 --quantity=333 --host-id=1000
hammer host subscription remove --subscription-id=1000 --host-id=1000
hammer host subscription auto-attach --host-id=1000