### PR TITLE
Fixes #18352 - Remove CV from CVV search

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -27,10 +27,7 @@ module HammerCLIKatello
         s("author", _("Puppet module's author to search by")),
         s("uuid", _("Puppet module's UUID to search by"))
       ],
-      :content_view_version => [
-        s("version", _("Content view version number")),
-        s("content_view_id", _("Content view to search by"))
-      ]
+      :content_view_version => [s("version", _("Content view version number"))]
     }.freeze
 
     DEFAULT_SEARCHABLES = [s_name(_("Name to search by"))].freeze
@@ -101,6 +98,18 @@ module HammerCLIKatello
       if options[key_names].any?
         find_resources(:repositories, options)
           .select { |repo| options[key_names].include? repo['name'] }.map { |repo| repo['id'] }
+      end
+    end
+
+    def content_view_version_ids(options)
+      key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
+      if options['option_versions'] && options[key_content_view_id]
+        options[key_content_view_id] ||= search_and_rescue(:content_view_id,
+                                                           "content_view", options)
+        id_strings = options['option_versions'].map do |version|
+          content_view_version_id(options.merge('option_version' => version))
+        end
+        id_strings.join(',')
       end
     end
 

--- a/test/functional/content_view/add_content_view_version_test.rb
+++ b/test/functional/content_view/add_content_view_version_test.rb
@@ -16,7 +16,7 @@ module HammerCLIKatello
 
     it 'resolves content view version ID' do
       ex = api_expects(:content_view_versions, :index) do |p|
-        p['content_view_id'] == '3' && p['version'] == '2.1'
+        p['content_view_id'] == 3 && p['version'] == '2.1'
       end
       ex.returns(index_response([{'id' => 6}]))
       ex.returns('id' => 1, 'component_ids' => [1, 3])
@@ -27,8 +27,7 @@ module HammerCLIKatello
       api_expects(:content_views, :update) do |p|
         p['id'] == '1' && p['component_ids'] == %w(1 3 6)
       end
-      run_cmd(%w(content-view add-version --id 1 --content-view-version-content-view-id 3
-                 --content-view-version 2.1))
+      run_cmd(%w(content-view add-version --id 1 --content-view-id 3 --content-view-version 2.1))
     end
   end
 end

--- a/test/functional/content_view/remove_content_view_version_test.rb
+++ b/test/functional/content_view/remove_content_view_version_test.rb
@@ -16,7 +16,7 @@ module HammerCLIKatello
 
     it 'resolves content view version ID' do
       ex = api_expects(:content_view_versions, :index) do |p|
-        p['content_view_id'] == '3' && p['version'] == '2.1'
+        p['content_view_id'] == 3 && p['version'] == '2.1'
       end
       ex.returns(index_response([{'id' => 6}]))
       ex.returns('id' => 1, 'component_ids' => [1, 3, 6])
@@ -27,8 +27,7 @@ module HammerCLIKatello
       api_expects(:content_views, :update) do |p|
         p['id'] == '1' && p['component_ids'] == %w(1 3)
       end
-      run_cmd(%w(content-view remove-version --id 1 --content-view-version-content-view-id 3
-                 --content-view-version 2.1))
+      run_cmd(%w(content-view remove-version --id 1 --content-view-id 3 --content-view-version 2.1))
     end
   end
 end

--- a/test/functional/content_view/remove_test.rb
+++ b/test/functional/content_view/remove_test.rb
@@ -1,0 +1,78 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/content_view'
+
+module HammerCLIKatello
+  describe ContentView::RemoveCommand do
+    include ForemanTaskHelpers
+
+    describe 'content view version options' do
+      it 'allows removing versions by ID' do
+        ex = api_expects(:content_views, :remove) do |p|
+          p['id'] == 1 && p['content_view_version_ids'] == %w(6 7 8)
+        end
+        ex.returns(id: 9)
+
+        expect_foreman_task('9')
+
+        run_cmd(%w(content-view remove --id 1 --content-view-version-ids 6,7,8))
+      end
+
+      it 'allows removing versions by version number' do
+        %w(6.0 7.0 8.0).each do |version|
+          ex = api_expects(:content_view_versions, :index) do |p|
+            p['version'] == version && p['content_view_id'] == 1
+          end
+          ex.returns(index_response('id' => version.to_i))
+        end
+        ex = api_expects(:content_views, :remove) do |p|
+          p['id'] == 1 && p['content_view_version_ids'] == %w(6 7 8)
+        end
+        ex.returns(id: 9)
+
+        expect_foreman_task('9')
+
+        run_cmd(%w(content-view remove --id 1 --content-view-versions 6.0,7.0,8.0))
+      end
+    end
+
+    describe 'environment options' do
+      it 'allows removing versions by ID' do
+        ex = api_expects(:content_views, :remove) do |p|
+          p['id'] == 1 && p['environment_ids'] == %w(6 7 8)
+        end
+        ex.returns(id: 9)
+
+        expect_foreman_task('9')
+
+        run_cmd(%w(content-view remove --id 1 --environment-ids 6,7,8))
+      end
+
+      it 'requires organization options when removing environments by name' do
+        api_expects_no_call
+
+        run_cmd(%w(content-view remove --id 1 --environments env6,env7,env8))
+      end
+
+      it 'allows removing environments by name' do
+        environment_ids = [6, 7, 8]
+        all_environment_ids = [3, 4, 5, 6, 7, 8]
+
+        ex = api_expects(:lifecycle_environments, :index) do |p|
+          p['organization_id'] == '1'
+        end
+        ex.returns(index_response(all_environment_ids.map do |id|
+          {'id' => id, 'name' => "env#{id}"}
+        end))
+
+        ex = api_expects(:content_views, :remove) do |p|
+          p['id'] == 1 && p['environment_ids'] == environment_ids
+        end
+        ex.returns(id: 9)
+
+        expect_foreman_task('9')
+
+        run_cmd(%w(content-view remove --id 1 --environments env6,env7,env8 --organization-id 1))
+      end
+    end
+  end
+end

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -9,6 +9,7 @@ module HammerCLIKatello
 
     before(:each) do
       api.stubs(:resources).returns([])
+      api.stubs(:resource).returns([])
     end
 
     describe '#repository_ids' do
@@ -41,6 +42,31 @@ module HammerCLIKatello
         id_resolver.expects(:find_resource).with(:repositories, name: 'repo1').returns('id' => 5)
         options = {name: 'repo1'}
         id_resolver.repository_id(options).must_equal 5
+      end
+    end
+
+    describe '#content_view_version_id' do
+      it 'resolves ID from version number' do
+        options = {'option_version' => '2.0', 'option_content_view_id' => 4}
+        id_resolver.expects(:find_resources)
+                   .with(:content_view_versions, options)
+                   .returns(['id' => 5])
+        id_resolver.content_view_version_id(options).must_equal 5
+      end
+    end
+
+    describe '#content_view_version_ids' do
+      it 'resolves IDs from version numbers' do
+        versions = %w(2.0 3.0)
+        version_ids = [2, 3]
+        response = "{\"id\"=>2},{\"id\"=>3}"
+        options = {'option_versions' => versions, 'option_content_view_id' => 4}
+        versions.each_with_index do |version, i|
+          id_resolver.expects(:content_view_version_id)
+                     .with(options.merge('option_version' => version))
+                     .returns(['id' => version_ids[i]])
+        end
+        id_resolver.content_view_version_ids(options).must_equal response
       end
     end
   end


### PR DESCRIPTION
Remove content view from content view version search parameters in the
ID resolver. Fix content-view remove command to properly resolve content
view version numbers, and add tests around the main content-view remove
functionality.