### PR TITLE
Fixes #18523 - hostgroup info is not showing content-related fields

### DIFF
--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -53,6 +53,7 @@ module HammerCLIKatello
       output do
         field :content_view_name, _('Content View')
         field :lifecycle_environment_name, _('Lifecycle Environment')
+        field :content_source_name, _('Content Source')
       end
     end
   end

--- a/test/functional/hostgroup/data/hostgroup.json
+++ b/test/functional/hostgroup/data/hostgroup.json
@@ -1,6 +1,6 @@
 {
-	"content_source_id":null,
-	"content_source_name":null,
+	"content_source_id":1,
+	"content_source_name":"foreman.example.com",
 	"content_view_id":1,
 	"content_view_name":"Default Organization View",
 	"lifecycle_environment_id":1,

--- a/test/functional/hostgroup/info_test.rb
+++ b/test/functional/hostgroup/info_test.rb
@@ -21,7 +21,8 @@ module HammerCLIForeman
 
         result = run_cmd(@cmd + params)
         expected_fields = [['Lifecycle Environment', 'Library'],
-                           ['Content View', 'Default Organization View']]
+                           ['Content View', 'Default Organization View'],
+                           ['Content Source', 'foreman.example.com']]
         expected_results = expected_fields.map { |field| success_result(FieldMatcher.new(*field)) }
         expected_results.each { |expected|  assert_cmd(expected, result) }
       end


### PR DESCRIPTION
This adds 'Content Source' field to 'hammer hostgroup info' command. 