### PR TITLE
fixes #25027 - fixes search for image by name

### DIFF
--- a/lib/hammer_cli_katello/foreman_search_options_creators.rb
+++ b/lib/hammer_cli_katello/foreman_search_options_creators.rb
@@ -76,7 +76,7 @@ module HammerCLIKatello
       create_search_options_without_katello_api(options, api.resource(:compute_resources), mode)
     end
 
-    def create_image_search_options(options, mode = nil)
+    def create_images_search_options(options, mode = nil)
       create_search_options_without_katello_api(options, api.resource(:images), mode)
     end
   end


### PR DESCRIPTION
Testing this will require a `compute_resource` with multiple associated images. Create a host with image based provisioning, and call the image by name rather than by id, i.e.:

`hammer host create --compute-resource-id 2 --architecture x86_64 --operatingsystem-id 1 --partition-table-id 1 --location-id 2 --organization-id 1 --name newhost --image "image1" --compute-profile-id 1 --hostgroup-id 1`