### PR TITLE
Fixes #24528: s/smart_proxy/Content Source/

### DIFF
--- a/lib/hammer_cli_katello/host_content_source_options.rb
+++ b/lib/hammer_cli_katello/host_content_source_options.rb
@@ -20,6 +20,9 @@ module HammerCLIKatello
           resource_hash["content_source_id"] = resolver.smart_proxy_id(proxy_options)
         end
       end
+    rescue HammerCLIForeman::ResolverError => e
+      e.message.gsub!('smart_proxy', _('Content Source'))
+      raise e
     end
   end
 end


### PR DESCRIPTION
When users provide `--content-source foo`, they should receive back
error messages talking about content source, not smart proxies.