### PR TITLE
Refs #22253 - Fixes after option validation is mixed with sources

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -90,7 +90,7 @@ module HammerCLIKatello
 
       option "--unlimited-hosts", :flag, "Set hosts max to unlimited"
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         all(:option_unlimited_hosts, :option_max_hosts).rejected
       end
 
@@ -159,7 +159,7 @@ module HammerCLIKatello
       option '--name', "ACTIVATION_KEY_NAME", _("Activation key name to search by"),
         attribute_name: :option_activation_key_name
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         any(:option_activation_key_id, :option_activation_key_name).required
       end
 
@@ -232,7 +232,7 @@ module HammerCLIKatello
       option "--name", "NAME", _("Name of activation key"),
              :attribute_name => :option_activation_key_name
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         any(:option_activation_key_id, :option_activation_key_name).required
       end
 

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -109,7 +109,7 @@ module HammerCLIKatello
         end
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         product_options = [:option_product_id, :option_product_name]
         if option(:option_repository_ids).exist?
           any(*product_options).rejected
@@ -138,7 +138,7 @@ module HammerCLIKatello
       option "--new-name", "NEW_NAME", _("New content view name"),
              :attribute_name => :option_new_name
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -165,7 +165,7 @@ module HammerCLIKatello
       success_message _("Content view updated.")
       failure_message _("Could not update the content view")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -187,7 +187,7 @@ module HammerCLIKatello
       success_message _("Content view is being deleted with task %{id}.")
       failure_message _("Could not delete the content view")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -227,7 +227,7 @@ module HammerCLIKatello
       build_options
     end
 
-    class CVEnvParamsSource
+    class CVEnvParamsSource < HammerCLI::Options::Sources::Base
       def initialize(command)
         @command = command
       end
@@ -257,8 +257,11 @@ module HammerCLIKatello
 
       def option_sources
         sources = super
-        idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-        sources.insert(idx, CVEnvParamsSource.new(self))
+        sources.find_by_name('IdResolution').insert_relative(
+          :after,
+          'IdParams',
+          CVEnvParamsSource.new(self)
+        )
         sources
       end
 
@@ -282,7 +285,7 @@ module HammerCLIKatello
       command_name 'add-version'
       desc _('Add a content view version to a composite view')
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         if option(:option_content_view_version_version).exist?
           any(:option_content_view_id, :option_content_view_name).required
         end
@@ -292,7 +295,7 @@ module HammerCLIKatello
         plural ? "components" : "component"
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -317,7 +320,7 @@ module HammerCLIKatello
       command_name 'remove-version'
       desc _('Remove a content view version from a composite view')
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         if option(:option_content_view_version_version).exist?
           any(:option_content_view_id, :option_content_view_name).required
         end
@@ -327,7 +330,7 @@ module HammerCLIKatello
         plural ? "components" : "component"
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 

--- a/lib/hammer_cli_katello/content_view_name_resolvable.rb
+++ b/lib/hammer_cli_katello/content_view_name_resolvable.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
   module ContentViewNameResolvable
-    class ContentViewParamSource
+    class ContentViewParamSource < HammerCLI::Options::Sources::Base
       def initialize(command)
         @command = command
       end
@@ -16,8 +16,11 @@ module HammerCLIKatello
 
     def option_sources
       sources = super
-      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-      sources.insert(idx, ContentViewParamSource.new(self))
+      sources.find_by_name('IdResolution').insert_relative(
+        :after,
+        'IdParams',
+        ContentViewParamSource.new(self)
+      )
       sources
     end
   end

--- a/lib/hammer_cli_katello/content_view_purge.rb
+++ b/lib/hammer_cli_katello/content_view_purge.rb
@@ -12,7 +12,7 @@ module HammerCLIKatello
     option "--count", "COUNT", _("count of unused versions to keep"),
            default: 3, format: HammerCLI::Options::Normalizers::Number.new
 
-    validate_options do
+    validate_options :before, 'IdResolution' do
       organization_options = [:option_organization_id, :option_organization_name, \
                               :option_organization_label]
 
@@ -25,7 +25,7 @@ module HammerCLIKatello
 
     build_options
 
-    class ContentViewIdParamSource
+    class ContentViewIdParamSource < HammerCLI::Options::Sources::Base
       def initialize(command)
         @command = command
       end
@@ -40,8 +40,11 @@ module HammerCLIKatello
 
     def option_sources
       sources = super
-      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-      sources.insert(idx, ContentViewIdParamSource.new(self))
+      sources.find_by_name('IdResolution').insert_relative(
+        :after,
+        'IdParams',
+        ContentViewIdParamSource.new(self)
+      )
       sources
     end
 

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -185,7 +185,7 @@ module HammerCLIKatello
              :format => HammerCLI::Options::Normalizers::List.new
             )
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name]
 
         if option(:option_lifecycle_environment_ids).exist?

--- a/lib/hammer_cli_katello/erratum.rb
+++ b/lib/hammer_cli_katello/erratum.rb
@@ -14,7 +14,7 @@ module HammerCLIKatello
         field :title, _("Title")
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 

--- a/lib/hammer_cli_katello/file.rb
+++ b/lib/hammer_cli_katello/file.rb
@@ -13,7 +13,7 @@ module HammerCLIKatello
         field :path, _("Path")
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name,
                                 :option_organization_label]
         if any(:option_product_name, :option_content_view_name).exist?
@@ -35,7 +35,7 @@ module HammerCLIKatello
         field :checksum, _("Checksum")
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name,
                                 :option_organization_label]
         product_options = [:option_product_id, :option_product_name]

--- a/lib/hammer_cli_katello/filter.rb
+++ b/lib/hammer_cli_katello/filter.rb
@@ -64,7 +64,7 @@ module HammerCLIKatello
       success_message _("Filter created.")
       failure_message _("Could not create the filter")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
         product_options = [:option_product_id, :option_product_name]

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -73,7 +73,7 @@ module HammerCLIKatello
       option "--name", "HOST_COLLECTION_NAME", _("Host Collection Name"),
              :attribute_name => :option_host_collection_name
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         host_collection_options = [:option_host_collection_id, :option_host_collection_name]
         any(*host_collection_options).required
       end

--- a/lib/hammer_cli_katello/hostgroup_extensions.rb
+++ b/lib/hammer_cli_katello/hostgroup_extensions.rb
@@ -13,7 +13,7 @@ module HammerCLIKatello
       base.option '--query-organization-label', 'ORGANIZATION_LABEL',
         _('Organization label to search by'), attribute_name: :option_organization_label
 
-      base.validate_options do
+      base.validate_options :before, 'IdResolution' do
         organization_options = [
           :option_organization_id, :option_organization_name, :option_organization_label
         ]

--- a/lib/hammer_cli_katello/id_name_options_validator.rb
+++ b/lib/hammer_cli_katello/id_name_options_validator.rb
@@ -18,7 +18,7 @@ module HammerCLIKatello
       child_options = IdNameOptionsValidator.build_child_options(record_name)
       parent_options = IdNameOptionsValidator.build_parent_options(parent)
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         any(*child_options).required if required
 
         if (name_option = child_options.detect { |opt| opt.end_with?('_name') }) &&

--- a/lib/hammer_cli_katello/lifecycle_environment.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment.rb
@@ -9,7 +9,7 @@ module HammerCLIKatello
           "PRIOR",
           _("Name of the prior environment")
         )
-        base.validate_options do
+        base.validate_options :before, 'IdResolution' do
           any(:option_prior, :option_prior_id).required
         end
       end

--- a/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/lifecycle_environment_name_resolvable.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
   module LifecycleEnvironmentNameResolvable
-    class LifecycleEnvironmentParamSource
+    class LifecycleEnvironmentParamSource < HammerCLI::Options::Sources::Base
       def initialize(command)
         @command = command
       end
@@ -16,8 +16,11 @@ module HammerCLIKatello
 
     def option_sources
       sources = super
-      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-      sources.insert(idx, LifecycleEnvironmentParamSource.new(self))
+      sources.find_by_name('IdResolution').insert_relative(
+        :after,
+        'IdParams',
+        LifecycleEnvironmentParamSource.new(self)
+      )
       sources
     end
   end

--- a/lib/hammer_cli_katello/package.rb
+++ b/lib/hammer_cli_katello/package.rb
@@ -9,7 +9,7 @@ module HammerCLIKatello
         field :sourcerpm, _("Source RPM")
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
         product_options = [:option_product_id, :option_product_name]

--- a/lib/hammer_cli_katello/puppet_environment_name_resolvable.rb
+++ b/lib/hammer_cli_katello/puppet_environment_name_resolvable.rb
@@ -1,6 +1,6 @@
 module HammerCLIKatello
   module PuppetEnvironmentNameResolvable
-    class PuppetEnvParamSource
+    class PuppetEnvParamSource < HammerCLI::Options::Sources::Base
       def initialize(command)
         @command = command
       end
@@ -16,8 +16,11 @@ module HammerCLIKatello
 
     def option_sources
       sources = super
-      idx = sources.index { |s| s.class == HammerCLIForeman::OptionSources::IdParams }
-      sources.insert(idx, PuppetEnvParamSource.new(self))
+      sources.find_by_name('IdResolution').insert_relative(
+        :after,
+        'IdParams',
+        PuppetEnvParamSource.new(self)
+      )
       sources
     end
   end

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -197,7 +197,7 @@ module HammerCLIKatello
       success_message _("Repository updated.")
       failure_message _("Could not update the repository")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -336,7 +336,7 @@ module HammerCLIKatello
         ::HammerCLIForeman.foreman_resource(:content_uploads)
       end
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name,
                                 :option_organization_label]
         product_options = [:option_product_id, :option_product_name]
@@ -484,7 +484,7 @@ module HammerCLIKatello
       success_message _("Repository content removed.")
       failure_message _("Could not remove content")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
@@ -511,7 +511,7 @@ module HammerCLIKatello
       success_message _("Repository is being exported in task %{id}.")
       failure_message _("Could not export the repository")
 
-      validate_options do
+      validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 

--- a/lib/hammer_cli_katello/repository_scoped_to_product.rb
+++ b/lib/hammer_cli_katello/repository_scoped_to_product.rb
@@ -1,7 +1,7 @@
 module HammerCLIKatello
   module RepositoryScopedToProduct
     def validate_repo_name_requires_product_options(name_option = :option_name)
-      validate_options do
+      validate_options :before, 'IdResolution' do
         any(:option_product_name, :option_product_id).required if option(name_option).exist?
       end
     end

--- a/test/unit/id_name_options_validator_test.rb
+++ b/test/unit/id_name_options_validator_test.rb
@@ -6,7 +6,7 @@ module HammerCLIKatello
     before(:each) do
       @cmd = Object.new
       @cmd.extend(IdNameOptionsValidator)
-      @cmd.class.send(:define_method, :validate_options) do |&block|
+      @cmd.class.send(:define_method, :validate_options) do |*_args, &block|
         block.call
       end
     end


### PR DESCRIPTION
This patch makes hammer-cli-katello compatible with changes in:
https://github.com/theforeman/hammer-cli/pull/242 and https://github.com/theforeman/hammer-cli-foreman/pull/402

Please see the discussion in the PR into hammer core for more details about the functionality that is going to be merged there.