### PR TITLE
Refs #21768 - allow nil searchables

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -229,14 +229,14 @@ module HammerCLIKatello
       def initialize(command)
         @command = command
       end
-  
-      def get_options(defined_options, result)
+
+      def get_options(_defined_options, result)
         result['option_content_view_id'] = @command.option_id
         result['option_lifecycle_environment_names'] = result['option_environment_names']
         result
       end
     end
-    
+
     class RemoveCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async
       include OrganizationOptions
@@ -267,7 +267,7 @@ module HammerCLIKatello
           end
         end
       end
-      
+
       success_message _("Content view objects are being removed task %{id}")
       failure_message _("Could not remove objects from content view")
 

--- a/lib/hammer_cli_katello/foreman_search_options_creators.rb
+++ b/lib/hammer_cli_katello/foreman_search_options_creators.rb
@@ -1,71 +1,71 @@
 module HammerCLIKatello
   module ForemanSearchOptionsCreators
-    def create_environments_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:environments))
+    def create_environments_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:environments), mode)
     end
 
-    def create_organizations_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:organizations))
+    def create_organizations_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:organizations), mode)
     end
 
-    def create_smart_proxies_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:smart_proxies))
+    def create_smart_proxies_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:smart_proxies), mode)
     end
 
-    def create_capsules_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:smart_proxies))
+    def create_capsules_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:smart_proxies), mode)
     end
 
-    def create_hosts_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:hosts))
+    def create_hosts_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:hosts), mode)
     end
 
-    def create_architectures_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:architectures))
+    def create_architectures_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:architectures), mode)
     end
 
-    def create_operatingsystems_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:operatingsystems))
+    def create_operatingsystems_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:operatingsystems), mode)
     end
 
-    def create_domains_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:domains))
+    def create_domains_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:domains), mode)
     end
 
-    def create_locations_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:locations))
+    def create_locations_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:locations), mode)
     end
 
-    def create_media_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:media))
+    def create_media_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:media), mode)
     end
 
-    def create_hostgroups_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:hostgroups))
+    def create_hostgroups_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:hostgroups), mode)
     end
 
-    def create_ptables_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:ptables))
+    def create_ptables_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:ptables), mode)
     end
 
-    def create_puppet_ca_proxies_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:puppet_ca_proxies))
+    def create_puppet_ca_proxies_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:puppet_ca_proxies), mode)
     end
 
-    def create_puppet_proxies_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:puppet_proxies))
+    def create_puppet_proxies_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:puppet_proxies), mode)
     end
 
-    def create_puppetclasses_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:puppetclasses))
+    def create_puppetclasses_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:puppetclasses), mode)
     end
 
-    def create_subnets_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:subnets))
+    def create_subnets_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:subnets), mode)
     end
 
-    def create_realms_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:realms))
+    def create_realms_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:realms), mode)
     end
   end
 end

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -42,7 +42,6 @@ module HammerCLIKatello
     end
   end
 
-  # rubocop:disable ClassLength
   class IdResolver < HammerCLIForeman::IdResolver
     include HammerCLIKatello::SearchOptionsCreators
 
@@ -117,32 +116,23 @@ module HammerCLIKatello
 
     def content_view_version_ids(options)
       key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
+      options[key_content_view_id] ||= search_and_rescue(:content_view_id, "content_view", options)
       if options['option_versions'] && options[key_content_view_id]
-        # FIXME: options[key_content_view_id] can not be false in this branch
-        options[key_content_view_id] ||= search_and_rescue(:content_view_id,
-                                                           "content_view", options)
         id_strings = options['option_versions'].map do |version|
           cvv_options = {'option_version' => version}
           cvv_options['option_id'] = nil if options['option_id'] # hide irrelevant id
           content_view_version_id(options.merge(cvv_options))
         end
-        id_strings.join(',') # FIXME: why we join to split later?
+        id_strings.join(',')
       end
     end
 
     def content_view_version_id(options)
       key_id = HammerCLI.option_accessor_name("id")
-      key_environment_id = HammerCLI.option_accessor_name("environment_id")
       key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
       from_environment_id = HammerCLI.option_accessor_name("from_environment_id")
 
       return options[key_id] if options[key_id]
-
-      if options[key_environment_id]
-        # FIXME: ???
-        options[key_environment_id] ||= search_and_rescue(
-          :lifecycle_environment_id, "environment", options)
-      end
 
       options[key_content_view_id] ||= search_and_rescue(:content_view_id, "content_view", options)
 

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -118,12 +118,15 @@ module HammerCLIKatello
     def content_view_version_ids(options)
       key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
       if options['option_versions'] && options[key_content_view_id]
+        # FIXME: options[key_content_view_id] can not be false in this branch
         options[key_content_view_id] ||= search_and_rescue(:content_view_id,
                                                            "content_view", options)
         id_strings = options['option_versions'].map do |version|
-          content_view_version_id(options.merge('option_version' => version))
+          cvv_options = {'option_version' => version}
+          cvv_options['option_id'] = nil if options['option_id'] # hide irrelevant id
+          content_view_version_id(options.merge(cvv_options))
         end
-        id_strings.join(',')
+        id_strings.join(',') # FIXME: why we join to split later?
       end
     end
 
@@ -136,6 +139,7 @@ module HammerCLIKatello
       return options[key_id] if options[key_id]
 
       if options[key_environment_id]
+        # FIXME: ???
         options[key_environment_id] ||= search_and_rescue(
           :lifecycle_environment_id, "environment", options)
       end

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -10,10 +10,11 @@ module HammerCLIKatello
     end
 
     def create_content_view_filter_rules_search_options(options, mode = nil)
-      create_search_options_without_katello_api(options, api.resource(:content_view_filter_rules), mode)
+      create_search_options_without_katello_api(
+        options, api.resource(:content_view_filter_rules), mode)
     end
 
-    def create_repositories_search_options(options, mode = nil)
+    def create_repositories_search_options(options, _mode = nil)
       name = options[HammerCLI.option_accessor_name("name")]
       names = options[HammerCLI.option_accessor_name("names")]
       product_id = options[HammerCLI.option_accessor_name("product_id")]
@@ -25,7 +26,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_content_views_search_options(options, mode = nil)
+    def create_content_views_search_options(options, _mode = nil)
       name = options[HammerCLI.option_accessor_name('name')]
       organization_id = options[HammerCLI.option_accessor_name("organization_id")] ||
                         organization_id(scoped_options('organization', options, :single))
@@ -52,7 +53,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_content_view_versions_search_options(options, mode = nil)
+    def create_content_view_versions_search_options(options, _mode = nil)
       environment_id = options[HammerCLI.option_accessor_name("environment_id")]
       content_view_id = options[HammerCLI.option_accessor_name("content_view_id")]
       version = options[HammerCLI.option_accessor_name("version")]
@@ -76,7 +77,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_search_options_with_katello_api(options, resource, mode = nil)
+    def create_search_options_with_katello_api(options, resource, _mode = nil)
       search_options = {}
       searchables(resource).each do |s|
         value = options[HammerCLI.option_accessor_name(s.name.to_s)]

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -38,7 +38,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_lifecycle_environments_search_options(options, mode=nil)
+    def create_lifecycle_environments_search_options(options, mode = nil)
       search_options = {}
       if mode != :multi
         name = options[HammerCLI.option_accessor_name("name")]

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -4,16 +4,16 @@ module HammerCLIKatello
   module SearchOptionsCreators
     include HammerCLIKatello::ForemanSearchOptionsCreators
 
-    def create_file_units_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:file_units))
-        .merge(create_search_options(options, api.resource(:file_units)))
+    def create_file_units_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:file_units), mode)
+        .merge(create_search_options(options, api.resource(:file_units), mode))
     end
 
-    def create_content_view_filter_rules_search_options(options)
-      create_search_options_without_katello_api(options, api.resource(:content_view_filter_rules))
+    def create_content_view_filter_rules_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:content_view_filter_rules), mode)
     end
 
-    def create_repositories_search_options(options)
+    def create_repositories_search_options(options, mode = nil)
       name = options[HammerCLI.option_accessor_name("name")]
       names = options[HammerCLI.option_accessor_name("names")]
       product_id = options[HammerCLI.option_accessor_name("product_id")]
@@ -25,7 +25,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_content_views_search_options(options)
+    def create_content_views_search_options(options, mode = nil)
       name = options[HammerCLI.option_accessor_name('name')]
       organization_id = options[HammerCLI.option_accessor_name("organization_id")] ||
                         organization_id(scoped_options('organization', options, :single))
@@ -52,7 +52,7 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_content_view_versions_search_options(options)
+    def create_content_view_versions_search_options(options, mode = nil)
       environment_id = options[HammerCLI.option_accessor_name("environment_id")]
       content_view_id = options[HammerCLI.option_accessor_name("content_view_id")]
       version = options[HammerCLI.option_accessor_name("version")]
@@ -65,18 +65,18 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_host_collections_search_options(options)
+    def create_host_collections_search_options(options, mode = nil)
       options[HammerCLI.option_accessor_name("organization_id")] ||= organization_id(
-        scoped_options("organization", options)
+        scoped_options("organization", options, :single)
       )
       search_options = create_search_options_with_katello_api(
-        options, api.resource(:host_collections)
+        options, api.resource(:host_collections), mode
       ) || {}
       search_options['organization_id'] ||= options['option_organization_id']
       search_options
     end
 
-    def create_search_options_with_katello_api(options, resource)
+    def create_search_options_with_katello_api(options, resource, mode = nil)
       search_options = {}
       searchables(resource).each do |s|
         value = options[HammerCLI.option_accessor_name(s.name.to_s)]

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -28,7 +28,7 @@ module HammerCLIKatello
     def create_content_views_search_options(options)
       name = options[HammerCLI.option_accessor_name('name')]
       organization_id = options[HammerCLI.option_accessor_name("organization_id")] ||
-                        organization_id(scoped_options('organization', options))
+                        organization_id(scoped_options('organization', options, :single))
 
       search_options = {}
       search_options['name'] = name if name
@@ -38,13 +38,14 @@ module HammerCLIKatello
       search_options
     end
 
-    def create_lifecycle_environments_search_options(options)
-      name = options[HammerCLI.option_accessor_name("name")]
-      organization_id = options[HammerCLI.option_accessor_name("organization_id")] ||
-                        organization_id(scoped_options('organization', options))
-
+    def create_lifecycle_environments_search_options(options, mode=nil)
       search_options = {}
-      search_options['name'] = name if name
+      if mode != :multi
+        name = options[HammerCLI.option_accessor_name("name")]
+        search_options['name'] = name if name
+      end
+      organization_id = organization_id(scoped_options('organization', options, :single))
+
       if options['option_lifecycle_environment_names'] || name
         search_options['organization_id'] = organization_id
       end

--- a/test/functional/content_view/filter/delete_test.rb
+++ b/test/functional/content_view/filter/delete_test.rb
@@ -26,7 +26,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1)
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -45,7 +44,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1, field: 'label')
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -63,7 +61,6 @@ module HammerCLIKatello
       params = ['--name=scanner', '--content-view=darkly', '--organization-id=1']
 
       expect_content_view_search('1', 'darkly', 1)
-      expect_content_view_search('1', 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'

--- a/test/functional/content_view/filter/info_test.rb
+++ b/test/functional/content_view/filter/info_test.rb
@@ -26,7 +26,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1)
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -45,7 +44,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1, field: 'label')
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -63,7 +61,6 @@ module HammerCLIKatello
       params = ['--name=scanner', '--content-view=darkly', '--organization-id=1']
 
       expect_content_view_search('1', 'darkly', 1)
-      expect_content_view_search('1', 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'

--- a/test/functional/content_view/filter/update_test.rb
+++ b/test/functional/content_view/filter/update_test.rb
@@ -26,7 +26,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1)
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -46,7 +45,6 @@ module HammerCLIKatello
 
       expect_organization_search('pkd', 1, field: 'label')
       expect_content_view_search(1, 'darkly', 1)
-      expect_content_view_search(1, 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'
@@ -64,7 +62,6 @@ module HammerCLIKatello
       params = ['--name=scanner', '--content-view=darkly', '--organization-id=1', '--new-name=ubik']
 
       expect_content_view_search('1', 'darkly', 1)
-      expect_content_view_search('1', 'darkly', 1) # redmine #15930
 
       ex = api_expects(:content_view_filters, :index, 'Content view filters list') do |par|
         par['content_view_id'] == 1 && par['name'] == 'scanner'

--- a/test/functional/host_collection/add_host_test.rb
+++ b/test/functional/host_collection/add_host_test.rb
@@ -43,9 +43,9 @@ module HammerCLIKatello
 
     it 'requires organization options if name is specified' do
       result = run_cmd(%w(host-collection add-host --name hc1))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do

--- a/test/functional/host_collection/copy_test.rb
+++ b/test/functional/host_collection/copy_test.rb
@@ -17,9 +17,9 @@ module HammerCLIKatello
 
     it 'requires organization options if name is specified' do
       result = run_cmd(%w(host-collection copy --name hc1 --new-name foo))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do

--- a/test/functional/host_collection/delete_test.rb
+++ b/test/functional/host_collection/delete_test.rb
@@ -10,9 +10,9 @@ module HammerCLIKatello
 
     it 'requires organization options if name is specified' do
       result = run_cmd(%w(host-collection delete --name hc1))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do

--- a/test/functional/host_collection/hosts_test.rb
+++ b/test/functional/host_collection/hosts_test.rb
@@ -24,8 +24,7 @@ module HammerCLIKatello
 
     it 'requires organization with host collection name' do
       result = run_cmd(%w(host-collection hosts --name collection))
-      expected_error = "Error: Could not find organization, please set one of options " \
-                       "--organization, --organization-label, --organization-id."
+      expected_error = "Missing options to search organization"
       assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
       assert_equal(expected_error, result.err[/#{expected_error}/])
     end

--- a/test/functional/host_collection/info_test.rb
+++ b/test/functional/host_collection/info_test.rb
@@ -10,9 +10,9 @@ module HammerCLIKatello
 
     it 'requires organization options if id is not specified' do
       result = run_cmd(%w(host-collection info --name hc1))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do

--- a/test/functional/host_collection/remove_host_test.rb
+++ b/test/functional/host_collection/remove_host_test.rb
@@ -43,9 +43,9 @@ module HammerCLIKatello
 
     it 'requires organization options if name is specified' do
       result = run_cmd(%w(host-collection remove-host --name hc1))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do

--- a/test/functional/host_collection/update_test.rb
+++ b/test/functional/host_collection/update_test.rb
@@ -10,9 +10,9 @@ module HammerCLIKatello
 
     it 'requires organization options if name is specified' do
       result = run_cmd(%w(host-collection update --name hc1))
-      expected_error = "Could not find organization"
-      assert_equal(result.exit_code, HammerCLI::EX_SOFTWARE)
-      assert_equal(result.err[/#{expected_error}/], expected_error)
+      expected_error = "Missing options to search organization"
+      assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+      assert_equal(expected_error, result.err[/#{expected_error}/])
     end
 
     it 'allows organization id' do


### PR DESCRIPTION
https://github.com/theforeman/hammer-cli-foreman/pull/346 brings some incompatible and test braking changes. This patch is fixing the tests and commands that were obviously broken by the changes.

For testing it is necessary to use hammer-cli master, latest apipie-bindings (0.2.2), hammer-cli-foreman with https://github.com/theforeman/hammer-cli-foreman/pull/346, and foreman with https://github.com/theforeman/foreman/pull/4917 (merged a few weeks ago).

