### PR TITLE
Fixes #25805 - Display correct value for redhat repo

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -101,7 +101,7 @@ module HammerCLIKatello
       end
 
       def setup_booleans(data)
-        data["_redhat_repo"] = data["product_type"] == "redhat" ? _("yes") : _("no")
+        data["_redhat_repo"] = data.dig("product", "redhat") ? _("yes") : _("no")
         data["_publish_via_http"] = data["unprotected"] ? _("yes") : _("no")
         data["_mirror_on_sync"] = data["mirror_on_sync"] ? _("yes") : _("no")
       end


### PR DESCRIPTION
**Issue:**
Redhat repository field displays as false even for redhat enabled repos.

Depends on: https://github.com/Katello/katello/pull/7913