### PR TITLE
Fixes #21142 - add support for file command

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -121,6 +121,11 @@ module HammerCLIKatello
                                          'hammer_cli_katello/ostree_branch'
                                         )
 
+  HammerCLI::MainCommand.lazy_subcommand("file", _("Manipulate files"),
+                                         'HammerCLIKatello::FileCommand',
+                                         'hammer_cli_katello/file'
+                                        )
+
   # subcommands to hammer_cli_foreman commands
   require 'hammer_cli_katello/host'
   require 'hammer_cli_katello/hostgroup'

--- a/lib/hammer_cli_katello/file.rb
+++ b/lib/hammer_cli_katello/file.rb
@@ -1,0 +1,72 @@
+module HammerCLIKatello
+  class FileCommand < HammerCLIKatello::Command
+    resource :file_units
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+        field :path, _("Path")
+      end
+
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name,
+                                :option_organization_label]
+        product_options = [:option_product_id, :option_product_name]
+
+        if any(:option_product_name, :option_content_view_name).exist?
+          any(*organization_options).required
+        end
+
+        if option(:option_repository_name).exist?
+          any(*product_options).required
+        end
+      end
+
+      build_options do |o|
+        o.expand.including(:products, :organizations, :content_views)
+      end
+    end
+
+    class InfoCommand < HammerCLIKatello::InfoCommand
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+        field :path, _("Path")
+        field :uuid, _("UUID")
+        field :checksum, _("Checksum")
+      end
+
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name,
+                                :option_organization_label]
+        product_options = [:option_product_id, :option_product_name]
+        repository_options = [:option_repository_id, :option_repository_name]
+        content_view_version_options = [:option_content_view_version_id,
+                                        :option_content_view_version_version]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+
+        if option(:option_repository_name).exist?
+          any(*product_options).required
+        end
+
+        if option(:option_name).exist?
+          any(*(repository_options + content_view_version_options)).required
+        end
+      end
+
+      def all_options
+        super.merge(options)
+      end
+
+      build_options do |o|
+        o.expand.including(:products, :organizations, :content_views, :content_view_versions)
+      end
+    end
+
+    autoload_subcommands
+  end
+end

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -7,6 +7,9 @@ module HammerCLIKatello
       :capsule =>               [s_name(_("Capsule name to search by"))],
       :content_view =>          [s_name(_("Content view name to search by"))],
       :content_view_component => [],
+      :file_unit =>             [s_name(_("File name to search by")),
+                                 s("content_view_version_id", _("Content View Version ID")),
+                                 s("repository_id", _("Repository ID"))],
       :gpg =>                   [s_name(_("Gpg key name to search by"))],
       :host_collection =>       [s_name(_("Host collection name to search by"))],
       :lifecycle_environment => [s_name(_("Lifecycle environment name to search by"))],
@@ -39,12 +42,21 @@ module HammerCLIKatello
     end
   end
 
+  # rubocop:disable ClassLength
   class IdResolver < HammerCLIForeman::IdResolver
     include HammerCLIKatello::SearchOptionsCreators
 
     # alias_method_chain :create_search_options, :katello_api
     alias_method :create_search_options_without_katello_api, :create_search_options
     alias_method :create_search_options, :create_search_options_with_katello_api
+
+    def file_unit_id(options)
+      if options['option_content_view_version_version']
+        options['option_content_view_version_id'] ||=
+          content_view_version_id(scoped_options('content_view_version', options))
+      end
+      get_id(:file_units, options)
+    end
 
     def capsule_content_id(options)
       smart_proxy_id(options)

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -16,6 +16,7 @@ module HammerCLIKatello
       build_options
     end
 
+    # rubocop:disable ClassLength
     class InfoCommand < HammerCLIKatello::InfoCommand
       include RepositoryScopedToProduct
 
@@ -70,6 +71,7 @@ module HammerCLIKatello
           field :docker_manifest_total, _("Docker Manifests"), Fields::Field, :hide_blank => true
           field :docker_tag_total, _("Docker Tags"), Fields::Field, :hide_blank => true
           field :ostree_branch_total, _("OSTree Branches"), Fields::Field, :hide_blank => true
+          field :file_total, _("Files"), Fields::Field, :hide_blank => true
         end
       end
 
@@ -113,6 +115,8 @@ module HammerCLIKatello
           data["puppet_total"] = content_counts["puppet_module"]
         when "ostree"
           data["ostree_branch_total"] = content_counts["ostree_branch"]
+        when "file"
+          data["file_total"] = content_counts["file"]
         end
       end
 
@@ -129,6 +133,7 @@ module HammerCLIKatello
         o.expand.including(:products, :organizations)
       end
     end
+    # rubocop:enable ClassLength
 
     class SyncCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -4,6 +4,11 @@ module HammerCLIKatello
   module SearchOptionsCreators
     include HammerCLIKatello::ForemanSearchOptionsCreators
 
+    def create_file_units_search_options(options)
+      create_search_options_without_katello_api(options, api.resource(:file_units))
+        .merge(create_search_options(options, api.resource(:file_units)))
+    end
+
     def create_content_view_filter_rules_search_options(options)
       create_search_options_without_katello_api(options, api.resource(:content_view_filter_rules))
     end

--- a/test/functional/content_view/content_view_helpers.rb
+++ b/test/functional/content_view/content_view_helpers.rb
@@ -11,4 +11,8 @@ module ContentViewHelpers
   def expect_generic_content_view_search(args)
     expect_generic_search(:content_views, args)
   end
+
+  def expect_content_view_version_search(params, returns)
+    expect_generic_search(:content_view_versions, params: params, returns: returns)
+  end
 end

--- a/test/functional/file/file_helpers.rb
+++ b/test/functional/file/file_helpers.rb
@@ -1,0 +1,13 @@
+require_relative '../search_helpers'
+
+module FileHelpers
+  include SearchHelpers
+
+  def expect_file_search(params, returns)
+    expect_generic_search(:file_units, params: params, returns: returns)
+  end
+
+  def expect_file_show(params)
+    api_expects(:file_units, :show).with_params(params)
+  end
+end

--- a/test/functional/file/info_test.rb
+++ b/test/functional/file/info_test.rb
@@ -1,0 +1,162 @@
+require_relative '../test_helper.rb'
+require_relative '../organization/organization_helpers'
+require_relative '../content_view/content_view_helpers'
+require_relative '../repository/repository_helpers'
+require_relative '../product/product_helpers'
+require_relative 'file_helpers'
+require 'hammer_cli_katello/file'
+
+# rubocop:disable ModuleLength
+module HammerCLIKatello
+  describe FileCommand::InfoCommand do
+    include FileHelpers
+    include ContentViewHelpers
+    include RepositoryHelpers
+    include ProductHelpers
+    include OrganizationHelpers
+
+    it 'allows minimal options' do
+      expect_file_show('id' => '1')
+      run_cmd(%w(file info --id 1))
+    end
+
+    describe 'requires' do
+      describe 'organization options' do
+        it 'to resolve product ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --product product1))
+          assert_match(/--organization-id/, result.err)
+        end
+
+        it 'to resolve content view ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --content-view cv1))
+          assert_match(/--organization-id/, result.err)
+        end
+      end
+
+      describe 'product options' do
+        it 'to resolve repository ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --repository repo1))
+          assert_match(/--product-id/, result.err)
+        end
+      end
+    end
+
+    describe 'allows filtering by' do
+      it 'repository ID' do
+        expect_file_search({'repository_id' => 2}, {})
+        run_cmd(%w(file list --repository-id 2))
+      end
+
+      it 'content view version ID' do
+        expect_file_search({'content_view_version_id' => 2}, {})
+        run_cmd(%w(file list --content-view-version-id 2))
+      end
+    end
+
+    describe 'resolves ID from file name' do
+      it 'and repository ID' do
+        expect_file_search({'repository_id' => '2', search: "name = \"foo\""}, 'id' => 1)
+        expect_file_show('id' => 1)
+        run_cmd(%w(file info --name foo --repository-id 2))
+      end
+
+      describe 'repository name' do
+        it 'and product ID' do
+          expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+          expect_file_search({'repository_id' => '2', search: "name = \"foo\""}, 'id' => 1)
+          expect_file_show('id' => 1)
+          run_cmd(%w(file info --name foo --repository repo2 --product-id 1))
+        end
+
+        describe 'product name, and organization' do
+          it 'ID' do
+            expect_generic_product_search({'name' => 'product1', 'organization_id' => 3}, 'id' => 1)
+            expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+            expect_file_search({'repository_id' => '2', search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --repository repo2 --product product1
+                       --organization-id 3))
+          end
+
+          it 'name' do
+            expect_organization_search('org3', 3)
+            expect_generic_product_search({'name' => 'product1', 'organization_id' => 3}, 'id' => 1)
+            expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+            expect_file_search({'repository_id' => '2', search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --repository repo2 --product product1
+                       --organization org3))
+          end
+
+          it 'label' do
+            expect_organization_search('org3', 3, field: 'label')
+            expect_generic_product_search({'name' => 'product1', 'organization_id' => 3}, 'id' => 1)
+            expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+            expect_file_search({'repository_id' => '2', search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --repository repo2 --product product1
+                       --organization-label org3))
+          end
+        end
+      end
+
+      it 'and content view version ID' do
+        expect_file_search({'content_view_version_id' => '2', 'name' => 'foo'}, 'id' => 1)
+        expect_file_show('id' => 1)
+        run_cmd(%w(file info --name foo --content-view-version-id 2))
+      end
+
+      describe 'content view version' do
+        it 'and content view ID' do
+          expect_content_view_version_search({'version' => '2.0',
+                                              'content_view_id' => 3}, 'id' => 2)
+          expect_file_search({'content_view_version_id' => '2',
+                              search: "name = \"foo\""}, 'id' => 1)
+          expect_file_show('id' => 1)
+          run_cmd(%w(file info --name foo --content-view-version 2.0 --content-view-id 3))
+        end
+
+        describe 'content view name, and organization' do
+          it 'ID' do
+            expect_content_view_search(4, 'cv3', 3)
+            expect_content_view_version_search({'version' => '2.0',
+                                                'content_view_id' => 3}, 'id' => 2)
+            expect_file_search({'content_view_version_id' => '2',
+                                search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --content-view-version 2.0 --content-view cv3
+                       --organization-id 4))
+          end
+
+          it 'name' do
+            expect_organization_search('org4', 4)
+            expect_content_view_search(4, 'cv3', 3)
+            expect_content_view_version_search({'version' => '2.0',
+                                                'content_view_id' => 3}, 'id' => 2)
+            expect_file_search({'content_view_version_id' => '2',
+                                search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --content-view-version 2.0 --content-view cv3
+                       --organization org4))
+          end
+
+          it 'label' do
+            expect_organization_search('org4', 4, field: 'label')
+            expect_content_view_search(4, 'cv3', 3)
+            expect_content_view_version_search({'version' => '2.0',
+                                                'content_view_id' => 3}, 'id' => 2)
+            expect_file_search({'content_view_version_id' => '2',
+                                search: "name = \"foo\""}, 'id' => 1)
+            expect_file_show('id' => 1)
+            run_cmd(%w(file info --name foo --content-view-version 2.0 --content-view cv3
+                       --organization-label org4))
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable ModuleLength

--- a/test/functional/file/list_test.rb
+++ b/test/functional/file/list_test.rb
@@ -1,0 +1,112 @@
+require_relative '../test_helper.rb'
+require_relative '../organization/organization_helpers'
+require_relative '../content_view/content_view_helpers'
+require_relative '../repository/repository_helpers'
+require_relative '../product/product_helpers'
+require_relative 'file_helpers'
+require 'hammer_cli_katello/file'
+
+module HammerCLIKatello
+  describe FileCommand::ListCommand do
+    include FileHelpers
+    include ContentViewHelpers
+    include RepositoryHelpers
+    include ProductHelpers
+    include OrganizationHelpers
+
+    it 'allows minimal options' do
+      expect_file_search({}, {})
+      run_cmd(%w(file list))
+    end
+
+    describe 'requires' do
+      describe 'organization options' do
+        it 'to resolve product ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --product product1))
+          assert_match(/--organization-id/, result.err)
+        end
+
+        it 'to resolve content view ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --content-view cv1))
+          assert_match(/--organization-id/, result.err)
+        end
+      end
+
+      describe 'product options' do
+        it 'to resolve repository ID' do
+          api_expects_no_call
+          result = run_cmd(%w(file list --repository repo1))
+          assert_match(/--product-id/, result.err)
+        end
+      end
+    end
+
+    describe 'allows filtering by' do
+      it 'repository ID' do
+        expect_file_search({'repository_id' => 2}, {})
+        run_cmd(%w(file list --repository-id 2))
+      end
+
+      it 'content view version ID' do
+        expect_file_search({'content_view_version_id' => 2}, {})
+        run_cmd(%w(file list --content-view-version-id 2))
+      end
+    end
+
+    describe 'resolves' do
+      describe 'repository ID' do
+        it 'from name and product ID' do
+          expect_generic_repositories_search(
+            {'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+          expect_file_search({'repository_id' => 2}, {})
+          run_cmd(%w(file list --repository repo2 --product-id 1))
+        end
+
+        it 'from name, product, and organization ID' do
+          expect_generic_product_search({'name' => 'product1', 'organization_id' => 3}, 'id' => 1)
+          expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+          expect_file_search({'repository_id' => 2}, {})
+          run_cmd(%w(file list --repository repo2 --product product1 --organization-id 3))
+        end
+
+        it 'from name, product, and organization name' do
+          expect_organization_search('org3', 3)
+          expect_generic_product_search({'name' => 'product1', 'organization_id' => 3}, 'id' => 1)
+          expect_generic_repositories_search({'name' => 'repo2', 'product_id' => 1}, 'id' => 2)
+          expect_file_search({'repository_id' => 2}, {})
+          run_cmd(%w(file list --repository repo2 --product product1 --organization org3))
+        end
+      end
+
+      describe 'content view version ID' do
+        it 'from version and content view ID' do
+          expect_content_view_version_search(
+            {'version' => '1.0', 'content_view_id' => 1}, 'id' => 2)
+          expect_file_search({'content_view_version_id' => 2}, {})
+          run_cmd(%w(file list --content-view-version 1.0 --content-view-id 1))
+        end
+
+        it 'from version, content view name, and organization ID' do
+          expect_generic_content_view_search(params: {'name' => 'cv1', 'organization_id' => 3},
+                                             returns: {'id' => 1})
+          expect_content_view_version_search(
+            {'version' => '1.0', 'content_view_id' => 1}, 'id' => 2)
+          expect_file_search({'content_view_version_id' => 2}, {})
+          run_cmd(%w(file list --content-view-version 1.0 --content-view cv1 --organization-id 3))
+        end
+
+        it 'from version, content view name, and organization name' do
+          expect_organization_search('org3', 3)
+          expect_generic_content_view_search(params: {'name' => 'cv1', 'organization_id' => 3},
+                                             returns: {'id' => 1})
+          expect_content_view_version_search(
+            {'version' => '1.0', 'content_view_id' => 1}, 'id' => 2)
+          expect_file_search({'content_view_version_id' => 2}, {})
+          run_cmd(%w(file list --content-view-version 1.0 --content-view cv1 --organization org3))
+        end
+      end
+    end
+  end
+end

--- a/test/functional/product/product_helpers.rb
+++ b/test/functional/product/product_helpers.rb
@@ -1,9 +1,11 @@
 module ProductHelpers
+  def expect_generic_product_search(params = {}, returns = {})
+    api_expects(:products, :index, 'Find the Product')
+      .with_params(params).returns(index_response([returns]))
+  end
+
   def expect_product_search(org_id, name, id)
-    ex = api_expects(:products, :index, 'Find the Product') do |par|
-      par['name'] == name && par['organization_id'] == org_id
-    end
-    ex.returns(index_response([{'id' => id}]))
+    expect_generic_product_search({'name' => name, 'organization_id' => org_id}, 'id' => id)
   end
 
   def expect_product_show(options = {})


### PR DESCRIPTION
~Requires https://github.com/Katello/katello/pull/6988~ Merged

```sh
$ hammer file list 
---|------------------|-----------------
ID | NAME             | PATH            
---|------------------|-----------------
3  | DvMap_letter.pdf | DvMap_letter.pdf
2  | foo.txt          | foo.txt         
1  | NCC-170115.xml   | NCC-170115.xml  
---|------------------|-----------------

$ hammer file info --id 1
ID:       1
Name:     NCC-170115.xml
Path:     NCC-170115.xml
UUID:     52c71db9-255d-4dc5-a947-86af376fab83
Checksum: e04ef36e5734add317b8a4b2ab3b9987d8f6c0dec35011820bac19ce8d8fcead
```