### PR TITLE
Fixes #27039 - Content View version Export Condition Fix

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -314,7 +314,10 @@ module HammerCLIKatello
         if repositories&.any? || cv['composite']
           create_tar(cv, cvv, repositories, json)
         else
-          puts "Ensure the content view version '#{cvv['name']}' has at least one repository."
+          msg = <<~MSG
+            Ensure the content view version '#{cvv['name']}' has at least one repository.
+          MSG
+          raise _(msg)
         end
         return HammerCLI::EX_OK
       end

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -324,7 +324,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories.any?
+        if repositories&.any?
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -322,7 +322,6 @@ module HammerCLIKatello
         export_tar = "#{export_prefix}.tar"
         export_dir = File.expand_path(options['option_export_dir'].to_s)
 
-
         if repositories&.any?
           Dir.mkdir("#{export_dir}/#{export_prefix}")
           Dir.chdir(PUBLISHED_REPOS_DIR) do

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -324,7 +324,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if !repositories.empty?
+        if repositories.any?
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
@@ -336,7 +336,7 @@ module HammerCLIKatello
             `tar cvfh #{repo_tar} #{repo_dirs.join(" ")}`
           end
         else
-          puts "Ensure the content view '#{cvv['name']}' has atleast one repository."
+          puts "Ensure the content view '#{cvv['name']}' has at least one repository."
         end
 
         Dir.chdir("#{export_dir}/#{export_prefix}") do

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -324,7 +324,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories.length > 0
+        if !repositories.empty?
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
@@ -336,7 +336,7 @@ module HammerCLIKatello
             `tar cvfh #{repo_tar} #{repo_dirs.join(" ")}`
           end
         else
-          puts "Please verify that content view version id - #{cvv['id']} contents atleast one repository"
+          puts "Ensure the content view '#{cvv['name']}' has atleast one repository."
         end
 
         Dir.chdir("#{export_dir}/#{export_prefix}") do

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -324,7 +324,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories
+        if repositories.length > 0
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
@@ -335,6 +335,8 @@ module HammerCLIKatello
 
             `tar cvfh #{repo_tar} #{repo_dirs.join(" ")}`
           end
+        else
+          puts "Please verify that content view version id - #{cvv['id']} contents atleast one repository"
         end
 
         Dir.chdir("#{export_dir}/#{export_prefix}") do

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -311,7 +311,7 @@ module HammerCLIKatello
         end
 
         json = export_json(export_json_options)
-        if repositories&.any? or cv['composite']
+        if repositories&.any? || cv['composite']
           create_tar(cv, cvv, repositories, json)
         else
           puts "Ensure the content view version '#{cvv['name']}' has at least one repository."
@@ -328,8 +328,8 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories
-          
+        if repositories&.any?
+
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
@@ -352,7 +352,6 @@ module HammerCLIKatello
           `tar cf #{export_tar} #{export_prefix}`
           FileUtils.rm_rf(export_prefix)
         end
-
       end
     end
 

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -322,9 +322,9 @@ module HammerCLIKatello
         export_tar = "#{export_prefix}.tar"
         export_dir = File.expand_path(options['option_export_dir'].to_s)
 
-        Dir.mkdir("#{export_dir}/#{export_prefix}")
 
         if repositories&.any?
+          Dir.mkdir("#{export_dir}/#{export_prefix}")
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
             repo_dirs = []
@@ -335,19 +335,22 @@ module HammerCLIKatello
 
             `tar cvfh #{repo_tar} #{repo_dirs.join(" ")}`
           end
-        else
-          puts "Ensure the content view '#{cvv['name']}' has at least one repository."
-        end
 
-        Dir.chdir("#{export_dir}/#{export_prefix}") do
-          File.open(export_file, 'w') do |file|
-            file.write(JSON.pretty_generate(json))
+          Dir.chdir("#{export_dir}/#{export_prefix}") do
+            File.open(export_file, 'w') do |file|
+              file.write(JSON.pretty_generate(json))
+            end
           end
-        end
 
-        Dir.chdir(export_dir) do
-          `tar cf #{export_tar} #{export_prefix}`
-          FileUtils.rm_rf(export_prefix)
+          Dir.chdir(export_dir) do
+            `tar cf #{export_tar} #{export_prefix}`
+            FileUtils.rm_rf(export_prefix)
+          end
+
+        elsif cv['composite']
+          puts "Cannot export composite content view."
+        else
+          puts "Ensure the content view version '#{cvv['name']}' has at least one repository."
         end
       end
     end

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -90,7 +90,7 @@ describe 'content-view version export' do
 
     File.expects(:exist?).with('/usr/share/foreman').returns(true)
     File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
-    
+
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").never
     Dir.expects(:mkdir).with('/tmp/exports/export-cv-1.0').returns(0)
     Dir.expects(:chdir).with('/tmp/exports').returns(0)

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -269,4 +269,38 @@ describe 'content-view version export' do
     result = run_cmd(@cmd + params)
     assert_equal(result.exit_code, 70)
   end
+
+  it "fails export if content view version has no repository" do
+    params = [
+      '--id=5',
+      '--export-dir=/tmp/exports'
+    ]
+
+    ex = api_expects(:content_view_versions, :show)
+    ex.returns(
+      'id' => '5',
+      'name' => 'Test_version',
+      'repositories' => [],
+      'major' => 1,
+      'minor' => 0,
+      'content_view' => {'name' => 'cv'},
+      'content_view_id' => 4321,
+      'puppet_modules' => []
+    )
+
+    ex = api_expects(:content_views, :show)
+    ex.returns(
+      'id' => '4321',
+      'composite' => false
+    )
+
+    File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.err, "Could not export the content view:\n"\
+                             "  Error: Ensure the content view version 'Test_version'"\
+                             " has at least one repository.\n")
+    assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+  end
 end

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -90,11 +90,7 @@ describe 'content-view version export' do
 
     File.expects(:exist?).with('/usr/share/foreman').returns(true)
     File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
-
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").never
-    Dir.expects(:mkdir).with('/tmp/exports/export-cv-1.0').returns(0)
-    Dir.expects(:chdir).with('/tmp/exports').returns(0)
-    Dir.expects(:chdir).with('/tmp/exports/export-cv-1.0').returns(0)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_OK, result.exit_code)

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -90,7 +90,11 @@ describe 'content-view version export' do
 
     File.expects(:exist?).with('/usr/share/foreman').returns(true)
     File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+    
     Dir.expects(:chdir).with("/var/lib/pulp/published/yum/https/repos/").never
+    Dir.expects(:mkdir).with('/tmp/exports/export-cv-1.0').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports').returns(0)
+    Dir.expects(:chdir).with('/tmp/exports/export-cv-1.0').returns(0)
 
     result = run_cmd(@cmd + params)
     assert_equal(HammerCLI::EX_OK, result.exit_code)


### PR DESCRIPTION
"repositories" return the empty array if there is no repo added in the content view. So we should check the length of the array instead checking if it is set. 