### PR TITLE
Refs #16101 - Remove gem git requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rvm:
   - 2.2
   - 2.3.1
 before_install:
+  - echo "gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'" > Gemfile.local
+  - echo "gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'" >> Gemfile.local
   - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,6 @@ group :test do
   gem 'minitest-spec-context'
   gem 'mocha'
   gem 'coveralls', require: false
-
-  gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'
-  gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'
 end
 
 # load local gemfile


### PR DESCRIPTION
The PR https://github.com/Katello/hammer-cli-katello/pull/442 didn't actually work because bundler won't let you specify different sources for a gem even if the gem requirements are in different groups. This PR simply writes out to Gemfile.local for travis using the git urls.