### PR TITLE
Fixes #26889 - issued and updated added on errata page

### DIFF
--- a/lib/hammer_cli_katello/erratum.rb
+++ b/lib/hammer_cli_katello/erratum.rb
@@ -14,6 +14,8 @@ module HammerCLIKatello
         field :errata_id, _("Errata ID")
         field :type, _("Type")
         field :title, _("Title")
+        field :issued, _("Issued")
+        field :updated, _("Updated")
       end
 
       validate_options :before, 'IdResolution' do


### PR DESCRIPTION
Added two additional fields on erratum list
```
# hammer erratum list --per-page 5
-----|----------------|-------------|------------------------------------------------|------------|-----------
ID   | ERRATA ID      | TYPE        | TITLE                                          | ISSUED     | UPDATED   
-----|----------------|-------------|------------------------------------------------|------------|-----------
2932 | RHSA-2019:1265 | security    | Critical: firefox security update              | 2019-05-23 | 2019-05-23
2489 | RHSA-2019:1264 | security    | Important: libvirt security and bug fix update | 2019-05-23 | 2019-05-23
3103 | RHSA-2019:1235 | security    | Important: ruby security update                | 2019-05-15 | 2019-05-15
3399 | RHSA-2019:1178 | security    | Important: qemu-kvm security update            | 2019-05-14 | 2019-05-14
3008 | RHEA-2019:1210 | enhancement | microcode_ctl enhancement update               | 2019-05-14 | 2019-05-14
-----|----------------|-------------|------------------------------------------------|------------|-----------
Page 1 of 713 (use --page and --per-page for navigation).
```