### PR TITLE
Fixes #25861 - Update download policy to include background

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -350,16 +350,16 @@ module HammerCLIKatello
       end
 
       def check_repo_download_policy(repositories)
-        on_demand = repositories.select do |repo|
-          show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] == 'on_demand'
+        non_immediate = repositories.select do |repo|
+          show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] != 'immediate'
         end
-        return true if on_demand.empty?
+        return true if non_immediate.empty?
 
-        on_demand_names = repositories.collect { |repo| repo['name'] }
+        non_immediate_names = repositories.collect { |repo| repo['name'] }
         msg = <<~MSG
           All exported repositories must be set to an immediate download policy and re-synced.
           The following repositories need action:
-            #{on_demand_names.join('\n')}
+            #{non_immediate_names.join(', ')}
         MSG
         raise _(msg)
       end


### PR DESCRIPTION
Tested on Katello 3.10 and Satellite 6.5

Before:

Would export background

After:

Small is background and medium is set to on_demand

```
Could not export the content view:
  Error: All exported repositories must be set to an immediate download policy and re-synced.
  The following repositories need action:
    medium, small

[root@dhcp129-218 ~]# hammer content-view version info --id 8
ID:                     8
Name:                   test 1.0
Version:                1.0
Description:            
Content View ID:        5
Content View Name:      test
Content View Label:     test
Lifecycle Environments: 
 1) ID:    1
    Name:  Library
    Label: Library
Repositories:           
 1) ID:    14
    Name:  small
    Label: small
	
hammer> repository info --id 13
ID:                 13
Name:               small
Label:              small
Organization:       Demo
Red Hat Repository: no
Content Type:       yum
Mirror on Sync:     yes
URL:                https://mmccune.fedorapeople.org/repos/small/
Publish Via HTTP:   yes
Published At:       http://dhcp129-218.rdu.redhat.com/pulp/repos/Demo/Library/custom/animals-product/small/
Relative Path:      Demo/Library/custom/animals-product/small
Download Policy:    background
Product:            
    ID:   16
    Name: animals-product
```