### PR TITLE
Fixes #23323 - Shows ignorable units in repo

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -44,6 +44,7 @@ module HammerCLIKatello
               Fields::Field, :hide_blank => true
         field :container_repository_name, _("Container Repository Name"),
               Fields::Field, :hide_blank => true
+        field :ignorable_content, _("Ignorable Content Units"), Fields::List, :hide_blank => true
 
         label _("Product") do
           from :product do


### PR DESCRIPTION
This commit feeds of the upstream 'ignorable content' feature and shows
content units that are going to be ignored during a sync operation for
that repo. This is only available for yum repos.