### PR TITLE
Fixes #21701 - fix loading of FilterRuleHelpers

### DIFF
--- a/test/functional/filter_rule/info_test.rb
+++ b/test/functional/filter_rule/info_test.rb
@@ -1,5 +1,5 @@
 require_relative '../test_helper'
-require 'hammer_cli_katello/filter_rule'
+require_relative 'filter_rule_helpers'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello

--- a/test/functional/filter_rule/update_test.rb
+++ b/test/functional/filter_rule/update_test.rb
@@ -1,5 +1,5 @@
 require_relative '../test_helper'
-require 'hammer_cli_katello/filter_rule'
+require_relative 'filter_rule_helpers'
 require 'hammer_cli_katello/filter_rule'
 
 module HammerCLIKatello


### PR DESCRIPTION
fixes:

    /home/remote/egolov/Devel/katello/hammer-cli-katello/test/functional/filter_rule/update_test.rb:7:in `block in <module:HammerCLIKatello>': uninitialized constant HammerCLIKatello::FilterRuleHelpers (NameError)
    Did you mean?  HammerCLIKatello::FilterRule
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/minitest-4.7.4/lib/minitest/spec.rb:71:in `class_eval'
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/minitest-4.7.4/lib/minitest/spec.rb:71:in `describe'
    	from /home/remote/egolov/Devel/katello/hammer-cli-katello/test/functional/filter_rule/update_test.rb:6:in `<module:HammerCLIKatello>'
    	from /home/remote/egolov/Devel/katello/hammer-cli-katello/test/functional/filter_rule/update_test.rb:5:in `<top (required)>'
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:15:in `require'
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:15:in `block in <main>'
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:4:in `select'
    	from /home/remote/egolov/.gem/ruby/2.4.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb:4:in `<main>'
    rake aborted!

@akofink can you please have a look? the changes were introduced by you originally