### PR TITLE
Fixes #26326 - Fix export tar name to match cvv

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -318,7 +318,7 @@ module HammerCLIKatello
       end
 
       def create_tar(cv, cvv, repositories, json)
-        export_prefix = "export-#{cv['label']}-#{cvv['id']}"
+        export_prefix = "export-#{cv['label']}-#{cvv['major']}.#{cvv['minor']}"
         export_file = "#{export_prefix}.json"
         export_repos_tar = "#{export_prefix}-repos.tar"
         export_tar = "#{export_prefix}.tar"

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -53,9 +53,9 @@ describe 'content-view version export' do
     File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
 
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").returns(true)
-    Dir.expects(:mkdir).with('/tmp/exports/export-cv-5').returns(0)
+    Dir.expects(:mkdir).with('/tmp/exports/export-cv-1.0').returns(0)
     Dir.expects(:chdir).with('/tmp/exports').returns(0)
-    Dir.expects(:chdir).with('/tmp/exports/export-cv-5').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-cv-1.0').returns(0)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_OK, result.exit_code)
@@ -89,9 +89,9 @@ describe 'content-view version export' do
     File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
 
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").never
-    Dir.expects(:mkdir).with('/tmp/exports/export-cv-999').returns(0)
+    Dir.expects(:mkdir).with('/tmp/exports/export-cv-1.0').returns(0)
     Dir.expects(:chdir).with('/tmp/exports').returns(0)
-    Dir.expects(:chdir).with('/tmp/exports/export-cv-999').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-cv-1.0').returns(0)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_OK, result.exit_code)


### PR DESCRIPTION
New export name:

```
[root@export ~]# ls
export-animals-4.1.tar  ssl-build
```