### PR TITLE
Fixes #14290 - Remove unneeded require

### DIFF
--- a/test/functional/content_view/create_test.rb
+++ b/test/functional/content_view/create_test.rb
@@ -1,8 +1,5 @@
 require_relative '../test_helper'
 
-# Workaround for issue #14289
-require 'hammer_cli_katello/content_view_puppet_module'
-
 describe 'content-view create' do
   before do
     @cmd = %w(content-view create)


### PR DESCRIPTION
#14289 is no longer an issue, so this workaround is no longer necessary.