### PR TITLE
Fixes #24060 - fix Puppet environments for host commands

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -5,16 +5,19 @@ require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_package_group'
 require 'hammer_cli_katello/host_kickstart_repository_options'
 require 'hammer_cli_katello/host_content_source_options'
+require 'hammer_cli_katello/puppet_environment_name_resolvable'
 
 module HammerCLIKatello
   module HostExtensions
     ::HammerCLIForeman::Host::CreateCommand.instance_eval do
+      include HammerCLIKatello::PuppetEnvironmentNameResolvable
       include HammerCLIKatello::ResolverCommons
       include HammerCLIKatello::HostContentSourceOptions
       include ::HammerCLIKatello::HostKickstartRepositoryOptions
     end
 
     ::HammerCLIForeman::Host::UpdateCommand.instance_eval do
+      include HammerCLIKatello::PuppetEnvironmentNameResolvable
       include HammerCLIKatello::ResolverCommons
       include HammerCLIKatello::HostContentSourceOptions
       include ::HammerCLIKatello::HostKickstartRepositoryOptions

--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -1,31 +1,9 @@
 require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_katello/puppet_environment_name_resolvable'
 require 'hammer_cli_katello/host_kickstart_repository_options'
 require 'hammer_cli_katello/host_content_source_options'
 
 module HammerCLIKatello
-  module PuppetEnvironmentNameResolvable
-    class PuppetEnvParamSource
-      def initialize(command)
-        @command = command
-      end
-
-      def get_options(_defined_options, result)
-        if result['option_environment_id'].nil? && result['option_environment_name']
-          result['option_environment_id'] = @command.resolver.puppet_environment_id(
-            @command.resolver.scoped_options('environment', result, :single))
-        end
-        result
-      end
-    end
-
-    def option_sources
-      sources = super
-      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-      sources.insert(idx, PuppetEnvParamSource.new(self))
-      sources
-    end
-  end
-
   module QueryOrganizationOptions
     def self.included(base)
       base.option '--query-organization-id', 'ORGANIZATION_ID',

--- a/lib/hammer_cli_katello/puppet_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/puppet_environment_name_resolvable.rb
@@ -1,0 +1,24 @@
+module HammerCLIKatello
+  module PuppetEnvironmentNameResolvable
+    class PuppetEnvParamSource
+      def initialize(command)
+        @command = command
+      end
+
+      def get_options(_defined_options, result)
+        if result['option_environment_id'].nil? && result['option_environment_name']
+          result['option_environment_id'] = @command.resolver.puppet_environment_id(
+            @command.resolver.scoped_options('environment', result, :single))
+        end
+        result
+      end
+    end
+
+    def option_sources
+      sources = super
+      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
+      sources.insert(idx, PuppetEnvParamSource.new(self))
+      sources
+    end
+  end
+end


### PR DESCRIPTION
Before this patch, the --environment option in host command was trying
to search in lifecycle environments. Reusing the resolvable definition
from the hostgroup, as they both should have the same behavior.