### PR TITLE
Fixes #18340 - Consistent hammer params for ordering

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -43,6 +43,13 @@ module HammerCLIKatello
 
   class ListCommand < HammerCLIForeman::ListCommand
     include HammerCLIKatello::ResolverCommons
+
+    def self.build_options(builder_params = {}, &block)
+      # remove --sort-by and --sort-order in favor of the Foreman's --order
+      builder_params[:without] ||= []
+      builder_params[:without] += %i(sort_by sort_order)
+      super(builder_params, &block)
+    end
   end
 
   class InfoCommand < HammerCLIForeman::InfoCommand


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/7707 to be merged first as it removes `--by` option automatically and adds two new options `--sort-by` and `--sort-order` which should be also removed according to the issue.