### PR TITLE
fixes #25404 - add command to recalculate errata for a host

### DIFF
--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -49,6 +49,16 @@ module HammerCLIKatello
       build_options
     end
 
+    class RecalculateCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+      resource :host_errata, :applicability
+      command_name "recalculate"
+      success_message _("Errata recalculated with task %{id}.")
+      failure_message _("Could not recalculate errata")
+
+      build_options
+    end
+
     autoload_subcommands
   end
 end

--- a/test/functional/host/errata/recalculate_test.rb
+++ b/test/functional/host/errata/recalculate_test.rb
@@ -21,11 +21,9 @@ describe 'recalculate errata' do
   it "recalculates errata for a host" do
     params = ["--host-id=#{host_id}"]
 
-    ex = api_expects(:host_errata, :applicability, 'Host errata recalculate') do |par|
-      par['host_id'] == host_id
-    end
-
-    ex.returns(response)
+    api_expects(:host_errata, :applicability, 'Host errata recalculate')
+      .with_params('host_id' => host_id)
+      .returns(response)
 
     expect_foreman_task(task_id)
 
@@ -35,11 +33,9 @@ describe 'recalculate errata' do
   it "applies an errata to a host with async flag" do
     params = ["--host-id=#{host_id}", "--async"]
 
-    ex = api_expects(:host_errata, :applicability, 'Host errata recalculate') do |par|
-      par['host_id'] == host_id
-    end
-
-    ex.returns(response)
+    api_expects(:host_errata, :applicability, 'Host errata recalculate')
+      .with_params('host_id' => host_id)
+      .returns(response)
 
     run_cmd(@cmd + params)
   end

--- a/test/functional/host/errata/recalculate_test.rb
+++ b/test/functional/host/errata/recalculate_test.rb
@@ -1,0 +1,46 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+require 'hammer_cli_katello/content_view_puppet_module'
+
+describe 'recalculate errata' do
+  include ForemanTaskHelpers
+
+  before do
+    @cmd = %w(host errata recalculate)
+  end
+
+  let(:host_id) { 1 }
+  let(:task_id) { '5' }
+  let(:response) do
+    {
+      'id' => task_id,
+      'state' => 'stopped'
+    }
+  end
+
+  it "recalculates errata for a host" do
+    params = ["--host-id=#{host_id}"]
+
+    ex = api_expects(:host_errata, :applicability, 'Host errata recalculate') do |par|
+      par['host_id'] == host_id
+    end
+
+    ex.returns(response)
+
+    expect_foreman_task(task_id)
+
+    run_cmd(@cmd + params)
+  end
+
+  it "applies an errata to a host with async flag" do
+    params = ["--host-id=#{host_id}", "--async"]
+
+    ex = api_expects(:host_errata, :applicability, 'Host errata recalculate') do |par|
+      par['host_id'] == host_id
+    end
+
+    ex.returns(response)
+
+    run_cmd(@cmd + params)
+  end
+end


### PR DESCRIPTION
This pull request adds a command to recalculate errata for a host.
It uses the /hosts/<host_id>/errata/applicability api endpoint.