### PR TITLE
Fixes #20091 - Require product to resolve repo

### DIFF
--- a/lib/hammer_cli_katello/filter.rb
+++ b/lib/hammer_cli_katello/filter.rb
@@ -67,13 +67,20 @@ module HammerCLIKatello
       validate_options do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
+        product_options = [:option_product_id, :option_product_name]
 
-        if option(:option_repository_names).exist? || option(:option_content_view_name).exist?
+        if option(:option_product_name).exist? || option(:option_content_view_name).exist?
           any(*organization_options).required
+        end
+
+        if option(:option_repository_names).exist?
+          any(*product_options).required
         end
       end
 
-      build_options
+      build_options do |o|
+        o.expand.including(:products)
+      end
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -4,27 +4,15 @@ module HammerCLIKatello
   module SearchOptionsCreators
     include HammerCLIKatello::ForemanSearchOptionsCreators
 
-    def create_repository_search_options(options)
-      name = options[HammerCLI.option_accessor_name("name")]
-      organization_id = options[HammerCLI.option_accessor_name("organization_id")]
-
-      search_options = {}
-      search_options['name'] = name if name
-      search_options['organization_id'] = organization_id if organization_id
-      search_options
-    end
-
     def create_repositories_search_options(options)
       name = options[HammerCLI.option_accessor_name("name")]
       names = options[HammerCLI.option_accessor_name("names")]
       product_id = options[HammerCLI.option_accessor_name("product_id")]
-      organization_id = options[HammerCLI.option_accessor_name("organization_id")]
 
       search_options = {}
       search_options['name'] = name if name
       search_options['names'] = names if names
       search_options['product_id'] = product_id if product_id
-      search_options['organization_id'] = organization_id if organization_id
       search_options
     end
 

--- a/test/functional/package/list_test.rb
+++ b/test/functional/package/list_test.rb
@@ -78,11 +78,9 @@ module HammerCLIKatello
       it 'allows organization ID when resolving ID by name' do
         expect_product_search(3, 'product1', 1)
 
-        expect_repository_search(1, nil, 2)
+        expect_generic_repositories_search({'product_id' => 1}, [{'id' => 2}])
 
-        api_expects(:packages, :index) do |p|
-          p['repository_id'] = 2
-        end
+        api_expects(:packages, :index).with_params('repository_id' => 2)
 
         run_cmd(%w(package list --product product1 --organization-id 3))
       end
@@ -92,11 +90,9 @@ module HammerCLIKatello
 
         expect_product_search(3, 'product1', 1)
 
-        expect_repository_search(1, nil, 2)
+        expect_generic_repositories_search({'product_id' => 1}, [{'id' => 2}])
 
-        api_expects(:packages, :index) do |p|
-          p['repository_id'] = 2
-        end
+        api_expects(:packages, :index).with_params('repository_id' => 2)
 
         run_cmd(%w(package list --product product1 --organization org3))
       end
@@ -106,11 +102,9 @@ module HammerCLIKatello
 
         expect_product_search(3, 'product1', 1)
 
-        expect_repository_search(1, nil, 2)
+        expect_generic_repositories_search({'product_id' => 1}, [{'id' => 2}])
 
-        api_expects(:packages, :index) do |p|
-          p['repository_id'] = 2
-        end
+        api_expects(:packages, :index).with_params('repository_id' => 2)
 
         run_cmd(%w(package list --product product1 --organization-label org3))
       end

--- a/test/functional/repository/delete_test.rb
+++ b/test/functional/repository/delete_test.rb
@@ -16,10 +16,9 @@ module HammerCLIKatello
       end
 
       it 'can be specified via product id' do
-        ex = api_expects(:repositories, :index) do |p|
-          p['product_id'] == 3 && p['name'] == 'repo1'
-        end
-        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:repositories, :index)
+          .with_params('product_id' => 3, 'name' => 'repo1')
+          .returns(index_response([{'id' => 1}]))
 
         api_expects(:repositories, :destroy) { |p| p['id'] == 1 }
 
@@ -27,15 +26,13 @@ module HammerCLIKatello
       end
 
       it 'can be specified via product name' do
-        ex = api_expects(:products, :index) do |p|
-          p['organization_id'] == '6' && p['name'] == 'product3'
-        end
-        ex.returns(index_response([{'id' => 3}]))
+        api_expects(:products, :index)
+          .with_params('organization_id' => '6', 'name' => 'product3')
+          .returns(index_response([{'id' => 3}]))
 
-        ex = api_expects(:repositories, :index) do |p|
-          p['product_id'] == 3 && p['name'] == 'repo1' && p['organization_id'] == '6'
-        end
-        ex.returns(index_response([{'id' => 1}]))
+        api_expects(:repositories, :index)
+          .with_params('product_id' => 3, 'name' => 'repo1')
+          .returns(index_response([{'id' => 1}]))
 
         api_expects(:repositories, :destroy) { |p| p['id'] == 1 }
 
@@ -44,31 +41,31 @@ module HammerCLIKatello
 
       describe 'organization options' do
         it 'can be specified by organization id' do
-          ex = api_expects(:repositories, :index) do |p|
-            p['product_id'] == 3 && p['name'] == 'repo1' && p['organization_id'] == '6'
-          end
-          ex.returns(index_response([{'id' => 1}]))
+          api_expects(:products, :index)
+            .with_params('organization_id' => '6', 'name' => 'product3')
+            .returns(index_response([{'id' => 3}]))
+
+          api_expects(:repositories, :index)
+            .with_params('product_id' => 3, 'name' => 'repo1')
+            .returns(index_response([{'id' => 1}]))
 
           api_expects(:repositories, :destroy) { |p| p['id'] == 1 }
 
-          run_cmd(%w(repository delete --name repo1 --product-id 3 --organization-id 6))
+          run_cmd(%w(repository delete --name repo1 --product product3 --organization-id 6))
         end
 
         it 'can be specified by organization name' do
-          ex = api_expects(:organizations, :index) do |p|
-            p[:search] == "name = \"org6\""
-          end
-          ex.returns(index_response([{'id' => 6}]))
+          api_expects(:organizations, :index)
+            .with_params(:search => "name = \"org6\"")
+            .returns(index_response([{'id' => 6}]))
 
-          ex = api_expects(:products, :index) do |p|
-            p['organization_id'] == 6 && p['name'] == 'product3'
-          end
-          ex.returns(index_response([{'id' => 3}]))
+          api_expects(:products, :index)
+            .with_params('organization_id' => 6, 'name' => 'product3')
+            .returns(index_response([{'id' => 3}]))
 
-          ex = api_expects(:repositories, :index) do |p|
-            p['product_id'] == 3 && p['name'] == 'repo1'
-          end
-          ex.returns(index_response([{'id' => 1}]))
+          api_expects(:repositories, :index)
+            .with_params('product_id' => 3, 'name' => 'repo1')
+            .returns(index_response([{'id' => 1}]))
 
           api_expects(:repositories, :destroy) { |p| p['id'] == 1 }
 
@@ -76,20 +73,17 @@ module HammerCLIKatello
         end
 
         it 'can be specified by organization label' do
-          ex = api_expects(:organizations, :index) do |p|
-            p[:search] == "label = \"org6\""
-          end
-          ex.returns(index_response([{'id' => 6}]))
+          api_expects(:organizations, :index)
+            .with_params(:search => "label = \"org6\"")
+            .returns(index_response([{'id' => 6}]))
 
-          ex = api_expects(:products, :index) do |p|
-            p['organization_id'] == 6 && p['name'] == 'product3'
-          end
-          ex.returns(index_response([{'id' => 3}]))
+          api_expects(:products, :index)
+            .with_params('organization_id' => 6, 'name' => 'product3')
+            .returns(index_response([{'id' => 3}]))
 
-          ex = api_expects(:repositories, :index) do |p|
-            p['product_id'] == 3 && p['name'] == 'repo1'
-          end
-          ex.returns(index_response([{'id' => 1}]))
+          api_expects(:repositories, :index)
+            .with_params('product_id' => 3, 'name' => 'repo1')
+            .returns(index_response([{'id' => 1}]))
 
           api_expects(:repositories, :destroy) { |p| p['id'] == 1 }
 

--- a/test/functional/repository/repository_helpers.rb
+++ b/test/functional/repository/repository_helpers.rb
@@ -1,15 +1,18 @@
 module RepositoryHelpers
   def expect_repository_search(product_id, name, id)
-    ex = api_expects(:repositories, :index, 'Find a repository') do |par|
-      par['name'] == name && par['product_id'] == product_id
-    end
-    ex.returns(index_response([{'id' => id}]))
+    api_expects(:repositories, :index, 'Find a repository')
+      .with_params('name' => name, 'product_id' => product_id)
+      .returns(index_response([{'id' => id}]))
   end
 
   def expect_repositories_search(org_id, names, ids)
-    ex = api_expects(:repositories, :index, 'Find repositories') do |par|
-      par['names'] == names && par['organization_id'] == org_id
-    end
-    ex.returns(index_response(ids.zip(names).map { |id, name| { 'id' => id, 'name' => name } }))
+    expect_generic_repositories_search({'names' => names, 'organization_id' => org_id},
+      ids.zip(names).map { |id, name| { 'id' => id, 'name' => name } })
+  end
+
+  def expect_generic_repositories_search(params = {}, returns = [])
+    api_expects(:repositories, :index, 'Find repositories')
+      .with_params(params)
+      .returns(index_response(returns))
   end
 end

--- a/test/unit/search_options_creators_test.rb
+++ b/test/unit/search_options_creators_test.rb
@@ -20,20 +20,6 @@ describe HammerCLIKatello::SearchOptionsCreators do
     resource.stubs(:singular_name).returns('')
   end
 
-  describe '#create_repository_search_options' do
-    it 'handles a repository' do
-      search_options_creators.create_repository_search_options(
-        'option_name' => 'repo1'
-      )['name'].must_equal 'repo1'
-    end
-
-    it 'handles an organization_id' do
-      search_options_creators.create_repository_search_options(
-        'option_organization_id' => 2
-      )['organization_id'].must_equal 2
-    end
-  end
-
   describe '#create_repositories_search_options' do
     it 'handles an array of names' do
       search_options_creators.create_repositories_search_options(
@@ -51,12 +37,6 @@ describe HammerCLIKatello::SearchOptionsCreators do
       search_options_creators.create_repositories_search_options(
         'option_product_id' => 3
       )['product_id'].must_equal 3
-    end
-
-    it 'handles an organization_id' do
-      search_options_creators.create_repositories_search_options(
-        'option_organization_id' => 4
-      )['organization_id'].must_equal 4
     end
   end
 


### PR DESCRIPTION
Resolving a repository ID from repository name should only require product ID, not organization.