### PR TITLE
Fixes #21912 - cs cv env ids for hostgroup

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -33,10 +33,26 @@ module HammerCLIKatello
       output do
         label _('Content Information') do
           from :content_facet_attributes do
-            field :content_view_name, _('Content View')
-            field :lifecycle_environment_name, _('Lifecycle Environment')
-            field :content_source_name, _('Content Source')
-            field :kickstart_repository_name, _('Repository')
+            label _("Content View") do
+              field :content_view_id, _("ID")
+              field :content_view_name, _("Name")
+            end
+
+            label _("Lifecycle Environment") do
+              field :lifecycle_environment_id, _("ID")
+              field :lifecycle_environment_name, _("Name")
+            end
+
+            label _("Content Source") do
+              field :content_source_id, _("ID")
+              field :content_source_name, _("Name")
+            end
+
+            label _("Kickstart Repository") do
+              field :kickstart_repository_id, _("ID")
+              field :kickstart_repository_name, _("Name")
+            end
+
             field :applicable_package_count, _('Applicable Packages')
             field :upgradable_package_count, _('Upgradable Packages')
 

--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -56,10 +56,25 @@ module HammerCLIKatello
 
     ::HammerCLIForeman::Hostgroup::InfoCommand.instance_eval do
       output do
-        field :content_view_name, _('Content View')
-        field :lifecycle_environment_name, _('Lifecycle Environment')
-        field :content_source_name, _('Content Source')
-        field :kickstart_repository_name, _('Repository')
+        label _("Content View") do
+          field :content_view_id, _("ID")
+          field :content_view_name, _("Name")
+        end
+
+        label _("Lifecycle Environment") do
+          field :lifecycle_environment_id, _("ID")
+          field :lifecycle_environment_name, _("Name")
+        end
+
+        label _("Content Source") do
+          field :content_source_id, _("ID")
+          field :content_source_name, _("Name")
+        end
+
+        label _("Kickstart Repository") do
+          field :kickstart_repository_id, _("ID")
+          field :kickstart_repository_name, _("Name")
+        end
       end
     end
   end

--- a/test/functional/host/extensions/info_test.rb
+++ b/test/functional/host/extensions/info_test.rb
@@ -15,12 +15,12 @@ describe 'host info' do
     ex.returns(JSON.parse(File.read(json_file)))
 
     result = run_cmd(@cmd + params)
-
-    expected_fields = [['Lifecycle Environment', 'Library'],
-                       ['Content View', 'Default Organization View'],
+    # rubocop:disable Style/WordArray
+    expected_fields = [['Name', 'Library'],
+                       ['Name', 'Default Organization View'],
                        ['Release Version', '7Server'],
-                       ['Repository', 'Rhel 7'],
-                       ['Content Source', 'capsule'],
+                       ['Name', 'Rhel 7'],
+                       ['Name', 'capsule'],
                        ['Bug Fix', '0'],
                        ['Name', 'my host collection'],
                        ['Applicable Packages', '5'],

--- a/test/functional/hostgroup/info_test.rb
+++ b/test/functional/hostgroup/info_test.rb
@@ -20,10 +20,11 @@ module HammerCLIForeman
         ex.returns(JSON.parse(File.read(json_file)))
 
         result = run_cmd(@cmd + params)
-        expected_fields = [['Lifecycle Environment', 'Library'],
-                           ['Content View', 'Default Organization View'],
-                           ['Content Source', 'foreman.example.com'],
-                           ['Repository', 'Rhel 7']]
+        # rubocop:disable Style/WordArray
+        expected_fields = [['Name', 'Library'],
+                           ['Name', 'Default Organization View'],
+                           ['Name', 'foreman.example.com'],
+                           ['Name', 'Rhel 7']]
         expected_results = expected_fields.map { |field| success_result(FieldMatcher.new(*field)) }
         expected_results.each { |expected|  assert_cmd(expected, result) }
       end


### PR DESCRIPTION
Make the hammer host group and host calls show id information for
content source, content view, lifecycle environment and kickstart
repository ids