### PR TITLE
Fixes #21196,18743 - Add repo name to host create/update

### DIFF
--- a/lib/hammer_cli_katello/host_content_source_options.rb
+++ b/lib/hammer_cli_katello/host_content_source_options.rb
@@ -1,0 +1,25 @@
+module HammerCLIKatello
+  module HostContentSourceOptions
+    def self.included(base)
+      base.option "--content-source", "CONTENT_SOURCE_NAME",
+             _("Content Source name "),
+             :attribute_name => :option_content_source
+    end
+
+    def request_params
+      super.tap do |mod|
+        resource_name = resource.singular_name
+        if option_content_source && !option_content_source_id
+          resource_hash = if resource_name == "hostgroup"
+                            mod[resource_name]
+                          else
+                            mod[resource_name]["content_facet_attributes"]
+                          end
+
+          proxy_options = { HammerCLI.option_accessor_name('name') => option_content_source}
+          resource_hash["content_source_id"] = resolver.smart_proxy_id(proxy_options)
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -3,9 +3,23 @@ require 'hammer_cli_katello/host_errata'
 require 'hammer_cli_katello/host_subscription'
 require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_package_group'
+require 'hammer_cli_katello/host_kickstart_repository_options'
+require 'hammer_cli_katello/host_content_source_options'
 
 module HammerCLIKatello
   module HostExtensions
+    ::HammerCLIForeman::Host::CreateCommand.instance_eval do
+      include HammerCLIKatello::ResolverCommons
+      include HammerCLIKatello::HostContentSourceOptions
+      include ::HammerCLIKatello::HostKickstartRepositoryOptions
+    end
+
+    ::HammerCLIForeman::Host::UpdateCommand.instance_eval do
+      include HammerCLIKatello::ResolverCommons
+      include HammerCLIKatello::HostContentSourceOptions
+      include ::HammerCLIKatello::HostKickstartRepositoryOptions
+    end
+
     ::HammerCLIForeman::Host::ListCommand.instance_eval do
       output do
         from :content_facet_attributes do

--- a/lib/hammer_cli_katello/host_kickstart_repository_options.rb
+++ b/lib/hammer_cli_katello/host_kickstart_repository_options.rb
@@ -1,0 +1,49 @@
+module HammerCLIKatello
+  module HostKickstartRepositoryOptions
+    def self.included(base)
+      base.option "--kickstart-repository", "REPOSITORY_NAME",
+             _("Kickstart repository name "),
+             :attribute_name => :option_kickstart_repository
+    end
+
+    def request_params
+      super.tap do |mod|
+        resource_name = resource.singular_name
+        if option_kickstart_repository && !option_kickstart_repository_id
+          resource_hash = if resource_name == "hostgroup"
+                            mod[resource_name]
+                          else
+                            mod[resource_name]["content_facet_attributes"]
+                          end
+
+          resource_hash ||= {}
+
+          env_id = resource_hash["lifecycle_environment_id"]
+          cv_id = resource_hash["content_view_id"]
+
+          raise _("Please provide --lifecycle-environment-id") unless env_id
+
+          raise _("Please provide --content-view-id") unless cv_id
+
+          resource_hash["kickstart_repository_id"] = fetch_repo_id(cv_id, env_id,
+                                                                   option_kickstart_repository)
+        end
+      end
+    end
+
+    def fetch_repo_id(cv_id, env_id, repo_name)
+      repo_resource = HammerCLIForeman.foreman_resource(:repositories)
+      index_options = {
+        "content_view_id" => cv_id,
+        "environment_id" => env_id,
+        "name" => repo_name
+      }
+      repos = repo_resource.call(:index, index_options)["results"]
+      if repos.empty?
+        raise _("No such repository with name %{name}, in lifecycle environment"\
+                  " %{environment_id} and content view %{content_view_id}" % index_options)
+      end
+      repos.first["id"]
+    end
+  end
+end

--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -1,4 +1,6 @@
 require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_katello/host_kickstart_repository_options'
+require 'hammer_cli_katello/host_content_source_options'
 
 module HammerCLIKatello
   module PuppetEnvironmentNameResolvable
@@ -39,6 +41,8 @@ module HammerCLIKatello
       include HammerCLIKatello::PuppetEnvironmentNameResolvable
       include HammerCLIKatello::ContentViewNameResolvable
       include HammerCLIKatello::QueryOrganizationOptions
+      include HammerCLIKatello::HostContentSourceOptions
+      include HammerCLIKatello::HostKickstartRepositoryOptions
     end
 
     ::HammerCLIForeman::Hostgroup::UpdateCommand.instance_eval do
@@ -46,6 +50,8 @@ module HammerCLIKatello
       include HammerCLIKatello::PuppetEnvironmentNameResolvable
       include HammerCLIKatello::ContentViewNameResolvable
       include HammerCLIKatello::QueryOrganizationOptions
+      include HammerCLIKatello::HostContentSourceOptions
+      include HammerCLIKatello::HostKickstartRepositoryOptions
     end
 
     ::HammerCLIForeman::Hostgroup::InfoCommand.instance_eval do

--- a/test/functional/host/extensions/create_test.rb
+++ b/test/functional/host/extensions/create_test.rb
@@ -1,0 +1,95 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require 'hammer_cli_foreman/host'
+
+module HammerCLIForeman
+  describe Host do
+    # These tests are only for the extensions Katello adds to the host command
+    # See hammer-cli-foreman for the core host tests
+    describe CreateCommand do
+      let(:env_name) { "world" }
+      let(:env_id) { 100 }
+      let(:cv_id) { 220 }
+      let(:repo_name) { "life_of_kickstart" }
+      let(:repo_id) { 12 }
+      let(:content_source_name) { "life_of_cs" }
+      let(:content_source_id) { 82 }
+      let(:host_name) { "mercury" }
+      let(:domain_id) { 134 }
+      let(:operatingsystem_id) { 103 }
+      let(:architecture_id) { 28 }
+      let(:partition_table_id) { 243 }
+      let(:location_id) { 213 }
+      let(:organization_id) { 324 }
+
+      it 'allows kickstart repository name' do
+        api_expects(:lifecycle_environments, :index).
+          with_params('name' => env_name,
+                      'organization_id' => organization_id).
+          returns(index_response([{'id' => env_id}]))
+
+        api_expects(:repositories, :index).
+          with_params('name' => repo_name,
+                      'environment_id' => env_id,
+                      'content_view_id' => cv_id).
+          returns(index_response([{'id' => repo_id}]))
+
+        api_expects(:hosts, :create).
+          with_params('host' => {
+                        'name' => host_name,
+                        'location_id' => location_id,
+                        'organization_id' => organization_id,
+                        'operatingsystem_id' => operatingsystem_id,
+                        'architecture_id' => architecture_id,
+                        'ptable_id' => partition_table_id,
+                        'domain_id' => domain_id,
+                        'content_facet_attributes' => {
+                          'lifecycle_environment_id' => env_id,
+                          'content_view_id' => cv_id,
+                          'kickstart_repository_id' => repo_id
+                        }
+                      })
+
+        cmd = "host create --name=#{host_name} --content-view-id=#{cv_id}"\
+              " --lifecycle-environment=#{env_name}"\
+              " --kickstart-repository=#{repo_name}"\
+              " --operatingsystem-id=#{operatingsystem_id}"\
+              " --architecture-id=#{architecture_id}"\
+              " --organization-id=#{organization_id}"\
+              " --partition-table-id=#{partition_table_id}"\
+              " --location-id=#{location_id}"\
+              " --domain-id=#{domain_id}"
+        run_cmd(cmd.split)
+      end
+
+      it 'allows content source name' do
+        api_expects(:smart_proxies, :index).
+          with_params(:search => "name = \"#{content_source_name}\"").
+          returns(index_response([{'id' => content_source_id}]))
+
+        api_expects(:hosts, :create).
+          with_params('host' => {
+                        'name' => host_name,
+                        'location_id' => location_id,
+                        'organization_id' => organization_id,
+                        'operatingsystem_id' => operatingsystem_id,
+                        'architecture_id' => architecture_id,
+                        'ptable_id' => partition_table_id,
+                        'domain_id' => domain_id,
+                        'content_facet_attributes' => {
+                          'content_source_id' => content_source_id
+                        }
+                      })
+
+        cmd = "host create --name=#{host_name}"\
+              " --content-source=#{content_source_name}"\
+              " --operatingsystem-id=#{operatingsystem_id}"\
+              " --architecture-id=#{architecture_id}"\
+              " --organization-id=#{organization_id}"\
+              " --partition-table-id=#{partition_table_id}"\
+              " --location-id=#{location_id}"\
+              " --domain-id=#{domain_id}"
+        run_cmd(cmd.split)
+      end
+    end
+  end
+end

--- a/test/functional/host/extensions/update_test.rb
+++ b/test/functional/host/extensions/update_test.rb
@@ -1,0 +1,69 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require 'hammer_cli_foreman/host'
+
+module HammerCLIForeman
+  describe Host do
+    # These tests are only for the extensions Katello adds to the hostgroup command
+    # See hammer-cli-foreman for the core hostgroup tests
+    describe UpdateCommand do
+      it 'allows kickstart repository name' do
+        env_name = "world"
+        env_id = 100
+        cv_id = 200
+        repo_name = "life_of_kickstart"
+        repo_id = 111
+        host_id = 777
+        organization_id = 329
+        api_expects(:lifecycle_environments, :index).
+          with_params('name' => env_name,
+                      'organization_id' => organization_id).
+          returns(index_response([{'id' => env_id}]))
+
+        api_expects(:repositories, :index).
+          with_params('name' => repo_name,
+                      'environment_id' => env_id,
+                      'content_view_id' => cv_id).
+          returns(index_response([{'id' => repo_id}]))
+
+        api_expects(:hosts, :update).
+          with_params('id' => host_id.to_s,
+                      'host' => {
+                        'organization_id' => organization_id,
+                        'content_facet_attributes' => {
+                          'lifecycle_environment_id' => env_id,
+                          'content_view_id' => cv_id,
+                          'kickstart_repository_id' => repo_id
+                        }
+                      })
+
+        cmd = "host update --id=#{host_id}"\
+              " --content-view-id=#{cv_id}"\
+              " --lifecycle-environment=#{env_name}"\
+              " --kickstart-repository=#{repo_name}"\
+              " --organization-id=#{organization_id}"
+        run_cmd(cmd.split)
+      end
+
+      it 'allows content source name' do
+        content_source_name = "life_of_cs"
+        content_source_id = 111
+        host_id = 441
+
+        api_expects(:smart_proxies, :index).
+          with_params(:search => "name = \"#{content_source_name}\"").
+          returns(index_response([{'id' => content_source_id}]))
+
+        api_expects(:hosts, :update).
+          with_params('id' => host_id.to_s,
+                      'host' => {
+                        'content_facet_attributes' => {
+                          'content_source_id' => content_source_id
+                        }
+                      })
+
+        cmd = "host update --id #{host_id} --content-source #{content_source_name}"
+        run_cmd(cmd.split)
+      end
+    end
+  end
+end

--- a/test/functional/hostgroup/create_test.rb
+++ b/test/functional/hostgroup/create_test.rb
@@ -13,6 +13,24 @@ module HammerCLIForeman
         run_cmd(%w(hostgroup create --name hg1 --content-source-id 1))
       end
 
+      it 'allows content source name' do
+        content_source_name = "life_of_cs"
+        content_source_id = 111
+        hg_name = "mercury"
+
+        api_expects(:smart_proxies, :index).
+          with_params(:search => "name = \"#{content_source_name}\"").
+          returns(index_response([{'id' => content_source_id}]))
+
+        api_expects(:hostgroups, :create).
+          with_params('hostgroup' => {'name' => hg_name,
+                                      'content_source_id' => content_source_id
+                                     })
+
+        cmd = "hostgroup create --name #{hg_name} --content-source #{content_source_name}"
+        run_cmd(cmd.split)
+      end
+
       it 'allows content view id' do
         api_expects(:hostgroups, :create) do |p|
           p['hostgroup']['name'] == 'hg1' && p['hostgroup']['content_view_id'] == 1
@@ -47,7 +65,7 @@ module HammerCLIForeman
 
       it 'allows lifecycle environment name' do
         ex = api_expects(:lifecycle_environments, :index) do |p|
-          p[:name] = 'le1' && p['organization_id'] == '1'
+          p['name'] == 'le1' && p['organization_id'] == '1'
         end
         ex.returns(index_response([{'id' => 1}]))
         api_expects(:hostgroups, :create) do |p|
@@ -61,6 +79,33 @@ module HammerCLIForeman
         api_expects_no_call
         result = run_cmd(%w(hostgroup create --name hg1 --lifecycle-environment le1))
         assert_match(/--query-organization/, result.err)
+      end
+
+      it 'allows kickstart repository name' do
+        env_id = 100
+        cv_id = 200
+        repo_name = "life_of_kickstart"
+        repo_id = 111
+        hg_name = "mercury"
+
+        api_expects(:repositories, :index).
+          with_params('name' => repo_name,
+                      'environment_id' => env_id,
+                      'content_view_id' => cv_id).
+          returns(index_response([{'id' => repo_id}]))
+
+        expected_params = {'hostgroup' => {
+          'name' => hg_name,
+          'lifecycle_environment_id' => env_id,
+          'content_view_id' => cv_id,
+          'kickstart_repository_id' => repo_id
+        }
+                          }
+        api_expects(:hostgroups, :create).with_params(expected_params)
+
+        cmd = "hostgroup create --name #{hg_name} --lifecycle-environment-id #{env_id}"\
+              " --content-view-id #{cv_id} --kickstart-repository #{repo_name}"
+        run_cmd(cmd.split)
       end
     end
   end

--- a/test/functional/hostgroup/update_test.rb
+++ b/test/functional/hostgroup/update_test.rb
@@ -1,6 +1,5 @@
 require_relative '../test_helper'
 require 'hammer_cli_foreman/hostgroup'
-
 module HammerCLIForeman
   describe Hostgroup do
     # These tests are only for the extensions Katello adds to the hostgroup command
@@ -11,6 +10,24 @@ module HammerCLIForeman
           p['id'] == '1' && p['hostgroup']['content_source_id'] == 1
         end
         run_cmd(%w(hostgroup update --id 1 --content-source-id 1))
+      end
+
+      it 'allows content source name' do
+        content_source_name = "life_of_cs"
+        content_source_id = 111
+        hg_id = 441
+
+        api_expects(:smart_proxies, :index).
+          with_params(:search => "name = \"#{content_source_name}\"").
+          returns(index_response([{'id' => content_source_id}]))
+
+        api_expects(:hostgroups, :update).
+          with_params('id' => hg_id.to_s,
+                      'hostgroup' => {'content_source_id' => content_source_id
+                                     })
+
+        cmd = "hostgroup update --id #{hg_id} --content-source #{content_source_name}"
+        run_cmd(cmd.split)
       end
 
       it 'allows content view id' do
@@ -67,6 +84,36 @@ module HammerCLIForeman
         api_expects_no_call
         result = run_cmd(%w(hostgroup update --id 1 --lifecycle-environment le1))
         assert_match(/--query-organization/, result.err)
+      end
+
+      it 'allows kickstart repository name' do
+        env_id = 100
+        cv_id = 200
+        repo_name = "life_of_kickstart"
+        repo_id = 111
+        hg_name = "mercury"
+        hg_id = 108
+
+        api_expects(:hostgroups, :index).
+          with_params(:search => "name = \"#{hg_name}\"").
+          returns(index_response([{'id' => hg_id}]))
+
+        api_expects(:repositories, :index).
+          with_params('name' => repo_name,
+                      'environment_id' => env_id,
+                      'content_view_id' => cv_id).
+          returns(index_response([{'id' => repo_id}]))
+
+        api_expects(:hostgroups, :update).
+          with_params('id' => hg_id,
+                      'hostgroup' => {'lifecycle_environment_id' => env_id,
+                                      'content_view_id' => cv_id,
+                                      'kickstart_repository_id' => repo_id
+                                     })
+
+        cmd = "hostgroup update --name #{hg_name} --lifecycle-environment-id #{env_id}"\
+              " --content-view-id #{cv_id} --kickstart-repository #{repo_name}"
+        run_cmd(cmd.split)
       end
     end
   end


### PR DESCRIPTION
This fix contains improvements to search by ks-repository-name
- Hostgroup create/update
```
$ hammer hostgroup create  --organization-ids=1 --content-view="rhel7" --lifecycle-environment="Library" --name=new1 --kickstart-repository="Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.3" --operatingsystem-id=2 --architecture="x86_64" --query-organization-id=1

$ hammer hostgroup update  --content-view="rhel7" --lifecycle-environment="Library"  --kickstart-repository="Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.3" --query-organization-id=1
``` 
- Host create/update
```
$ hammer host create  --organization-ids=1 --content-view="rhel7" --lifecycle-environment_id=1  --name=new1 --kickstart-repository="Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.3" --operatingsystem-id=2 --architecture="x86_64" ----domain-id=100 organization-id=1

$ hammer host update  --content-view="rhel7" --lifecycle-environment-id=1 --kickstart-repository="Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.3"organization-id=1
``` 

Also added the ```--content-source``` option for these commands.
