### PR TITLE
Fixes #21623 - Validate repo upload options

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -200,6 +200,7 @@ module HammerCLIKatello
       end
     end
 
+    # rubocop:disable ClassLength
     class UploadContentCommand < HammerCLIKatello::InfoCommand
       include RepositoryScopedToProduct
       include HammerCLIForemanTasks::Helper
@@ -245,6 +246,28 @@ module HammerCLIKatello
 
       def content_upload_resource
         ::HammerCLIForeman.foreman_resource(:content_uploads)
+      end
+
+      validate_options do
+        organization_options = [:option_organization_id, :option_organization_name,
+                                :option_organization_label]
+        product_options = [:option_product_id, :option_product_name]
+        repository_options = [:option_id, :option_name]
+
+        any(*repository_options).required
+
+        if option(:option_name).exist?
+          any(*product_options).required
+        end
+
+        if option(:option_id).exist?
+          any(*product_options).rejected(
+            msg: _("Cannot specify both product options and repository ID."))
+        end
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
       end
 
       success_message _("Repository content uploaded")
@@ -323,6 +346,7 @@ module HammerCLIKatello
         resource.call(:import_uploads, params)
       end
     end
+    # rubocop:enable ClassLength
 
     class RemoveContentCommand < HammerCLIKatello::SingleResourceCommand
       include RepositoryScopedToProduct

--- a/test/functional/repository/upload_test.rb
+++ b/test/functional/repository/upload_test.rb
@@ -196,4 +196,34 @@ describe 'upload repository' do
     assert_equal "Could not find any files matching PATH\n", result.err
     assert_equal HammerCLI::EX_NOINPUT, result.exit_code
   end
+
+  describe 'requires' do
+    it 'repository options' do
+      api_expects_no_call
+      error = run_cmd(@cmd + %W(--path #{path})).err
+      assert error.include?('--id, --name is required'), "Actual result: #{error}"
+    end
+
+    it 'product options when repository name is specified' do
+      api_expects_no_call
+      error = run_cmd(@cmd + %W(--name repo1 --path #{path})).err
+      assert(error.include?('--product, --product-id is required'), "Actual result: #{error}")
+    end
+
+    it 'organization options when product name is specified' do
+      api_expects_no_call
+      error = run_cmd(@cmd + %W(--name repo1 --product product2 --path #{path})).err
+      assert(error.include?('--organization-id, --organization, --organization-label is required'),
+             "Actual result: #{error}")
+    end
+  end
+
+  describe 'disallows' do
+    it 'product options when repository ID is specified' do
+      api_expects_no_call
+      error = run_cmd(@cmd + %W(--id 1 --product product2 --path #{path})).err
+      assert(error.include?('Cannot specify both product options and repository ID'),
+             "Actual result: #{error}")
+    end
+  end
 end


### PR DESCRIPTION
This is the first validation that actually rejects an extra argument, afaik. It rejects product options if repository ID is provided. I also added some missing requirement validations in this sub-command.