### PR TITLE
Fixes #26047 - Add check for puppet in cvv export.

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -301,6 +301,7 @@ module HammerCLIKatello
           export_json_options[:repositories] = []
         else
           repositories = fetch_cvv_repositories(cvv)
+          puppet_check(cvv)
           check_repo_type(repositories)
           check_repo_download_policy(repositories)
 
@@ -348,32 +349,6 @@ module HammerCLIKatello
           `tar cf #{export_tar} #{export_prefix}`
           FileUtils.rm_rf(export_prefix)
         end
-      end
-
-      def check_repo_type(repositories)
-        repositories.select do |repo|
-          if repo['content_type'] != 'yum'
-            raise _("The Repository '#{repo['name']}' is a non-yum repository."\
-            " Only Yum is supported at this time."\
-            " Please remove the repository from the Content View,"\
-            " republish and try the export again.")
-          end
-        end
-      end
-
-      def check_repo_download_policy(repositories)
-        non_immediate = repositories.select do |repo|
-          show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] != 'immediate'
-        end
-        return true if non_immediate.empty?
-
-        non_immediate_names = repositories.collect { |repo| repo['name'] }
-        msg = <<~MSG
-          All exported repositories must be set to an immediate download policy and re-synced.
-          The following repositories need action:
-            #{non_immediate_names.join(', ')}
-        MSG
-        raise _(msg)
       end
     end
 


### PR DESCRIPTION
This PR adds a check to export, to check and see if a cv version contains puppet modules and give the user a friendly error instead of having `tar` complain with something that is confusing. 

I also re-factored the export checks into a method in the helper file to clean up the code within the content_view_version file to allow for more readability and flexibility for adding more checks etc that come up over time.

```
CV with only Puppet modules

[vagrant@centos7-katello-devel ~]$ hammer content-view version export --id 2 --export-dir /tmp
Could not export the content view:
  Error: The Content View 'puppet-view' contains Puppet modules, this is not supported at this time. Please remove the modules, publish a new version and try the export again.

CV with Puppet modules and yum repos

[vagrant@centos7-katello-devel ~]$ hammer content-view version export --id 4 --export-dir /tmp
Could not export the content view:
  Error: The Content View 'mixed-zoo' contains Puppet modules, this is not supported at this time. Please remove the modules, publish a new version and try the export again.

Verified checks still work after moving them to the helper file

[vagrant@centos7-katello-devel ~]$ hammer content-view version export --id 6 --export-dir /tmp
Could not export the content view:
  Error: All exported repositories must be set to an immediate download policy and re-synced.
  The following repositories need action:
    background
[vagrant@centos7-katello-devel ~]$ hammer content-view version export --id 7 --export-dir /tmp
Could not export the content view:
  Error: The Repository 'filerepo' is a non-yum repository. Only Yum is supported at this time. Please remove the repository from the Content View, republish and try the export again.
```