### PR TITLE
Fixes #25728 - Show Recurring Logic Id

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -10,6 +10,7 @@ module HammerCLIKatello
         field :interval, _("Interval")
         field :enabled, _("Enabled"), Fields::Boolean
         field :cron_expression, _("Cron Expression")
+        field :foreman_tasks_recurring_logic_id, _("Recurring Logic ID")
       end
 
       build_options


### PR DESCRIPTION
Sync Plan list/info should also show the recurring logic id