### PR TITLE
Fixes #26257 - Use pages on package/errata index to prevent t/o

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 7
 Metrics/AbcSize:
-  Max: 38
+  Max: 39
 
 # Offense count: 1
 Metrics/PerceivedComplexity:

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -291,6 +291,7 @@ module HammerCLIKatello
         cv = show(:content_views, 'id' => cvv['content_view_id'])
 
         composite = cv["composite"]
+
         export_json_options = { :cvv => cvv }
 
         if composite
@@ -304,11 +305,8 @@ module HammerCLIKatello
           puppet_check(cvv)
           check_repo_type(repositories)
           check_repo_download_policy(repositories)
+          collect_packages(repositories)
 
-          repositories.each do |repo|
-            repo['packages'] = index(:packages, 'repository_id' => repo['id'], :full_result => true)
-            repo['errata'] = index(:errata, 'repository_id' => repo['id'], :full_result => true)
-          end
           export_json_options[:repositories] = repositories
         end
 

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -58,6 +58,26 @@ module HammerCLIKatello
       end
     end
 
+    def collect_packages(repositories)
+      repositories.each do |repo|
+        per_page = 50
+        repo['packages'] = []
+        repo['errata'] = []
+        repo_packages = repo['content_counts']['rpm']
+        errata_count = repo['content_counts']['erratum']
+        pkg_pages = (repo_packages / per_page.to_f).ceil
+        errata_pages = (errata_count / per_page.to_f).ceil
+        (1..pkg_pages).each do |page|
+          repo['packages'] += index(:packages, 'repository_id' => repo['id'],
+                                               :page => page, :per_page => 50)
+        end
+        (1..errata_pages).each do |page|
+          repo['errata'] += index(:errata, 'repository_id' => repo['id'],
+                                           :page => page, :per_page => 50)
+        end
+      end
+    end
+
     def import_checks(cv, import_cv, major, minor)
       version = "#{major}.#{minor}".to_f
 

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -22,7 +22,6 @@ describe 'content-view version export' do
       'content_view' => {'name' => 'cv'},
       'content_view_id' => 4321,
       'puppet_modules' => []
-
     )
 
     ex = api_expects(:content_views, :show)
@@ -39,7 +38,11 @@ describe 'content-view version export' do
       'content_type' => 'yum',
       'backend_identifier' => 'Default_Organization-Library-Test_Repo',
       'relative_path' => 'Default_Organization/Library/Test_Repo',
-      'library_instance_id' => '1'
+      'library_instance_id' => '1',
+      'content_counts' => {
+        'rpm' => 1,
+        'erratum' => 1
+      }
     )
 
     api_expects(:repositories, :show).with_params('id' => '1').returns(


### PR DESCRIPTION
Export not having timeout and showing correct:
```
hammer -d content-view version export --id 2 --export-dir /tmp

[DEBUG 2019-04-08T15:33:30 API] Params: {
    "repository_id" => 5,
              :page => 193,
          :per_page => 50
}
[DEBUG 2019-04-08T15:33:30 API] Headers: {
    :params => {
        "repository_id" => 5,
                  :page => 193,
              :per_page => 50
    }
}

[root@exportpatch tmp]# du -sh /tmp/export-timeout-2.tar 
45G	/tmp/export-timeout-2.tar
```
Import machine, importing correctly:
```
hammer -d content-view version import --organization-id 1 --export-tar /var/lib/pulp/katello-export/export-timeout-2.tar

                                 :vary => "Accept-Encoding",
                     :content_encoding => "gzip",
                       :content_length => "534",
                         :content_type => "application/json; charset=utf-8"
}
[.....................................................................................................................................................................................................................................................] [100%]
```
Screenshot of repos looking good:

RHEL - https://nimb.ws/YLe8pw

RHSCL - https://nimb.ws/xHC4yg

Screenshot of CV published and imported:

https://nimb.ws/P4sYQm

Client able to install `screen` package from timeout cv:
```
Installed:
  screen.x86_64 0:4.1.0-0.25.20120314git3c2946.el7                                                                                                                                                                                                            

Complete!

Repo-id      : rhel-7-server-rpms/7Server/x86_64
Repo-name    : Red Hat Enterprise Linux 7 Server (RPMs)
Repo-revision: 1554752590
Repo-updated : Mon Apr  8 19:43:10 2019
Repo-pkgs    : 23,918
Repo-size    : 34 G
Repo-baseurl : https://importpatch.toledo.satellite.lab.eng.rdu2.redhat.com/pulp/repos/Default_Organization/Library/timeout/content/dist/rhel/server/7/7Server/x86_64/os
Repo-expire  : 1 second(s) (last: Mon Apr  8 19:53:20 2019)
  Filter     : read-only:present
Repo-filename: /etc/yum.repos.d/redhat.repo
```