### PR TITLE
Fixes #20791 - Show Registered To option through hammer

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -41,6 +41,7 @@ module HammerCLIKatello
             field :service_level, _('Service Level')
             field :release_version, _('Release Version')
             field :autoheal, _('Autoheal')
+            field :registered_through, _('Registered To')
             field :registered_at, _('Registered At')
             collection :activation_keys, _('Registered by Activation Keys'), :hide_blank => true do
               custom_field Fields::Reference


### PR DESCRIPTION
`hammer host info` command shows the information capsule the client is currently registered to.
~~~
# hammer host info --name client.example.com
<snip>
Subscription Information: 
    UUID:            739317d0-baf7-46d2-828a-c2d410dcd99a
    Last Checkin:    2017-08-04 09:35:35 UTC
    Service Level:   
    Release Version: 
    Autoheal:        true
    Registered To:   foreman-devel.example.com
    Registered At:   2017-08-04 02:31:43 UTC
Host Collections:
~~~