### PR TITLE
Fixes #17127 - Add org options to CV rule cmds

### DIFF
--- a/lib/hammer_cli_katello/filter_rule.rb
+++ b/lib/hammer_cli_katello/filter_rule.rb
@@ -5,6 +5,8 @@ module HammerCLIKatello
     desc 'View and manage filter rules'
 
     class ListCommand < HammerCLIKatello::ListCommand
+      include OrganizationOptions
+
       output do
         field :id, _("Rule ID")
         field :content_view_filter_id, _("Filter ID")
@@ -22,6 +24,8 @@ module HammerCLIKatello
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand
+      include OrganizationOptions
+
       output do
         field :id, _("Rule ID")
         field :content_view_filter_id, _("Filter ID")
@@ -43,6 +47,8 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
+      include OrganizationOptions
+
       success_message _("Filter rule created")
       failure_message _("Could not create the filter rule")
 
@@ -58,6 +64,8 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
+      include OrganizationOptions
+
       success_message _("Filter rule updated")
       failure_message _("Could not update the filter rule")
 
@@ -65,6 +73,8 @@ module HammerCLIKatello
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand
+      include OrganizationOptions
+
       success_message _("Filter rule deleted")
       failure_message _("Could not delete the filter rule")
 

--- a/test/functional/filter_rule/delete_test.rb
+++ b/test/functional/filter_rule/delete_test.rb
@@ -2,19 +2,24 @@ require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
-  describe FilterRule::CreateCommand do
+  describe FilterRule::DeleteCommand do
     it 'allows minimal options' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1)
+      api_expects(:content_view_filter_rules, :destroy) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --name rpm1))
+      run_cmd(%w(content-view filter rule delete --content-view-filter-id 1 --id 9))
     end
 
-    it 'allows multiple package names' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1 rpm2)
+    it 'resolves rule ID from rule name and filter ID' do
+      ex = api_expects(:content_view_filter_rules, :index) do |p|
+        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --names rpm1,rpm2))
+      ex.returns(index_response([{'id' => 9}]))
+
+      api_expects(:content_view_filter_rules, :destroy) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == 9
+      end
+      run_cmd(%w(content-view filter rule delete --content-view-filter-id 1 --name rule9))
     end
 
     it 'allows name resolution of filter with content-view-id' do
@@ -23,11 +28,11 @@ module HammerCLIKatello
       end
       ex.returns(index_response([{'id' => 1}]))
 
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+      api_expects(:content_view_filter_rules, :destroy) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --content-view-id 3
-                 --name rule9))
+      run_cmd(%w(content-view filter rule delete --content-view-filter cvf1 --content-view-id 3
+                 --id 9))
     end
 
     describe 'organization' do
@@ -42,11 +47,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :destroy) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-id 6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule delete --content-view-filter cvf1 --organization-id 6
+                   --content-view cv3 --id 9))
       end
 
       it 'name can be specified to resolve content view name' do
@@ -65,11 +70,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :destroy) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization org6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule delete --content-view-filter cvf1 --organization org6
+                   --content-view cv3 --id 9))
       end
 
       it 'label can be specified to resolve content view name' do
@@ -88,11 +93,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :destroy) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-label
-                   org6 --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule delete --content-view-filter cvf1 --organization-label
+                   org6 --content-view cv3 --id 9))
       end
     end
   end

--- a/test/functional/filter_rule/info_test.rb
+++ b/test/functional/filter_rule/info_test.rb
@@ -2,19 +2,24 @@ require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
-  describe FilterRule::CreateCommand do
+  describe FilterRule::InfoCommand do
     it 'allows minimal options' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1)
+      api_expects(:content_view_filter_rules, :show) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --name rpm1))
+      run_cmd(%w(content-view filter rule info --content-view-filter-id 1 --id 9))
     end
 
-    it 'allows multiple package names' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1 rpm2)
+    it 'resolves rule ID from rule name and filter ID' do
+      ex = api_expects(:content_view_filter_rules, :index) do |p|
+        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --names rpm1,rpm2))
+      ex.returns(index_response([{'id' => 9}]))
+
+      api_expects(:content_view_filter_rules, :show) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == 9
+      end
+      run_cmd(%w(content-view filter rule info --content-view-filter-id 1 --name rule9))
     end
 
     it 'allows name resolution of filter with content-view-id' do
@@ -23,11 +28,11 @@ module HammerCLIKatello
       end
       ex.returns(index_response([{'id' => 1}]))
 
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+      api_expects(:content_view_filter_rules, :show) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --content-view-id 3
-                 --name rule9))
+      run_cmd(%w(content-view filter rule info --content-view-filter cvf1 --content-view-id 3
+                 --id 9))
     end
 
     describe 'organization' do
@@ -42,11 +47,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :show) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-id 6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule info --content-view-filter cvf1 --organization-id 6
+                   --content-view cv3 --id 9))
       end
 
       it 'name can be specified to resolve content view name' do
@@ -65,11 +70,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :show) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization org6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule info --content-view-filter cvf1 --organization org6
+                   --content-view cv3 --id 9))
       end
 
       it 'label can be specified to resolve content view name' do
@@ -88,11 +93,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :show) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-label
-                   org6 --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule info --content-view-filter cvf1 --organization-label
+                   org6 --content-view cv3 --id 9))
       end
     end
   end

--- a/test/functional/filter_rule/list_test.rb
+++ b/test/functional/filter_rule/list_test.rb
@@ -2,32 +2,24 @@ require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
-  describe FilterRule::CreateCommand do
+  describe FilterRule::ListCommand do
     it 'allows minimal options' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1)
+      api_expects(:content_view_filter_rules, :index) do |p|
+        p['content_view_filter_id'] == 1
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --name rpm1))
+      run_cmd(%w(content-view filter rule list --content-view-filter-id 1))
     end
 
-    it 'allows multiple package names' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1 rpm2)
-      end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --names rpm1,rpm2))
-    end
-
-    it 'allows name resolution of filter with content-view-id' do
+    it 'allows name resolution with content-view-id' do
       ex = api_expects(:content_view_filters, :index) do |p|
         p['name'] == 'cvf1' && p['content_view_id'] == 3
       end
       ex.returns(index_response([{'id' => 1}]))
 
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+      api_expects(:content_view_filter_rules, :index) do |p|
+        p['content_view_filter_id'] == 1
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --content-view-id 3
-                 --name rule9))
+      run_cmd(%w(content-view filter rule list --content-view-filter cvf1 --content-view-id 3))
     end
 
     describe 'organization' do
@@ -42,11 +34,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :index) do |p|
+          p['content_view_filter_id'] == 1
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-id 6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule list --content-view-filter cvf1 --organization-id 6
+                   --content-view cv3))
       end
 
       it 'name can be specified to resolve content view name' do
@@ -65,11 +57,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :index) do |p|
+          p['content_view_filter_id'] == 1
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization org6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule list --content-view-filter cvf1 --organization org6
+                   --content-view cv3))
       end
 
       it 'label can be specified to resolve content view name' do
@@ -88,11 +80,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :index) do |p|
+          p['content_view_filter_id'] == 1
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-label
-                   org6 --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule list --content-view-filter cvf1 --organization-label
+                   org6 --content-view cv3))
       end
     end
   end

--- a/test/functional/filter_rule/update_test.rb
+++ b/test/functional/filter_rule/update_test.rb
@@ -2,19 +2,24 @@ require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
-  describe FilterRule::CreateCommand do
+  describe FilterRule::UpdateCommand do
     it 'allows minimal options' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1)
+      api_expects(:content_view_filter_rules, :update) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --name rpm1))
+      run_cmd(%w(content-view filter rule update --content-view-filter-id 1 --id 9))
     end
 
-    it 'allows multiple package names' do
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rpm1 rpm2)
+    it 'resolves rule ID from rule name and filter ID' do
+      ex = api_expects(:content_view_filter_rules, :index) do |p|
+        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter-id 1 --names rpm1,rpm2))
+      ex.returns(index_response([{'id' => 9}]))
+
+      api_expects(:content_view_filter_rules, :update) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == 9
+      end
+      run_cmd(%w(content-view filter rule update --content-view-filter-id 1 --name rule9))
     end
 
     it 'allows name resolution of filter with content-view-id' do
@@ -23,11 +28,11 @@ module HammerCLIKatello
       end
       ex.returns(index_response([{'id' => 1}]))
 
-      api_expects(:content_view_filter_rules, :create) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+      api_expects(:content_view_filter_rules, :update) do |p|
+        p['content_view_filter_id'] == 1 && p['id'] == '9'
       end
-      run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --content-view-id 3
-                 --name rule9))
+      run_cmd(%w(content-view filter rule update --content-view-filter cvf1 --content-view-id 3
+                 --id 9))
     end
 
     describe 'organization' do
@@ -42,11 +47,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :update) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-id 6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule update --content-view-filter cvf1 --organization-id 6
+                   --content-view cv3 --id 9))
       end
 
       it 'name can be specified to resolve content view name' do
@@ -65,11 +70,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :update) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization org6
-                   --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule update --content-view-filter cvf1 --organization org6
+                   --content-view cv3 --id 9))
       end
 
       it 'label can be specified to resolve content view name' do
@@ -88,11 +93,11 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:content_view_filter_rules, :create) do |p|
-          p['content_view_filter_id'] == 1 && p['name'] == %w(rule9)
+        api_expects(:content_view_filter_rules, :update) do |p|
+          p['content_view_filter_id'] == 1 && p['id'] == '9'
         end
-        run_cmd(%w(content-view filter rule create --content-view-filter cvf1 --organization-label
-                   org6 --content-view cv3 --name rule9))
+        run_cmd(%w(content-view filter rule update --content-view-filter cvf1 --organization-label
+                   org6 --content-view cv3 --id 9))
       end
     end
   end


### PR DESCRIPTION
Add organization options to all content view filter rule commands

Test with:

```sh
hammer content-view filter rule create --content-view cv17127 --organization-id 1 --content-view-filter filter1 --name rule6
hammer content-view filter rule list --content-view-filter filter1 --content-view cv17127 --organization-id 1
hammer content-view filter rule info --content-view cv17127 --organization-id 1 --content-view-filter filter1 --id 6
hammer content-view filter rule update --content-view cv17127 --organization-id 1 --content-view-filter filter1 --id 6 --new-name rule17127
hammer content-view filter rule delete --content-view cv17127 --organization-id 1 --content-view-filter filter1 --id 6 --id 6
```