### PR TITLE
Fixes #24750 - Search options for compute profiles

### DIFF
--- a/lib/hammer_cli_katello/foreman_search_options_creators.rb
+++ b/lib/hammer_cli_katello/foreman_search_options_creators.rb
@@ -76,6 +76,10 @@ module HammerCLIKatello
       create_search_options_without_katello_api(options, api.resource(:compute_resources), mode)
     end
 
+    def create_compute_profiles_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:compute_profiles), mode)
+    end
+
     def create_images_search_options(options, mode = nil)
       create_search_options_without_katello_api(options, api.resource(:images), mode)
     end

--- a/test/unit/search_options_creators_test.rb
+++ b/test/unit/search_options_creators_test.rb
@@ -110,6 +110,12 @@ describe HammerCLIKatello::SearchOptionsCreators do
       end
     end
 
+    describe '#create_compute_profiles_search_options(options, mode = nil)' do
+      it 'does not use the katello api' do
+        search_options_creators.create_compute_profiles_search_options(:anything)
+      end
+    end
+
     describe '#create_search_options_with_katello_api(options, resource)' do
       it 'does not use the katello api' do
         search_options_creators.create_organizations_search_options(:anything)


### PR DESCRIPTION
Keep foreman API compatible  search options for compute profiles.