### PR TITLE
Fixes #18499 - Hammer CV filter rule accepts PackageGroup UUID

### DIFF
--- a/lib/hammer_cli_katello/package_group.rb
+++ b/lib/hammer_cli_katello/package_group.rb
@@ -5,7 +5,14 @@ module HammerCLIKatello
     class ListCommand < HammerCLIKatello::ListCommand
       output do
         field :id, _("ID")
-        field :name, _("Name")
+        field :name, _("Package Group Name")
+        field :repo_name, _("Repository Name")
+        field :uuid, _("UUID")
+      end
+
+      def extend_data(data)
+        data["repo_name"] = data["repository"]["name"]
+        data
       end
 
       build_options do |o|
@@ -16,12 +23,19 @@ module HammerCLIKatello
     class InfoCommand < HammerCLIKatello::InfoCommand
       output do
         field :id, _("ID")
-        field :name, _("Name")
+        field :name, _("Package Group Name")
+        field :repo_name, _("Repository Name")
+        field :uuid, _("UUID")
         field :description, _("Description")
         field :default_package_names, _("Default Packages"), Fields::List
         field :mandatory_package_names, _("Mandatory Packages"), Fields::List
         field :conditional_package_names, _("Conditional Packages"), Fields::List
         field :optional_package_names, _("Optional Packages"), Fields::List
+      end
+
+      def extend_data(data)
+        data["repo_name"] = data["repository"]["name"]
+        data
       end
 
       build_options

--- a/test/functional/package_group/list_test.rb
+++ b/test/functional/package_group/list_test.rb
@@ -1,0 +1,33 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/package_group'
+
+module HammerCLIKatello
+  describe PackageGroupCommand::ListCommand do
+    it 'allows minimal options' do
+      api_expects(:package_groups, :index)
+
+      run_cmd(%w(package-group list))
+    end
+
+    it 'can be provided by repository ID' do
+      api_expects(:package_groups, :index) do |params|
+        params['repository_id'] == 1
+      end
+
+      run_cmd(%w(package-group list --repository-id 1))
+    end
+
+    it 'can be provided by repository name' do
+      ex = api_expects(:repositories, :index) do |params|
+        params['name'] = 'Repo'
+      end
+      ex.returns(index_response([{'id' => 1}]))
+
+      api_expects(:package_groups, :index) do |params|
+        params['repository_id'] == 1
+      end
+
+      run_cmd(%w(package-group list --repository Repo))
+    end
+  end
+end


### PR DESCRIPTION
This is the second part of the fix from the Hammer CLI end which now accepts PackageGroup UUID as parameter. 

Also see https://github.com/Katello/katello/pull/6613