### PR TITLE
Add rubocop to the test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :test do
   gem 'minitest-spec-context'
   gem 'mocha'
   gem 'coveralls', require: false
+  gem 'rubocop', '0.42'
+  gem 'rubocop-checkstyle_formatter'
 end
 
 # load local gemfile


### PR DESCRIPTION
In the new hammer-cli-katello-master test we install with `--without=development`. That results in no rubocop and causes the tests to fail.

See https://ci.theforeman.org/job/hammer-cli-katello-master-test/1/console for an example.