### PR TITLE
fixes #20748 - cv filter rule list/info should include architecture

### DIFF
--- a/lib/hammer_cli_katello/filter_rule.rb
+++ b/lib/hammer_cli_katello/filter_rule.rb
@@ -15,6 +15,7 @@ module HammerCLIKatello
         field :version, _("Version")
         field :min_version, _("Minimum Version")
         field :max_version, _("Maximum Version")
+        field :architecture, _("Architecture")
         field :errata_id, _("Errata ID")
         field :start_date, _("Start Date")
         field :end_date, _("End Date")
@@ -34,6 +35,7 @@ module HammerCLIKatello
         field :version, _("Version"), Fields::Field, :hide_blank => true
         field :min_version, _("Minimum Version"), Fields::Field, :hide_blank => true
         field :max_version, _("Maximum Version"), Fields::Field, :hide_blank => true
+        field :architecture, _("Architecture"), Fields::Field, :hide_blank => true
         field :errata_id, _("Errata ID"), Fields::Field, :hide_blank => true
         field :start_date, _("Start Date"), Fields::Field, :hide_blank => true
         field :end_date, _("End Date"), Fields::Field, :hide_blank => true


### PR DESCRIPTION
Support was added to content view package filter rules to allow setting of architecture.  This change is to let the user see the value set.

Note: in order to create the rule using the cli, the following PR will be needed:
https://github.com/Katello/katello/pull/6925

Below is an example:
```
hammer> content-view filter rule create --content-view-filter-id 1 --name foo --architecture x86_64 --version 1234
Filter rule created

hammer> content-view filter rule list --content-view-filter-id 1
--------|-----------|------|---------|-----------------|-----------------|--------------|-----------|------------|---------
RULE ID | FILTER ID | NAME | VERSION | MINIMUM VERSION | MAXIMUM VERSION | ARCHITECTURE | ERRATA ID | START DATE | END DATE
--------|-----------|------|---------|-----------------|-----------------|--------------|-----------|------------|---------
3       | 1         | foo  | 1234    |                 |                 | x86_64       |           |            |         
--------|-----------|------|---------|-----------------|-----------------|--------------|-----------|------------|---------

hammer> content-view filter rule info --content-view-filter-id 1 --id 3
Rule ID:      3
Filter ID:    1
Name:         foo
Version:      1234
Architecture: x86_64
Created:      2017/08/25 19:58:48
Updated:      2017/08/25 19:58:48
```