### PR TITLE
Refs #20761 - Allow filter rule name search

### DIFF
--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -4,6 +4,10 @@ module HammerCLIKatello
   module SearchOptionsCreators
     include HammerCLIKatello::ForemanSearchOptionsCreators
 
+    def create_content_view_filter_rules_search_options(options)
+      create_search_options_without_katello_api(options, api.resource(:content_view_filter_rules))
+    end
+
     def create_repositories_search_options(options)
       name = options[HammerCLI.option_accessor_name("name")]
       names = options[HammerCLI.option_accessor_name("names")]

--- a/test/functional/filter_rule/delete_test.rb
+++ b/test/functional/filter_rule/delete_test.rb
@@ -1,8 +1,11 @@
 require_relative '../test_helper'
+require_relative 'filter_rule_helpers'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
   describe FilterRule::DeleteCommand do
+    include FilterRuleHelpers
+
     it 'allows minimal options' do
       api_expects(:content_view_filter_rules, :destroy) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == '9'
@@ -11,10 +14,7 @@ module HammerCLIKatello
     end
 
     it 'resolves rule ID from rule name and filter ID' do
-      ex = api_expects(:content_view_filter_rules, :index) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
-      end
-      ex.returns(index_response([{'id' => 9}]))
+      expect_filter_rule_search('rule9', 1, 9)
 
       api_expects(:content_view_filter_rules, :destroy) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == 9

--- a/test/functional/filter_rule/filter_rule_helpers.rb
+++ b/test/functional/filter_rule/filter_rule_helpers.rb
@@ -1,0 +1,12 @@
+require_relative '../search_helpers'
+
+module FilterRuleHelpers
+  include SearchHelpers
+
+  def expect_filter_rule_search(name, filter_id, return_id)
+    expect_generic_search(
+      :content_view_filter_rules,
+      params: {search: "name = \"#{name}\"", 'content_view_filter_id' => filter_id},
+      returns: {'id' => return_id})
+  end
+end

--- a/test/functional/filter_rule/info_test.rb
+++ b/test/functional/filter_rule/info_test.rb
@@ -1,8 +1,11 @@
 require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
+require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
   describe FilterRule::InfoCommand do
+    include FilterRuleHelpers
+
     it 'allows minimal options' do
       api_expects(:content_view_filter_rules, :show) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == '9'
@@ -11,10 +14,7 @@ module HammerCLIKatello
     end
 
     it 'resolves rule ID from rule name and filter ID' do
-      ex = api_expects(:content_view_filter_rules, :index) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
-      end
-      ex.returns(index_response([{'id' => 9}]))
+      expect_filter_rule_search('rule9', 1, 9)
 
       api_expects(:content_view_filter_rules, :show) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == 9

--- a/test/functional/filter_rule/update_test.rb
+++ b/test/functional/filter_rule/update_test.rb
@@ -1,8 +1,11 @@
 require_relative '../test_helper'
 require 'hammer_cli_katello/filter_rule'
+require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello
   describe FilterRule::UpdateCommand do
+    include FilterRuleHelpers
+
     it 'allows minimal options' do
       api_expects(:content_view_filter_rules, :update) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == '9'
@@ -11,10 +14,7 @@ module HammerCLIKatello
     end
 
     it 'resolves rule ID from rule name and filter ID' do
-      ex = api_expects(:content_view_filter_rules, :index) do |p|
-        p['content_view_filter_id'] == 1 && p['name'] == 'rule9'
-      end
-      ex.returns(index_response([{'id' => 9}]))
+      expect_filter_rule_search('rule9', 1, 9)
 
       api_expects(:content_view_filter_rules, :update) do |p|
         p['content_view_filter_id'] == 1 && p['id'] == 9


### PR DESCRIPTION
The `name` option had to be passed through the `search` parameter.

To test, make sure you have multiple rules on your filter:

```sh
hammer content-view filter rule info --content-view-filter-id 5 --name vim
```

Requires https://github.com/Katello/katello/pull/6956