### PR TITLE
Refs #24963 - pull all packages and handle multiple repos

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -305,14 +305,14 @@ module HammerCLIKatello
       def execute
         cvv = show(:content_view_versions, 'id' => options['option_id'])
         repositories = cvv['repositories'].collect do |repo|
-          show(:repositories, 'id' => repo['id'])
+          show(:repositories, 'id' => repo['id'], :full_result => true)
         end
 
         check_repo_download_policy(repositories)
 
         repositories.each do |repo|
-          repo['packages'] = index(:packages, 'repository_id' => repo['id'])
-          repo['errata'] = index(:errata, 'repository_id' => repo['id'])
+          repo['packages'] = index(:packages, 'repository_id' => repo['id'], :full_result => true)
+          repo['errata'] = index(:errata, 'repository_id' => repo['id'], :full_result => true)
         end
 
         json = export_json(cvv, repositories)
@@ -329,10 +329,14 @@ module HammerCLIKatello
         Dir.mkdir("#{options['option_export_dir']}/#{export_prefix}")
 
         Dir.chdir(PUBLISHED_REPOS_DIR) do
+          repo_tar = "#{options['option_export_dir']}/#{export_prefix}/#{export_repos_tar}"
+          repo_dirs = []
+
           repositories.each do |repo|
-            repo_tar = "#{options['option_export_dir']}/#{export_prefix}/#{export_repos_tar}"
-            `tar cvfh #{repo_tar} #{repo['relative_path']}`
+            repo_dirs.push(repo['relative_path'])
           end
+
+          `tar cvfh #{repo_tar} #{repo_dirs.join(" ")}`
         end
 
         Dir.chdir("#{options['option_export_dir']}/#{export_prefix}") do


### PR DESCRIPTION
Previously, only the first 20 package names in a repo would be fetched
for the export json. This resulted in partial CV version created on
import.

Additionally, the `tar` command was overwriting the old repo tarball
for each new repo.

This patch sends `:full_result => true` when the full results are
needed. It also constructs a full `tar` command that includes all repo
directories.