### PR TITLE
Use SPDX 2.0 codes

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
     "Zach Huntington-Meath"
   ]
   gem.email = ['katello@lists.fedorahosted.org']
-  gem.license = "GPL-3.0-only"
+  gem.license = "GPL-3.0"
   gem.description = 'Hammer-CLI-Katello is a plugin for Hammer to provide' \
     ' connectivity to a Katello server.'
   gem.summary = 'Katello commands for Hammer'


### PR DESCRIPTION
Ruby isn't using SPDX 3.0 codes yet so it still generates a warning.