### PR TITLE
Refs #25878 - New lines in text attr dont break output

### DIFF
--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -8,7 +8,6 @@ module HammerCLIKatello
 
       output do
         field :label, _("Label")
-        field :description, _("Description")
       end
 
       build_options


### PR DESCRIPTION
See: https://projects.theforeman.org/issues/25878

`hammer organization list` command has redundant second column `Description`.