### PR TITLE
Fixes #26091 - Require product-id on cv update

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -172,9 +172,22 @@ module HammerCLIKatello
         if option(:option_name).exist?
           any(*organization_options).required
         end
+
+        product_options = [:option_product_id, :option_product_name]
+        if option(:option_repository_ids).exist?
+          any(*product_options).rejected
+          option(:option_repository_names).rejected
+        end
+
+        if option(:option_repository_names).exist?
+          any(*product_options).required
+        end
+
       end
 
-      build_options
+      build_options do |o|
+        o.expand.including(:products)
+      end
     end
 
     class DeleteCommand < HammerCLIKatello::DeleteCommand

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -169,7 +169,7 @@ module HammerCLIKatello
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
 
-        if option(:option_name).exist?
+        if option(:option_name).exist? || option(:option_product_name).exist?
           any(*organization_options).required
         end
 

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -182,7 +182,6 @@ module HammerCLIKatello
         if option(:option_repository_names).exist?
           any(*product_options).required
         end
-
       end
 
       build_options do |o|

--- a/test/functional/content_view/update_test.rb
+++ b/test/functional/content_view/update_test.rb
@@ -57,7 +57,8 @@ module HammerCLIKatello
         cmd = %W(content-view update --id=#{id}\
                  --repository-ids=#{repo_id} --product=#{product_name})
         result = run_cmd(cmd)
-        assert(result.err[/--organization-id, --organization, --organization-label is required/],
+        expected_error = "--organization-id, --organization, --organization-label is required"
+        assert(result.err.include?(expected_error),
                "Organization option requirements are validated")
       end
 
@@ -69,7 +70,8 @@ module HammerCLIKatello
         cmd = %W(content-view update --id=#{id}\
                  --repositories=#{repo_id} --organization-id=#{organization_id})
         result = run_cmd(cmd)
-        assert(result.err[/--product-id, --product is required/],
+        expected_error = "--product-id, --product is required"
+        assert(result.err.include?(expected_error),
                "Product option requirements are validated")
       end
     end

--- a/test/functional/content_view/update_test.rb
+++ b/test/functional/content_view/update_test.rb
@@ -48,6 +48,30 @@ module HammerCLIKatello
         end
         run_cmd(%w(content-view update --name cv2 --organization-label org1))
       end
+
+      it 'requires organization if product name is supplied along with repository' do
+        id = 122
+        repo_id = 100
+        product_name = "foo"
+        api_expects_no_call
+        cmd = %W(content-view update --id=#{id}\
+                 --repository-ids=#{repo_id} --product=#{product_name})
+        result = run_cmd(cmd)
+        assert(result.err[/--organization-id, --organization, --organization-label is required/],
+               "Organization option requirements are validated")
+      end
+
+      it 'requires product if repository names are provided' do
+        id = 122
+        repo_id = 100
+        organization_id = 5
+        api_expects_no_call
+        cmd = %W(content-view update --id=#{id}\
+                 --repositories=#{repo_id} --organization-id=#{organization_id})
+        result = run_cmd(cmd)
+        assert(result.err[/--product-id, --product is required/],
+               "Product option requirements are validated")
+      end
     end
   end
 end

--- a/test/functional/content_view/update_test.rb
+++ b/test/functional/content_view/update_test.rb
@@ -59,7 +59,7 @@ module HammerCLIKatello
         result = run_cmd(cmd)
         expected_error = "--organization-id, --organization, --organization-label is required"
         assert(result.err.include?(expected_error),
-               "Organization option requirements are validated")
+               "Invalid Error Message")
       end
 
       it 'requires product if repository names are provided' do
@@ -72,7 +72,7 @@ module HammerCLIKatello
         result = run_cmd(cmd)
         expected_error = "--product-id, --product is required"
         assert(result.err.include?(expected_error),
-               "Product option requirements are validated")
+               "Invalid Error Message")
       end
     end
   end


### PR DESCRIPTION
This commit fixes the following call
hammer content-view update
--id=6 --organization-id=4  --repositories=goo

It fixes it by requiring the user to specify the product-id when the
repositories flag is used.