### PR TITLE
Fixes #20046 - Allow content view options

### DIFF
--- a/lib/hammer_cli_katello/package.rb
+++ b/lib/hammer_cli_katello/package.rb
@@ -13,18 +13,30 @@ module HammerCLIKatello
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
         product_options = [:option_product_id, :option_product_name]
+        content_view_options = [:option_content_view_id, :option_content_view_name]
 
-        if option(:option_product_name).exist?
+        if option(:option_product_name).exist? || option(:option_content_view_name).exist?
           any(*organization_options).required
         end
 
         if option(:option_repository_name).exist?
           any(*product_options).required
         end
+
+        if option(:option_content_view_version_version).exist?
+          any(*content_view_options).required
+        end
+
+        if any(*content_view_options).exist?
+          any(:option_content_view_version_id,
+              :option_content_view_version_version,
+              :option_environment_id,
+              :option_environment_name).required
+        end
       end
 
       build_options do |o|
-        o.expand.including(:products)
+        o.expand.including(:products, :content_views)
       end
     end
 


### PR DESCRIPTION
Providing organization_id results in the following error:

```sh
$ hammer package list --organization-id 1
Error: found more than one repository
```

This issue is tracked [in 20091](http://projects.theforeman.org/issues/20091) and affects content view ID resolution because organization ID is required; however, the user has the option to use content view ID instead of name.

I used this opportunity to update the package/list_test.rb tests to use the new `with_params()` syntax rather than the params block for easier to read test error output.