### PR TITLE
Fixes #18785 - Hammer not showing errata as installable

### DIFF
--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -21,7 +21,7 @@ module HammerCLIKatello
         field :errata_id, _("Erratum ID")
         field :type, _("Type")
         field :title, _("Title")
-        field :available, _("Installable")
+        field :installable, _("Installable")
       end
 
       build_options


### PR DESCRIPTION
Checked the API output, it returns installable