### PR TITLE
Fixes #25932 - Prevent reimport of same CV version

### DIFF
--- a/test/functional/content_view/version/import_test.rb
+++ b/test/functional/content_view/version/import_test.rb
@@ -209,6 +209,40 @@ describe 'content-view version import' do
     assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
   end
 
+  it "fails import if cv version already exists" do
+    params = [
+      '--export-tar=/tmp/exports/export-2.tar',
+      '--organization-id=1'
+    ]
+
+    File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
+    File.expects(:exist?).with("/tmp/exports/export-2.tar").returns(true)
+    Dir.expects(:chdir).with('/tmp/exports').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-2').returns(0)
+    File.expects(:read).with("/tmp/exports/export-2/export-2.json").returns(
+      JSON.dump(
+        'name' => 'Foo View',
+        'major' => '2',
+        'minor' => '1'
+      )
+    )
+
+    ex = api_expects(:content_views, :index)
+    ex = ex.with_params('name' => 'Foo View', 'organization_id' => '1')
+    ex.returns(
+      'results' => [{
+        'id' => '5',
+        'content_view' => {'name' => 'cv'},
+        'versions' => [{'version' => '2.1', 'id' => '654'}]
+      }]
+    )
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.exit_code, 70)
+  end
+
   it "fails import if any repository does not exist" do
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
@@ -224,7 +258,9 @@ describe 'content-view version import' do
     File.expects(:read).with("/tmp/exports/export-2/export-2.json").returns(
       JSON.dump(
         'name' => 'Foo View',
-        'repositories' => ['label' => 'foo']
+        'repositories' => ['label' => 'foo'],
+        'major' => '2',
+        'minor' => '1'
       )
     )
 


### PR DESCRIPTION
This PR checks to see if the CV version being imported has already been imported or the latest version is higher than the version being imported, and if not gives the user an error that is more friendly and exists:

Before:

The import would not check and it would try to kick off a sync of the repos on the import side and then kick off a publish of the content view which would be bad and could cause issues with stuck tasks etc.

After:
```
[vagrant@centos7-devel hammer_cli_katello]$ hammer content-view version import --organization-id 2 --export-tar /tmp/export-7.tar
Could not import the content view.:
  Error: The latest version (7.1) of the Content View pizza is greater than the version you are trying to import (7.1)
```