### PR TITLE
Fixes #22824: Fix cv_version_ids resolution

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -114,19 +114,6 @@ module HammerCLIKatello
       end
     end
 
-    def content_view_version_ids(options)
-      key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
-      options[key_content_view_id] ||= search_and_rescue(:content_view_id, "content_view", options)
-      if options['option_versions'] && options[key_content_view_id]
-        id_strings = options['option_versions'].map do |version|
-          cvv_options = {'option_version' => version}
-          cvv_options['option_id'] = nil if options['option_id'] # hide irrelevant id
-          content_view_version_id(options.merge(cvv_options))
-        end
-        id_strings.join(',')
-      end
-    end
-
     def content_view_version_id(options)
       key_id = HammerCLI.option_accessor_name("id")
       key_content_view_id = HammerCLI.option_accessor_name("content_view_id")

--- a/lib/hammer_cli_katello/search_options_creators.rb
+++ b/lib/hammer_cli_katello/search_options_creators.rb
@@ -57,8 +57,15 @@ module HammerCLIKatello
       environment_id = options[HammerCLI.option_accessor_name("environment_id")]
       content_view_id = options[HammerCLI.option_accessor_name("content_view_id")]
       version = options[HammerCLI.option_accessor_name("version")]
+      versions = options[HammerCLI.option_accessor_name("versions")]
 
       search_options = {}
+
+      if versions
+        search_options.merge!(
+          create_search_options_without_katello_api(options, api.resource(:content_view_versions))
+        )
+      end
 
       search_options['content_view_id'] = content_view_id if content_view_id
       search_options['environment_id'] = environment_id if environment_id && content_view_id

--- a/test/unit/id_resolver_test.rb
+++ b/test/unit/id_resolver_test.rb
@@ -54,20 +54,5 @@ module HammerCLIKatello
         id_resolver.content_view_version_id(options).must_equal 5
       end
     end
-
-    describe '#content_view_version_ids' do
-      it 'resolves IDs from version numbers' do
-        versions = %w(2.0 3.0)
-        version_ids = [2, 3]
-        response = "{\"id\"=>2},{\"id\"=>3}"
-        options = {'option_versions' => versions, 'option_content_view_id' => 4}
-        versions.each_with_index do |version, i|
-          id_resolver.expects(:content_view_version_id)
-                     .with(options.merge('option_version' => version))
-                     .returns(['id' => version_ids[i]])
-        end
-        id_resolver.content_view_version_ids(options).must_equal response
-      end
-    end
   end
 end


### PR DESCRIPTION
Related to https://github.com/Katello/hammer-cli-katello/pull/535

The only way to properly resolve the `content_view_version_ids` in one API request is to use the `HammerCliForeman::SearchOptionCreator#create_search_options` (aka `HammerCliKatello::SearchOptionCreator#create_search_options_without_katello`), which appends a scoped_search search param to the `search_options`.