### PR TITLE
Fixes #26888 - start date field added

### DIFF
--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -15,6 +15,7 @@ module HammerCLIKatello
         field :contract_number, _("Contract")
         field :account_number, _("Account")
         field :support_level, _("Support")
+        field :start_date, _("Start Date"), Fields::Date
         field :end_date, _("End Date"), Fields::Date
         field :format_quantity, _("Quantity")
         field :consumed, _("Consumed")

--- a/test/functional/subscription/list_test.rb
+++ b/test/functional/subscription/list_test.rb
@@ -36,7 +36,7 @@ module HammerCLIKatello
       result = run_cmd(@cmd + params)
 
       fields = ['ID', 'UUID', 'NAME', 'TYPE', 'CONTRACT', 'ACCOUNT', 'SUPPORT',
-                'END DATE', 'QUANTITY', 'CONSUMED']
+                'START DATE', 'END DATE', 'QUANTITY', 'CONSUMED']
       expected_result = success_result(IndexMatcher.new([fields, []]))
       assert_cmd(expected_result, result)
     end


### PR DESCRIPTION
Start date field added on the hammer report
```
# hammer --csv subscription list --organization-id 1
ID,UUID,Name,Type,Contract,Account,Support,Start Date,End Date,Quantity,Consumed
1,8a889d166aeb2ca5016aebda28522c10,Employee SKU,Physical,10169621,540155,Self-Support,2013/04/24 04:00:00,2022/01/01 04:59:59,10,0

# hammer  subscription list --organization-id 1
---|----------------------------------|--------------|----------|----------|---------|--------------|---------------------|---------------------|----------|---------
ID | UUID                             | NAME         | TYPE     | CONTRACT | ACCOUNT | SUPPORT      | START DATE          | END DATE            | QUANTITY | CONSUMED
---|----------------------------------|--------------|----------|----------|---------|--------------|---------------------|---------------------|----------|---------
1  | 8a889d166aeb2ca5016aebda28522c10 | Employee SKU | Physical | 10169621 | 540155  | Self-Support | 2013/04/24 04:00:00 | 2022/01/01 04:59:59 | 10       | 0       
---|----------------------------------|--------------|----------|----------|---------|--------------|---------------------|---------------------|----------|---------
```