### PR TITLE
Fixes #18923 - Allow ID in puppet module remove

### DIFF
--- a/lib/hammer_cli_katello/content_view_puppet_module.rb
+++ b/lib/hammer_cli_katello/content_view_puppet_module.rb
@@ -53,22 +53,7 @@ module HammerCLIKatello
       success_message _("Puppet module removed from content view")
       failure_message _("Couldn't remove puppet module from the content view")
 
-      def resolve_puppet_module_id_from_uuid(options)
-        uuid = options.delete HammerCLI.option_accessor_name("id")
-        options[HammerCLI.option_accessor_name("uuid")] = uuid
-        resolver.content_view_puppet_module_id(options)
-      end
-
-      def all_options
-        if super['option_id']
-          super.merge(HammerCLI.option_accessor_name("id") =>
-                      resolve_puppet_module_id_from_uuid(super))
-        else
-          super
-        end
-      end
-
-      build_options :without => :uuid
+      build_options
     end
 
     autoload_subcommands

--- a/test/functional/content_view/content_view_helpers.rb
+++ b/test/functional/content_view/content_view_helpers.rb
@@ -1,8 +1,14 @@
+require_relative '../search_helpers'
+
 module ContentViewHelpers
+  include SearchHelpers
+
   def expect_content_view_search(org_id, name, id)
-    ex = api_expects(:content_views, :index, 'Find the content view') do |par|
-      par['name'] == name && par['organization_id'] == org_id
-    end
-    ex.returns(index_response([{'id' => id}]))
+    expect_generic_content_view_search(params: {'name' => name, 'organization_id' => org_id},
+                                       returns: {'id' => id})
+  end
+
+  def expect_generic_content_view_search(args)
+    expect_generic_search(:content_views, args)
   end
 end

--- a/test/functional/content_view/puppet_module/remove_test.rb
+++ b/test/functional/content_view/puppet_module/remove_test.rb
@@ -1,0 +1,54 @@
+require_relative '../../test_helper'
+require_relative '../../content_view/content_view_helpers'
+require_relative '../../organization/organization_helpers'
+require 'hammer_cli_katello/content_view_puppet_module'
+
+module HammerCLIKatello
+  describe ContentViewPuppetModule::DeleteCommand do
+    include ContentViewHelpers
+    include OrganizationHelpers
+
+    def expect_module_destroy(opts)
+      api_expects(:content_view_puppet_modules, :destroy).with_params(opts[:params])
+    end
+
+    it 'allows minimal options' do
+      expect_module_destroy(params: {'content_view_id' => 1, 'id' => '2'})
+
+      run_cmd(%w(content-view puppet-module remove --content-view-id 1 --id 2))
+    end
+
+    it 'resolves puppet module ID from UUID' do
+      expect_generic_search(:content_view_puppet_modules,
+                            params: {'uuid' => 'abcd1234', 'content_view_id' => 1},
+                            returns: {'id' => 2})
+      expect_module_destroy(params: {'content_view_id' => 1, 'id' => 2})
+
+      run_cmd(%w(content-view puppet-module remove --content-view-id 1 --uuid abcd1234))
+    end
+
+    it 'resolves content view ID from name' do
+      expect_content_view_search('3', 'cv1', 1)
+      expect_module_destroy(params: {'content_view_id' => 1, 'id' => '2'})
+
+      run_cmd(%w(content-view puppet-module remove --content-view cv1 --organization-id 3 --id 2))
+    end
+
+    it 'resolves organization ID from name' do
+      expect_organization_search('org3', 3)
+      expect_content_view_search(3, 'cv1', 1)
+      expect_module_destroy(params: {'content_view_id' => 1, 'id' => '2'})
+
+      run_cmd(%w(content-view puppet-module remove --content-view cv1 --organization org3 --id 2))
+    end
+
+    it 'resolves organization ID from label' do
+      expect_organization_search('org3', 3, field: 'label')
+      expect_content_view_search(3, 'cv1', 1)
+      expect_module_destroy(params: {'content_view_id' => 1, 'id' => '2'})
+
+      run_cmd(%w(content-view puppet-module remove --content-view cv1 --organization-label
+                 org3 --id 2))
+    end
+  end
+end

--- a/test/functional/search_helpers.rb
+++ b/test/functional/search_helpers.rb
@@ -1,0 +1,6 @@
+module SearchHelpers
+  def expect_generic_search(resource, args)
+    ex = api_expects(resource, :index, "Find the #{resource}").with_params(args[:params])
+    ex.returns(index_response([args[:returns]]))
+  end
+end


### PR DESCRIPTION
Allow passing puppet module ID *or* UUID to remove a puppet module from
a content view