### PR TITLE
Fixes #17067 - Removing from environment options

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -79,13 +79,6 @@ module HammerCLIKatello
              _("Name of the target environment"), :attribute_name => :option_to_environment_name
       option "--to-lifecycle-environment-id", "TO_ENVIRONMENT_ID",
              _("Id of the target environment"), :attribute_name => :option_to_environment_id
-      option "--from-lifecycle-environment", "FROM_ENVIRONMENT_ID",
-             _("Environment name from where to promote its version from (if version is unknown)"),
-             :attribute_name => :option_from_environment_name
-      option "--from-lifecycle-environment-id", "FROM_ENVIRONMENT_ID",
-             _(["Id of the environment from where to promote its version ",
-                "from (if version is unknown)"].join),
-               :attribute_name => :option_from_environment_id
 
       def environment_search_options
         {


### PR DESCRIPTION
Seems like the from_lifecycle_environment option doesn't actually do anything as this command succeeds:

```
hammer content-view version promote --id 9 --from-lifecycle-environment ENVTHATDOESNOTEXIST --to-lifecycle-environment Dev --organization-id 1
```

I can even run promote without the option:

```
hammer content-view version promote --id 9 --to-lifecycle-environment Test --organization-id 1
```