### PR TITLE
Fixes #15555 - Add org opts to repo commands

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -158,9 +158,19 @@ module HammerCLIKatello
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
       include RepositoryScopedToProduct
+      include OrganizationOptions
 
       success_message _("Repository updated")
       failure_message _("Could not update the repository")
+
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+      end
 
       build_options(:without => [:unprotected]) do |o|
         o.expand.including(:products)
@@ -311,25 +321,50 @@ module HammerCLIKatello
     end
 
     class RemoveContentCommand < HammerCLIKatello::SingleResourceCommand
-      resource :repositories, :remove_content
+      include RepositoryScopedToProduct
+      include OrganizationOptions
+
+      action :remove_content
       command_name "remove-content"
       desc _("Remove content from a repository")
 
       success_message _("Repository content removed")
       failure_message _("Could not remove content")
 
-      build_options
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+      end
+
+      build_options do |o|
+        o.expand.including(:products)
+      end
     end
 
     class ExportCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async
       include RepositoryScopedToProduct
+      include OrganizationOptions
 
       action :export
       command_name "export"
+      desc _("Export content from a repository to the configured directory")
 
       success_message _("Repository is being exported in task %{id}")
       failure_message _("Could not export the repository")
+
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+      end
 
       build_options do |o|
         o.expand.including(:products)

--- a/test/functional/repository/export_test.rb
+++ b/test/functional/repository/export_test.rb
@@ -3,21 +3,25 @@ require_relative '../organization/organization_helpers'
 require 'hammer_cli_katello/repository'
 
 module HammerCLIKatello
-  describe Repository::RemoveContentCommand do
+  describe Repository::ExportCommand do
+    include ForemanTaskHelpers
     include OrganizationHelpers
 
     it 'allows minimal options' do
-      api_expects(:repositories, :remove_content) do |p|
-        p['id'] == '1' && p['ids'] == %w(20 21 22)
+      ex = api_expects(:repositories, :export) do |p|
+        p['id'] == '1'
       end
+      ex.returns(id: 2)
 
-      run_cmd(%w(repository remove-content --id 1 --ids 20,21,22))
+      expect_foreman_task('2')
+
+      run_cmd(%w(repository export --id 1))
     end
 
     describe 'resolves repository ID' do
       it 'by requiring product' do
         api_expects_no_call
-        result = run_cmd(%w(repository remove-content --name repo1 --ids 20,21,22))
+        result = run_cmd(%w(repository export --name repo1))
         assert(result.err[/--product, --product-id is required/], 'Incorrect error message')
       end
 
@@ -27,18 +31,21 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        ex = api_expects(:repositories, :export) do |p|
+          p['id'] == 1
         end
+        ex.returns(id: 2)
 
-        run_cmd(%w(repository remove-content --name repo1 --product-id 3 --ids 20,21,22))
+        expect_foreman_task('2')
+
+        run_cmd(%w(repository export --name repo1 --product-id 3))
       end
     end
 
     describe 'resolves product ID' do
       it 'by requiring organization options' do
         api_expects_no_call
-        result = run_cmd(%w(repository remove-content --name repo1 --product prod1 --ids 20,21,22))
+        result = run_cmd(%w(repository export --name repo1 --product prod1))
         assert(result.err[/--organization-id, --organization, --organization-label is required/],
                "Organization option requirements must be validated")
       end
@@ -54,12 +61,14 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        ex = api_expects(:repositories, :export) do |p|
+          p['id'] == 1
         end
+        ex.returns(id: 2)
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization-id 5
-                   --ids 20,21,22))
+        expect_foreman_task('2')
+
+        run_cmd(%w(repository export --name repo1 --product prod3 --organization-id 5))
       end
 
       it 'by organization name' do
@@ -75,12 +84,14 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        ex = api_expects(:repositories, :export) do |p|
+          p['id'] == 1
         end
+        ex.returns(id: 2)
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization org5
-                   --ids 20,21,22))
+        expect_foreman_task('2')
+
+        run_cmd(%w(repository export --name repo1 --product prod3 --organization org5))
       end
 
       it 'by organization label' do
@@ -96,12 +107,14 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        ex = api_expects(:repositories, :export) do |p|
+          p['id'] == 1
         end
+        ex.returns(id: 2)
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization-label org5
-                   --ids 20,21,22))
+        expect_foreman_task('2')
+
+        run_cmd(%w(repository export --name repo1 --product prod3 --organization-label org5))
       end
     end
   end

--- a/test/functional/repository/update_test.rb
+++ b/test/functional/repository/update_test.rb
@@ -3,21 +3,21 @@ require_relative '../organization/organization_helpers'
 require 'hammer_cli_katello/repository'
 
 module HammerCLIKatello
-  describe Repository::RemoveContentCommand do
+  describe Repository::UpdateCommand do
     include OrganizationHelpers
 
     it 'allows minimal options' do
-      api_expects(:repositories, :remove_content) do |p|
-        p['id'] == '1' && p['ids'] == %w(20 21 22)
+      api_expects(:repositories, :update) do |p|
+        p['id'] == '1' && p['name'] == 'rep1'
       end
 
-      run_cmd(%w(repository remove-content --id 1 --ids 20,21,22))
+      run_cmd(%w(repository update --id 1 --new-name rep1))
     end
 
     describe 'resolves repository ID' do
       it 'by requiring product' do
         api_expects_no_call
-        result = run_cmd(%w(repository remove-content --name repo1 --ids 20,21,22))
+        result = run_cmd(%w(repository update --name repo1 --new-name rep1))
         assert(result.err[/--product, --product-id is required/], 'Incorrect error message')
       end
 
@@ -27,18 +27,18 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        api_expects(:repositories, :update) do |p|
+          p['id'] == 1 && p['name'] == 'rep1'
         end
 
-        run_cmd(%w(repository remove-content --name repo1 --product-id 3 --ids 20,21,22))
+        run_cmd(%w(repository update --name repo1 --product-id 3 --new-name rep1))
       end
     end
 
     describe 'resolves product ID' do
       it 'by requiring organization options' do
         api_expects_no_call
-        result = run_cmd(%w(repository remove-content --name repo1 --product prod1 --ids 20,21,22))
+        result = run_cmd(%w(repository update --name repo1 --product prod1 --new-name rep1))
         assert(result.err[/--organization-id, --organization, --organization-label is required/],
                "Organization option requirements must be validated")
       end
@@ -54,12 +54,12 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        api_expects(:repositories, :update) do |p|
+          p['id'] == 1 && p['name'] == 'rep1'
         end
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization-id 5
-                   --ids 20,21,22))
+        run_cmd(%w(repository update --name repo1 --product prod3 --organization-id 5
+                   --new-name rep1))
       end
 
       it 'by organization name' do
@@ -75,12 +75,12 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        api_expects(:repositories, :update) do |p|
+          p['id'] == 1 && p['name'] == 'rep1'
         end
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization org5
-                   --ids 20,21,22))
+        run_cmd(%w(repository update --name repo1 --product prod3 --organization org5
+                   --new-name rep1))
       end
 
       it 'by organization label' do
@@ -96,12 +96,12 @@ module HammerCLIKatello
         end
         ex.returns(index_response([{'id' => 1}]))
 
-        api_expects(:repositories, :remove_content) do |p|
-          p['id'] == 1 && p['ids'] == %w(20 21 22)
+        api_expects(:repositories, :update) do |p|
+          p['id'] == 1 && p['name'] == 'rep1'
         end
 
-        run_cmd(%w(repository remove-content --name repo1 --product prod3 --organization-label org5
-                   --ids 20,21,22))
+        run_cmd(%w(repository update --name repo1 --product prod3 --organization-label org5
+                   --new-name rep1))
       end
     end
   end


### PR DESCRIPTION
Add organization options to the `export`, `remove-content`, and `update`
repository subcommands