### PR TITLE
Fixes #25272 - add support for composite CV import/export

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -29,6 +29,7 @@ module HammerCLIKatello
   require 'hammer_cli_katello/id_name_options_validator'
   require 'hammer_cli_katello/local_helper'
   require 'hammer_cli_katello/apipie_helper'
+  require 'hammer_cli_katello/cv_import_export_helper'
 
   # commands
   HammerCLI::MainCommand.lazy_subcommand("activation-key", _("Manipulate activation keys"),

--- a/lib/hammer_cli_katello/apipie_helper.rb
+++ b/lib/hammer_cli_katello/apipie_helper.rb
@@ -8,6 +8,10 @@ module HammerCLIKatello
       call(:index, resource, options)['results']
     end
 
+    def update(resource, options = {})
+      call(:update, resource, options)['results']
+    end
+
     def call(action, resource, options = {})
       HammerCLIForeman.foreman_resource(resource).call(action, options)
     end

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -1,0 +1,83 @@
+module HammerCLIKatello
+  module CVImportExportHelper
+    PUBLISHED_REPOS_DIR = "/var/lib/pulp/published/yum/https/repos/".freeze
+
+    def fetch_cvv_repositories(cvv)
+      cvv['repositories'].collect do |repo|
+        show(:repositories, 'id' => repo['id'], :full_result => true)
+      end
+    end
+
+    def find_local_component_id(component_from_export)
+      *name, version = component_from_export.split(' ')
+      name = name.join(' ')
+      existing_component_cv = content_view(name, options['option_organization_id'])
+      found_composite_version = existing_component_cv['versions'].select do |v|
+        v['version'] == version
+      end
+      if found_composite_version.empty?
+        raise _("Unable to find CV version %{cvv} on system. Please ensure it " \
+                "is already imported." % {'cvv' => component_from_export})
+      end
+      found_composite_version.first['id']
+    end
+
+    def untar_export(options)
+      export_tar_file = options[:filename]
+      export_tar_dir =  options[:dirname]
+      export_tar_prefix = options[:prefix]
+
+      Dir.chdir(export_tar_dir) do
+        `tar -xf #{export_tar_file}`
+      end
+
+      Dir.chdir("#{export_tar_dir}/#{export_tar_prefix}") do
+        if File.exist?(export_tar_file.gsub('.tar', '-repos.tar'))
+          `tar -xf #{export_tar_file.gsub('.tar', '-repos.tar')}`
+        end
+      end
+    end
+
+    def obtain_export_params(option_export_tar)
+      export_tar_file = File.basename(option_export_tar)
+      {:filename => export_tar_file,
+       :dirname => File.dirname(option_export_tar),
+       :prefix => export_tar_file.gsub('.tar', '')}
+    end
+
+    def read_json(options)
+      export_tar_file = options[:filename]
+      export_tar_dir =  options[:dirname]
+      export_tar_prefix = options[:prefix]
+
+      json_file = export_tar_file.gsub('tar', 'json')
+      json_file = "#{export_tar_dir}/#{export_tar_prefix}/#{json_file}"
+      json_file = File.read(json_file)
+      JSON.parse(json_file)
+    end
+
+    def export_json(export_json_options)
+      content_view_version = export_json_options[:cvv]
+      repositories = export_json_options[:repositories]
+      json = {
+        "name" => content_view_version['content_view']['name'],
+        "major" => content_view_version['major'],
+        "minor" => content_view_version['minor']
+      }
+      json["composite_components"] = export_json_options[:component_cvvs]
+      json["repositories"] = repositories.collect do |repo|
+        {
+          "id" => repo['id'],
+          "label" => repo['label'],
+          "content_type" => repo['content_type'],
+          "backend_identifier" => repo['backend_identifier'],
+          "relative_path" => repo['relative_path'],
+          "on_disk_path" => "#{PUBLISHED_REPOS_DIR}/#{repo['relative_path']}",
+          "rpm_filenames" => repo['packages'].collect { |package| package['filename'] },
+          "errata_ids" => repo['errata'].collect { |errata| errata['errata_id'] }
+        }
+      end
+      json
+    end
+  end
+end

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -19,7 +19,14 @@ describe 'content-view version export' do
       'repositories' => [{'id' => '2'}],
       'major' => 1,
       'minor' => 0,
-      'content_view' => {'name' => 'cv'}
+      'content_view' => {'name' => 'cv'},
+      'content_view_id' => 4321
+    )
+
+    ex = api_expects(:content_views, :show)
+    ex.returns(
+      'id' => '4321',
+      'composite' => false
     )
 
     ex = api_expects(:repositories, :show).with_params('id' => '2')
@@ -40,10 +47,47 @@ describe 'content-view version export' do
     api_expects(:errata, :index).returns('results' => [])
 
     File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").returns(true)
     Dir.expects(:mkdir).with('/tmp/exports/export-5').returns(0)
     Dir.expects(:chdir).with('/tmp/exports').returns(0)
     Dir.expects(:chdir).with('/tmp/exports/export-5').returns(0)
+
+    result = run_cmd(@cmd + params)
+    assert_equal(HammerCLI::EX_OK, result.exit_code)
+  end
+
+  it "performs composite export" do
+    params = [
+      '--id=999',
+      '--export-dir=/tmp/exports'
+    ]
+
+    ex = api_expects(:content_view_versions, :show)
+    ex.returns(
+      'id' => '999',
+      'repositories' => [{'id' => '2'}],
+      'major' => 1,
+      'minor' => 0,
+      'content_view' => {'name' => 'cv'},
+      'content_view_id' => 4321
+    )
+
+    ex = api_expects(:content_views, :show)
+    ex.returns(
+      'id' => '4321',
+      'composite' => true,
+      'components' => [{ 'name' => "injera 95.5" }, {'name' => 'carrot wot 87.0'}]
+    )
+
+    File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
+    Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").never
+    Dir.expects(:mkdir).with('/tmp/exports/export-999').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-999').returns(0)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_OK, result.exit_code)
@@ -61,7 +105,14 @@ describe 'content-view version export' do
       'repositories' => [{'id' => '2'}],
       'major' => 1,
       'minor' => 0,
-      'content_view' => {'name' => 'cv'}
+      'content_view' => {'name' => 'cv'},
+      'content_view_id' => 4321
+    )
+
+    ex = api_expects(:content_views, :show)
+    ex.returns(
+      'id' => '4321',
+      'composite' => false
     )
 
     ex = api_expects(:repositories, :show).with_params('id' => '2')
@@ -80,6 +131,7 @@ describe 'content-view version export' do
     )
 
     File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)


### PR DESCRIPTION
Previously, CV import/export would treat composites as "regular"
content views.  This resulted in each repo of the composite being
exported as if it was part of a regular content view.

These exports were unable to be imported since the repos existed on
the components and not the composite.

This commit exports composite content views with information needed to
reconstitute them on the importing side. Each component CV name and
version is written to the JSON, and upon import, hammer searches for
the matching name and version on the importing side. If all of the
info lines up, the components are associated with the CV and a publish
occurs.