### PR TITLE
Fixes #26447 - Remove version date from ostree info

### DIFF
--- a/lib/hammer_cli_katello/ostree_branch.rb
+++ b/lib/hammer_cli_katello/ostree_branch.rb
@@ -24,7 +24,6 @@ module HammerCLIKatello
         field :name, _("Name")
         field :version, _("Version")
         field :commit, _("Commit")
-        field :version_date, _("Date")
       end
 
       build_options


### PR DESCRIPTION
This is the hammer part of changes for https://github.com/Katello/katello/pull/8040 which deletes the version_date field.