### PR TITLE
Fixes #16101 - Update Gemfile and README setup info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ gemspec
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
-group :development, :test do
-  gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
-  gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'
-end
-
 group :test do
   gem 'rake', '~> 10.1.0'
   gem 'thor'
@@ -17,6 +12,9 @@ group :test do
   gem 'minitest-spec-context'
   gem 'mocha'
   gem 'coveralls', require: false
+
+  gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
+  gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'
 end
 
 # load local gemfile

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ First, cd into the directory where you typically keep your projects and where ha
 
 ```bash
 git clone https://github.com/Katello/hammer-cli-katello.git
+```
+
+Optionally, if you want to have git checkouts for hammer-cli-katello's dependencies, check these projects out:
+
+```
 git clone https://github.com/theforeman/hammer-cli.git
 git clone https://github.com/theforeman/hammer-cli-foreman.git
 git clone https://github.com/theforeman/hammer-cli-foreman-tasks.git
@@ -37,13 +42,22 @@ echo "hammer" > .ruby-gemset
 cd ..; cd -
 ```
 
-Before we bundle, we need to setup our local Gemfile. Edit `Gemfile.local.rb` in your hammer-cli-katello directory to point to the local projects instead of using the gems. Enter the following:
+Before we bundle, we need to setup our local Gemfile. Edit `Gemfile.local.rb` in your hammer-cli-katello directory to point to the local projects instead of using the gems. 
+
+If you're using local checkouts, enter the following:
 
 ```ruby
 # vim:ft=ruby
 gem 'hammer_cli', :path => '../hammer-cli'
 gem 'hammer_cli_foreman', :path => '../hammer-cli-foreman'
 gem 'hammer_cli_foreman_tasks', :path => '../hammer-cli-foreman-tasks'
+```
+
+Otherwise enter:
+
+```ruby
+gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
+gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'
 ```
 
 Now run bundler inside your hammer-cli-katello directory:


### PR DESCRIPTION
Looking for feedback on this. If you follow the setup instructions in the README, you get a bundler error:

```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that hammer_cli (>= 0) should come from https://github.com/theforeman/hammer-cli.git (at master) and source at `../hammer-cli`
. Bundler cannot continue.

 #  from /home/vagrant/Projects/hammer-cli-katello/Gemfile:25
 #  -------------------------------------------
 #    local_gemfile = File.join(File.dirname(__FILE__), file_name)
 >    self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
 #  end
 #  -------------------------------------------
```

It's because we specify git repo locations for hammer_cli and hammer_cli_foreman. This PR removes the development group and documents how developers can use either local checkouts or git repos via Gemfile.local. This should also simplify the hammer-devel playbook (see https://github.com/Katello/forklift/pull/273).