### PR TITLE
Fixes #24894 - Support for cron expressions

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -9,6 +9,7 @@ module HammerCLIKatello
         field :sync_date, _("Start Date"), Fields::Date
         field :interval, _("Interval")
         field :enabled, _("Enabled"), Fields::Boolean
+        field :cron_expression, _("Cron Expression")
       end
 
       build_options
@@ -30,10 +31,9 @@ module HammerCLIKatello
     end
 
     class CreateCommand < HammerCLIKatello::CreateCommand
-      option "--interval", "INTERVAL", _("how often synchronization should run"),
-             :format => HammerCLI::Options::Normalizers::Enum.new(
-               %w(hourly daily weekly)
-             )
+      option "--interval", "INTERVAL", _("how often synchronization should run")
+
+      option "--cron-expression", "CRON EXPRESSION", _("set this when interval is custom cron")
 
       option "--sync-date", "SYNC_DATE",
              _("Start date and time for the sync plan." \
@@ -47,10 +47,8 @@ module HammerCLIKatello
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand
-      option "--interval", "INTERVAL", _("how often synchronization should run"),
-             :format => HammerCLI::Options::Normalizers::Enum.new(
-               %w(hourly daily weekly)
-             )
+      option "--interval", "INTERVAL", _("how often synchronization should run")
+
       option "--sync-date", "SYNC_DATE", _("start date and time of the synchronization"),
              :format => HammerCLI::Options::Normalizers::DateTime.new
 

--- a/test/functional/sync_plan/create_test.rb
+++ b/test/functional/sync_plan/create_test.rb
@@ -1,0 +1,60 @@
+require_relative '../test_helper'
+
+describe "create sync plan" do
+  let(:org_id) { 1 }
+  let(:name) { "sync_plan1" }
+  let(:hourly) { "hourly" }
+  let(:custom) { "custom cron" }
+  let(:cron) { "10 * * * *" }
+  let(:date) { "2018-09-08T00:00:00+00:00" }
+
+  it 'with organization ID,name,interval,date and enabled' do
+    api_expects(:sync_plans, :create, 'create a sync plan').
+      with_params('organization_id' => org_id,
+                  'name' => name,
+                  'interval' => hourly,
+                  'sync_date' => date,
+                  'enabled' => true)
+    command = %W(sync-plan create --organization-id #{org_id} --name #{name}
+                 --interval #{hourly} --enabled 1 --sync-date #{date})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'with custom cron' do
+    api_expects(:sync_plans, :create, 'create a sync plan').
+      with_params('organization_id' => org_id,
+                  'name' => name,
+                  'interval' => custom,
+                  'cron_expression' => cron,
+                  'sync_date' => date,
+                  'enabled' => true)
+    # end
+    command = %W(sync-plan create --organization-id #{org_id} --name #{name} --interval #{custom}
+                 --cron-expression #{cron} --enabled 1 --sync-date #{date})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'fails without organization-id' do
+    command = %w(sync-plan create --name #{name}
+                 --interval #{hourly} --enabled 1 --sync-date #{date})
+    refute_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'fails without name' do
+    command = %w(sync-plan create --organization-id #{org_id}
+                 --interval #{hourly} --enabled 1 --sync-date #{date})
+    refute_equal(0, run_cmd(command).err)
+  end
+
+  it 'fails without interval' do
+    command = %w(sync-plan create --organization-id #{org_id} --name #{name}
+                 --enabled 1 --sync-date #{date})
+    refute_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'fails without enabled' do
+    command = %w(sync-plan create --organization-id #{org_id} --name #{name}
+                 --interval #{hourly} --sync-date #{date})
+    refute_equal(0, run_cmd(command).exit_code)
+  end
+end

--- a/test/functional/sync_plan/delete_test.rb
+++ b/test/functional/sync_plan/delete_test.rb
@@ -1,0 +1,46 @@
+require_relative '../test_helper'
+require_relative 'sync_plan_helpers'
+require_relative '../organization/organization_helpers'
+
+describe 'delete a sync plan' do
+  include OrganizationHelpers
+  include SyncPlanHelpers
+
+  let(:org_id) { 1 }
+  let(:id) { 1 }
+  let(:name) { "sync_plan1" }
+  let(:org_name) { "org1" }
+
+  it 'by organization ID and sync plan id' do
+    api_expects(:sync_plans, :destroy, 'delete a sync plan').
+      with_params('organization_id' => org_id,
+                  'id' => id)
+    command = %W(sync-plan delete --organization-id #{org_id} --id #{id})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'by organization ID and sync plan name' do
+    expect_sync_plan_search(1, 'sync_plan1', 1)
+    api_expects(:sync_plans, :destroy, 'delete a sync plan').
+      with_params('id' => id)
+    command = %W(sync-plan delete --organization-id #{org_id} --name #{name})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'by organization name and sync plan name' do
+    expect_organization_search('org1', 1)
+    expect_sync_plan_search(1, 'sync_plan1', 1)
+    api_expects(:sync_plans, :destroy, 'delete a sync plan').
+      with_params('id' => id)
+    command = %W(sync-plan delete --organization #{org_name} --name #{name})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'by organization name and sync plan id' do
+    expect_organization_search(org_name, org_id)
+    api_expects(:sync_plans, :destroy, 'delete a sync plan').
+      with_params('id' => id)
+    command = %W(sync-plan delete --organization #{org_name} --id #{id})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+end

--- a/test/functional/sync_plan/update_test.rb
+++ b/test/functional/sync_plan/update_test.rb
@@ -1,0 +1,44 @@
+require_relative '../test_helper'
+require_relative 'sync_plan_helpers'
+require_relative '../organization/organization_helpers'
+
+describe 'update a sync plan' do
+  include OrganizationHelpers
+  include SyncPlanHelpers
+
+  let(:org_id) { 1 }
+  let(:id) { 1 }
+  let(:name) { "sync_plan1" }
+  let(:org_name) { "org1" }
+  let(:desc) { "New Description" }
+
+  it 'with organization id and sync plan ID' do
+    api_expects(:sync_plans, :update, 'update a sync plan').
+      with_params('description' => desc,
+                  'id' => id)
+    command = %W(sync-plan update --organization-id #{org_id} --id #{id}
+                 --description #{desc})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'with organization ID and sync plan name' do
+    expect_sync_plan_search(org_id, name, id)
+    api_expects(:sync_plans, :update, 'update a sync plan').
+      with_params('description' => desc,
+                  'id' => id)
+    command = %W(sync-plan update --organization-id #{org_id} --name #{name}
+                 --description #{desc})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'with organization name and sync plan name' do
+    expect_organization_search(org_name, org_id)
+    expect_sync_plan_search(org_id, name, id)
+    api_expects(:sync_plans, :update, 'update a sync plan').
+      with_params('description' => desc,
+                  'id' => id)
+    command = %W(sync-plan update --organization #{org_name} --name #{name}
+                 --description #{desc})
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+end


### PR DESCRIPTION
Adds support for custom cron expressions in sync plans.

Requires https://github.com/Katello/katello/pull/7644 , https://github.com/Katello/katello/pull/7700