### PR TITLE
Fixes #26469 - Modular Info displayed for rpms

### DIFF
--- a/lib/hammer_cli_katello/package.rb
+++ b/lib/hammer_cli_katello/package.rb
@@ -55,6 +55,7 @@ module HammerCLIKatello
         field :license, _("License")
         field :relativepath, _("Relative Path")
         field :description, _("Description")
+        field :modular, _("Modular"), Fields::Boolean
       end
 
       build_options


### PR DESCRIPTION
```
$ hammer package info --id=2
ID:            2
Name:          pteradactyl
Version:       1.0
Architecture:  noarch
Epoch:         0
Release:       1
Filename:      pteradactyl-1.0-1.noarch.rpm
Build Host:    ....
Vendor:        
License:       GPL
Relative Path: pteradactyl-1.0-1.noarch.rpm
Description:   Fake provide for pteradactyl.
Modular:       yes



```