### PR TITLE
Fixes #17619 - Provide correct org options in msg

### DIFF
--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -20,6 +20,16 @@ module HammerCLIKatello
         _('Organization name to search by'), attribute_name: :option_organization_name
       base.option '--query-organization-label', 'ORGANIZATION_LABEL',
         _('Organization label to search by'), attribute_name: :option_organization_label
+
+      base.validate_options do
+        organization_options = [
+          :option_organization_id, :option_organization_name, :option_organization_label
+        ]
+
+        if option(:option_lifecycle_environment_name).exist?
+          any(*organization_options).required
+        end
+      end
     end
   end
 

--- a/test/functional/hostgroup/create_test.rb
+++ b/test/functional/hostgroup/create_test.rb
@@ -50,6 +50,12 @@ module HammerCLIForeman
         run_cmd(%w(hostgroup create --name hg1 --lifecycle-environment le1
                    --query-organization-id 1 --organization-ids 1,2))
       end
+
+      it 'requires organization options to resolve lifecycle environment name' do
+        api_expects_no_call
+        result = run_cmd(%w(hostgroup create --name hg1 --lifecycle-environment le1))
+        assert_match(/--query-organization/, result.err)
+      end
     end
   end
 end

--- a/test/functional/hostgroup/update_test.rb
+++ b/test/functional/hostgroup/update_test.rb
@@ -50,6 +50,12 @@ module HammerCLIForeman
         run_cmd(%w(hostgroup update --id 1 --lifecycle-environment le1
                    --query-organization-id 1 --organization-ids 1,2))
       end
+
+      it 'requires organization options to resolve lifecycle environment name' do
+        api_expects_no_call
+        result = run_cmd(%w(hostgroup update --name hg1 --lifecycle-environment le1))
+        assert_match(/--query-organization/, result.err)
+      end
     end
   end
 end


### PR DESCRIPTION
Provide the correct organization options to the user when trying to
resolve lifecycle environment name when creating/updating a hostgroup