### PR TITLE
Fixes #8016 - API connection moved to context

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -1,6 +1,14 @@
 module HammerCLIKatello
   RESOURCE_NAME_MAPPING = {}.freeze
 
+  def self.api_connection
+    if HammerCLI.context[:api_connection]
+      HammerCLI.context[:api_connection].get("foreman")
+    else
+      HammerCLI::Connection.get("foreman").api
+    end
+  end
+
   module ResolverCommons
     def self.included(base)
       base.extend(ClassMethods)
@@ -8,8 +16,10 @@ module HammerCLIKatello
 
     module ClassMethods
       def resolver
-        api = HammerCLI::Connection.get("foreman").api
-        HammerCLIKatello::IdResolver.new(api, HammerCLIKatello::Searchables.new)
+        HammerCLIKatello::IdResolver.new(
+          HammerCLIKatello.api_connection,
+          HammerCLIKatello::Searchables.new
+        )
       end
 
       def searchables

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -172,13 +172,12 @@ module HammerCLIKatello
       end
 
       def resolver
-        api = HammerCLI::Connection.get("foreman").api
         custom_resolver = Class.new(HammerCLIKatello::IdResolver) do
           def hosts_bulk_action_id(options)
             host_collection_id(options)
           end
         end
-        custom_resolver.new(api, HammerCLIKatello::Searchables.new)
+        custom_resolver.new(HammerCLIKatello.api_connection, HammerCLIKatello::Searchables.new)
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,14 +16,23 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/setup'
 require 'hammer_cli'
-require 'hammer_cli_foreman/commands'
 
 KATELLO_VERSION = Gem::Version.new(ENV['TEST_API_VERSION'] || '3.2')
 
-HammerCLIForeman.stubs(:resource_config).returns(
-  :apidoc_cache_dir => 'test/data/' + KATELLO_VERSION.to_s,
-  :apidoc_cache_name => 'foreman_api',
-  :dry_run => true
-)
+if HammerCLI.context[:api_connection]
+  HammerCLI.context[:api_connection].create('foreman') do
+    HammerCLI::Apipie::ApiConnection.new(
+      :apidoc_cache_dir => 'test/data/' + KATELLO_VERSION.to_s,
+      :apidoc_cache_name => 'foreman_api',
+      :dry_run => true
+    )
+  end
+else
+  HammerCLIForeman.stubs(:resource_config).returns(
+    :apidoc_cache_dir => 'test/data/' + KATELLO_VERSION.to_s,
+    :apidoc_cache_name => 'foreman_api',
+    :dry_run => true
+  )
+end
 
 require 'hammer_cli_katello'


### PR DESCRIPTION
Makes hammer-cli-katello compatible with latest changes in hammer-cli related to session auth.