### PR TITLE
Fixes #17709 - Provide err msg for cv name in hg

### DIFF
--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -26,7 +26,8 @@ module HammerCLIKatello
           :option_organization_id, :option_organization_name, :option_organization_label
         ]
 
-        if option(:option_lifecycle_environment_name).exist?
+        if option(:option_lifecycle_environment_name).exist? ||
+           option(:option_content_view_name).exist?
           any(*organization_options).required
         end
       end

--- a/test/functional/hostgroup/create_test.rb
+++ b/test/functional/hostgroup/create_test.rb
@@ -31,6 +31,12 @@ module HammerCLIForeman
         run_cmd(%w(hostgroup create --name hg1 --content-view cv1 --query-organization-id 1))
       end
 
+      it 'requires organization options to resolve content view name' do
+        api_expects_no_call
+        result = run_cmd(%w(hostgroup create --name hg1 --content-view cv1))
+        assert_match(/--query-organization/, result.err)
+      end
+
       it 'allows lifecycle environment id' do
         api_expects(:hostgroups, :create) do |p|
           p['hostgroup']['name'] == 'hg1' && p['hostgroup']['lifecycle_environment_id'] == 1 &&

--- a/test/functional/hostgroup/update_test.rb
+++ b/test/functional/hostgroup/update_test.rb
@@ -31,6 +31,12 @@ module HammerCLIForeman
         run_cmd(%w(hostgroup update --id 1 --content-view cv1 --query-organization-id 1))
       end
 
+      it 'requires organization options to resolve content view name' do
+        api_expects_no_call
+        result = run_cmd(%w(hostgroup update --id 1 --content-view cv1))
+        assert_match(/--query-organization/, result.err)
+      end
+
       it 'allows lifecycle environment id' do
         api_expects(:hostgroups, :update) do |p|
           p['id'] == '1' && p['hostgroup']['lifecycle_environment_id'] == 1 &&
@@ -54,6 +60,12 @@ module HammerCLIForeman
       it 'requires organization options to resolve lifecycle environment name' do
         api_expects_no_call
         result = run_cmd(%w(hostgroup update --name hg1 --lifecycle-environment le1))
+        assert_match(/--query-organization/, result.err)
+      end
+
+      it 'requires organization options to resolve lifecycle environment name' do
+        api_expects_no_call
+        result = run_cmd(%w(hostgroup update --id 1 --lifecycle-environment le1))
         assert_match(/--query-organization/, result.err)
       end
     end


### PR DESCRIPTION
Provide proper error message to indicate required organization options
for content-view name in hostgroup create/update. These messages are
especially important for these commands because the organization options
are `--query-organization[-id|-label]` rather than just
`--organization[-id|-label]`.