### PR TITLE
fixes #21371 - convert repository-set enable/disable to be Command

### DIFF
--- a/lib/hammer_cli_katello/repository_set.rb
+++ b/lib/hammer_cli_katello/repository_set.rb
@@ -59,7 +59,7 @@ module HammerCLIKatello
       build_options
     end
 
-    class EnableCommand < HammerCLIKatello::UpdateCommand
+    class EnableCommand < HammerCLIKatello::Command
       resource :repository_sets, :enable
       command_name "enable"
 
@@ -69,7 +69,7 @@ module HammerCLIKatello
       build_options
     end
 
-    class DisableCommand < HammerCLIKatello::UpdateCommand
+    class DisableCommand < HammerCLIKatello::Command
       resource :repository_sets, :disable
       command_name "disable"
 


### PR DESCRIPTION
The repository-set enable/disable commands are currently
derived from the UpdateCommand.  This is resulting in the
inclusion of a '--new-name' parameter, which is not needed
or used by the commands.  As a result, updating them
to be simple Commands so that the parameter is not included.