### PR TITLE
Fixes #25919 - Add error message when import cv is nil

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -378,7 +378,7 @@ module HammerCLIKatello
       command_name "import"
 
       success_message _("Content view imported.")
-      failure_message _("Could not import the content view.")
+      failure_message _("Could not import the content view")
 
       option "--organization-id", "ORGANIZATION_ID", _("Organization numeric identifier")
       option(
@@ -393,6 +393,7 @@ module HammerCLIKatello
 
       build_options
 
+      # rubocop:disable Metrics/AbcSize
       def execute
         unless File.exist?(options['option_export_tar'])
           raise _("Export tar #{options['option_export_tar']} does not exist.")
@@ -403,6 +404,11 @@ module HammerCLIKatello
 
         export_json = read_json(import_tar_params)
         cv = content_view(export_json['name'], options['option_organization_id'])
+
+        if cv.nil?
+          raise _("The Content View '#{export_json['name']}' is not present on this server,"\
+          " please create the Content View and try the import again.")
+        end
 
         if export_json['composite_components']
           composite_version_ids = export_json['composite_components'].map do |component|
@@ -422,6 +428,7 @@ module HammerCLIKatello
         end
         return HammerCLI::EX_OK
       end
+      # rubocop:enable Metrics/AbcSize
 
       def sync_repositories(repositories, organization_id, options)
         export_tar_dir =  options[:dirname]

--- a/test/functional/content_view/version/import_test.rb
+++ b/test/functional/content_view/version/import_test.rb
@@ -183,6 +183,32 @@ describe 'content-view version import' do
     assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
   end
 
+  it "fails import if cv has not been created" do
+    params = [
+      '--export-tar=/tmp/exports/export-2.tar',
+      '--organization-id=1'
+    ]
+
+    File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
+    File.expects(:exist?).with("/tmp/exports/export-2.tar").returns(true)
+    Dir.expects(:chdir).with('/tmp/exports').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-2').returns(0)
+    File.expects(:read).with("/tmp/exports/export-2/export-2.json").returns(
+      JSON.dump(
+        'name' => 'Foo View'
+      )
+    )
+
+    ex = api_expects(:content_views, :index)
+    ex = ex.with_params('name' => 'Foo View', 'organization_id' => '1')
+    ex.returns([])
+
+    result = run_cmd(@cmd + params)
+    assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+  end
+
   it "fails import if any repository does not exist" do
     params = [
       '--export-tar=/tmp/exports/export-2.tar',


### PR DESCRIPTION
Before:

```ruby
Could not import the content view.:
  Error: undefined method `[]' for nil:NilClass
```

After:

```ruby
[ERROR 2019-01-24T20:45:33 Exception] Error: The Content View 'zoo' is not present on this server, please create the Content View and try the import again.
Could not import the content view:
  Error: The Content View 'zoo' is not present on this server, please create the Content View and try the import again.
```

Added the disable/enable on the abc cop because I was getting this:
```ruby
 lib/hammer_cli_katello/content_view_version.rb:396:7: C: Assignment Branch Condition size for execute is too high. [40.31/38]
```

Removed the period on line `381` because it made the error message look odd:

`before: Could not import the content view.:`

`after: Could not import the content view:`