### PR TITLE
Fixes #25857 - Make export dir always absolute

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -320,12 +320,13 @@ module HammerCLIKatello
         export_file = "#{export_prefix}.json"
         export_repos_tar = "#{export_prefix}-repos.tar"
         export_tar = "#{export_prefix}.tar"
+        export_dir = File.expand_path(options['option_export_dir'].to_s)
 
-        Dir.mkdir("#{options['option_export_dir']}/#{export_prefix}")
+        Dir.mkdir("#{export_dir}/#{export_prefix}")
 
         if repositories
           Dir.chdir(PUBLISHED_REPOS_DIR) do
-            repo_tar = "#{options['option_export_dir']}/#{export_prefix}/#{export_repos_tar}"
+            repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
 
             repositories.each do |repo|
@@ -336,13 +337,13 @@ module HammerCLIKatello
           end
         end
 
-        Dir.chdir("#{options['option_export_dir']}/#{export_prefix}") do
+        Dir.chdir("#{export_dir}/#{export_prefix}") do
           File.open(export_file, 'w') do |file|
             file.write(JSON.pretty_generate(json))
           end
         end
 
-        Dir.chdir(options['option_export_dir']) do
+        Dir.chdir(export_dir) do
           `tar cf #{export_tar} #{export_prefix}`
           FileUtils.rm_rf(export_prefix)
         end


### PR DESCRIPTION
Before:

```
hammer content-view version export --export-dir test1 --id 2
tar: ExportedCV/export-2/export-2-repos.tar: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

With code change:
```
[root@dhcp129-218 test]# ll
total 0
drwxr-xr-x. 2 root root 6 Jan 14 11:17 test1
[root@dhcp129-218 test]# pwd
/tmp/test

[root@dhcp129-218 test]# ll -R
.:
total 0
drwxr-xr-x. 2 root root 26 Jan 14 11:18 test1

./test1:
total 152
-rw-r--r--. 1 root root 153600 Jan 14 11:18 export-5.tar
```