### PR TITLE
Fixes #25915 - Skip white list info on repos

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -90,6 +90,10 @@ module HammerCLIKatello
       end
 
       def extend_data(data)
+        if data["content_type"] != "docker"
+          data.delete("docker_tags_whitelist")
+        end
+
         if data["content_type"] == "yum" && data["gpg_key"]
           data["gpg_key_name"] = data["gpg_key"]["name"]
         end


### PR DESCRIPTION
This commit make the white list information NOT show up for non-docker
repos.
In other words
hammer repository info --name=yum --product-id=100

will not show the "Container Image Tags Filter" for non docker repos