### PR TITLE
Fixes #16677 - Add LifecycleEnvironment list/create/update tests

### DIFF
--- a/test/functional/lifecycle_environment/create_test.rb
+++ b/test/functional/lifecycle_environment/create_test.rb
@@ -1,0 +1,14 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/lifecycle_environment'
+
+module HammerCLIKatello
+  describe LifecycleEnvironmentCommand::CreateCommand do
+    it 'allows minimal options' do
+      api_expects(:lifecycle_environments, :create) do |p|
+        p['name'] == 'le1' && p['prior_id'] == '3' && p['organization_id'] == 1
+      end
+
+      run_cmd(%w(lifecycle-environment create --name le1 --prior-id 3 --organization-id 1))
+    end
+  end
+end

--- a/test/functional/lifecycle_environment/list_test.rb
+++ b/test/functional/lifecycle_environment/list_test.rb
@@ -1,0 +1,38 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/lifecycle_environment'
+
+module HammerCLIKatello
+  describe LifecycleEnvironmentCommand::ListCommand do
+    it 'allows minimal options' do
+      api_expects(:lifecycle_environments, :index)
+
+      run_cmd(%w(lifecycle-environment list))
+    end
+
+    describe 'allows organization' do
+      it 'id' do
+        api_expects(:lifecycle_environments, :index) { |p| p['organization_id'] == 1 }
+
+        run_cmd(%w(lifecycle-environment list --organization-id 1))
+      end
+
+      it 'name' do
+        api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+          .at_least_once.returns(index_response([{'id' => 1}]))
+
+        api_expects(:lifecycle_environments, :index) { |p| p['organization_id'] == 1 }
+
+        run_cmd(%w(lifecycle-environment list --organization org1))
+      end
+
+      it 'label' do
+        api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
+          .at_least_once.returns(index_response([{'id' => 1}]))
+
+        api_expects(:lifecycle_environments, :index) { |p| p['organization_id'] == 1 }
+
+        run_cmd(%w(lifecycle-environment list --organization-label org1))
+      end
+    end
+  end
+end

--- a/test/functional/lifecycle_environment/update_test.rb
+++ b/test/functional/lifecycle_environment/update_test.rb
@@ -1,0 +1,14 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/lifecycle_environment'
+
+module HammerCLIKatello
+  describe LifecycleEnvironmentCommand::UpdateCommand do
+    it 'allows minimal options' do
+      api_expects(:lifecycle_environments, :update) do |p|
+        p['new_name'] == 'le3' && p['id'] == 3
+      end
+
+      run_cmd(%w(lifecycle-environment update --id 3 --new-name le3))
+    end
+  end
+end


### PR DESCRIPTION
I'd like to at least have minimal options for most commands covered. Ideally, we'd verify that all options for each command are allowed, and the ones that are required are actually required.