### PR TITLE
Fixes #23772: int->str for task IDs in tests

### DIFF
--- a/test/functional/content_view/remove_test.rb
+++ b/test/functional/content_view/remove_test.rb
@@ -10,7 +10,7 @@ module HammerCLIKatello
         ex = api_expects(:content_views, :remove) do |p|
           p['id'] == 1 && p['content_view_version_ids'] == %w(6 7 8)
         end
-        ex.returns(id: 9)
+        ex.returns(id: '9')
 
         expect_foreman_task('9')
 
@@ -28,7 +28,7 @@ module HammerCLIKatello
 
         api_expects(:content_views, :remove).with_params(
           'id' => 1, 'content_view_version_ids' => ids
-        ).returns(id: 9)
+        ).returns(id: '9')
 
         expect_foreman_task('9')
 
@@ -41,7 +41,7 @@ module HammerCLIKatello
         ex = api_expects(:content_views, :remove) do |p|
           p['id'] == 1 && p['environment_ids'] == %w(6 7 8)
         end
-        ex.returns(id: 9)
+        ex.returns(id: '9')
 
         expect_foreman_task('9')
 
@@ -68,7 +68,7 @@ module HammerCLIKatello
         ex = api_expects(:content_views, :remove) do |p|
           p['id'] == 1 && p['environment_ids'] == environment_ids
         end
-        ex.returns(id: 9)
+        ex.returns(id: '9')
 
         expect_foreman_task('9')
 

--- a/test/functional/host/errata/apply_test.rb
+++ b/test/functional/host/errata/apply_test.rb
@@ -11,7 +11,7 @@ describe 'apply an errata' do
 
   let(:errata_id) { "RHEA-1111:1111" }
   let(:host_id) { 1 }
-  let(:task_id) { 5 }
+  let(:task_id) { '5' }
   let(:response) do
     {
       'id' => task_id,

--- a/test/functional/repository/export_test.rb
+++ b/test/functional/repository/export_test.rb
@@ -11,9 +11,9 @@ module HammerCLIKatello
       ex = api_expects(:repositories, :export) do |p|
         p['id'] == 1
       end
-      ex.returns(id: 2)
+      ex.returns(id: '2')
 
-      expect_foreman_task(2)
+      expect_foreman_task('2')
 
       run_cmd(%w(repository export --id 1))
     end
@@ -34,9 +34,9 @@ module HammerCLIKatello
         ex = api_expects(:repositories, :export) do |p|
           p['id'] == 1
         end
-        ex.returns(id: 2)
+        ex.returns(id: '2')
 
-        expect_foreman_task(2)
+        expect_foreman_task('2')
 
         run_cmd(%w(repository export --name repo1 --product-id 3))
       end
@@ -64,9 +64,9 @@ module HammerCLIKatello
         ex = api_expects(:repositories, :export) do |p|
           p['id'] == 1
         end
-        ex.returns(id: 2)
+        ex.returns(id: '2')
 
-        expect_foreman_task(2)
+        expect_foreman_task('2')
 
         run_cmd(%w(repository export --name repo1 --product prod3 --organization-id 5))
       end
@@ -87,9 +87,9 @@ module HammerCLIKatello
         ex = api_expects(:repositories, :export) do |p|
           p['id'] == 1
         end
-        ex.returns(id: 2)
+        ex.returns(id: '2')
 
-        expect_foreman_task(2)
+        expect_foreman_task('2')
 
         run_cmd(%w(repository export --name repo1 --product prod3 --organization org5))
       end
@@ -110,9 +110,9 @@ module HammerCLIKatello
         ex = api_expects(:repositories, :export) do |p|
           p['id'] == 1
         end
-        ex.returns(id: 2)
+        ex.returns(id: '2')
 
-        expect_foreman_task(2)
+        expect_foreman_task('2')
 
         run_cmd(%w(repository export --name repo1 --product prod3 --organization-label org5))
       end

--- a/test/functional/repository/synchronize_test.rb
+++ b/test/functional/repository/synchronize_test.rb
@@ -16,7 +16,7 @@ describe 'Synchronize a repository' do
   let(:product_id) { 3 }
   let(:sync_response) do
     {
-      'id' => repo_id,
+      'id' => repo_id.to_s,
       'state' => 'planned'
     }
   end
@@ -30,7 +30,7 @@ describe 'Synchronize a repository' do
 
     ex.returns(sync_response)
 
-    expect_foreman_task(3)
+    expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
     assert_equal(result.exit_code, 0)
@@ -49,7 +49,7 @@ describe 'Synchronize a repository' do
 
     ex.returns(sync_response)
 
-    expect_foreman_task(3)
+    expect_foreman_task('3')
 
     result = run_cmd(@cmd + params)
     assert_equal(result.exit_code, 0)


### PR DESCRIPTION
task IDs are of the form '31b2acdd-e5e0-4cc3-8e90-7c908ef3fd26', and we simplify that in tests. We just need to be careful to use string values and never integers because of [this method](https://github.com/theforeman/hammer-cli-foreman-tasks/blob/master/lib/hammer_cli_foreman_tasks/helper.rb#L4), which would call `.empty?` on any integer passed in.