### PR TITLE
Fixes #23872 - fix the missing values

### DIFF
--- a/lib/hammer_cli_katello/host_kickstart_repository_options.rb
+++ b/lib/hammer_cli_katello/host_kickstart_repository_options.rb
@@ -34,9 +34,9 @@ module HammerCLIKatello
     def fetch_repo_id(cv_id, env_id, repo_name)
       repo_resource = HammerCLIForeman.foreman_resource(:repositories)
       index_options = {
-        "content_view_id" => cv_id,
-        "environment_id" => env_id,
-        "name" => repo_name
+        :content_view_id => cv_id,
+        :environment_id => env_id,
+        :name => repo_name
       }
       repos = repo_resource.call(:index, index_options)["results"]
       if repos.empty?


### PR DESCRIPTION
```
raise _("No such repository with name %{name}, in lifecycle environment"\
                 " %{environment_id} and content view %{content_view_id}" % index_options)
```
would work perfectly fine if the index_options had its keys in the form of symbols.