### PR TITLE
Fixes #20613 - Update help text for --sync-date

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -31,7 +31,8 @@ module HammerCLIKatello
              )
 
       option "--sync-date", "SYNC_DATE",
-             _("start date and time of the synchronization defaults to now"),
+             _("Start date and time for the sync plan." \
+               "Time is optional, if kept blank current system time will be considered"),
              :format => HammerCLI::Options::Normalizers::DateTime.new
 
       success_message _("Sync plan created")


### PR DESCRIPTION
Current help text for "hammer sync-plan create" is confusing for --sync-date option. 


Changed the text 
From: 
"start date and time of the synchronization defaults to now"
To: 
"Start date and time for the sync plan. Time is optional, if kept blank current system time will be considered"

Sync plan get created even if we do not pass the time in "YYYY-MM-DD HH:MM:SS" format, date is mandatory.

$ hammer  sync-plan create --organization-id 1 --name "RedHat Software collections sync" --description "A sync plan for RHSCL" --enabled True --interval "weekly" --sync-date 2017-08-16
Sync plan created

