### PR TITLE
Fixes #27094 - hammer host list including errata info

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -29,13 +29,13 @@ module HammerCLIKatello
           field :content_view_name, _('Content View')
           field :lifecycle_environment_name, _('Lifecycle Environment')
           from :errata_counts do
-            field :security, _("Security")
+            field :security, _("Security"), :sets => ['ALL']
           end
           from :errata_counts do
-            field :bugfix, _("Bugfix")
+            field :bugfix, _("Bugfix"), :sets => ['ALL']
           end
           from :errata_counts do
-            field :enhancement, _("Enhancement")
+            field :enhancement, _("Enhancement"), :sets => ['ALL']
           end
         end
       end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -30,11 +30,7 @@ module HammerCLIKatello
           field :lifecycle_environment_name, _('Lifecycle Environment')
           from :errata_counts do
             field :security, _("Security"), nil, :sets => ['ALL']
-          end
-          from :errata_counts do
             field :bugfix, _("Bugfix"), nil, :sets => ['ALL']
-          end
-          from :errata_counts do
             field :enhancement, _("Enhancement"), nil, :sets => ['ALL']
           end
         end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -29,13 +29,13 @@ module HammerCLIKatello
           field :content_view_name, _('Content View')
           field :lifecycle_environment_name, _('Lifecycle Environment')
           from :errata_counts do
-            field :security, _("Security"), :sets => ['ALL']
+            field :security, _("Security"), nil, :sets => ['ALL']
           end
           from :errata_counts do
-            field :bugfix, _("Bugfix"), :sets => ['ALL']
+            field :bugfix, _("Bugfix"), nil, :sets => ['ALL']
           end
           from :errata_counts do
-            field :enhancement, _("Enhancement"), :sets => ['ALL']
+            field :enhancement, _("Enhancement"), nil, :sets => ['ALL']
           end
         end
       end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -28,6 +28,15 @@ module HammerCLIKatello
         from :content_facet_attributes do
           field :content_view_name, _('Content View')
           field :lifecycle_environment_name, _('Lifecycle Environment')
+          from :errata_counts do
+            field :security, _("Security")
+          end
+          from :errata_counts do
+            field :bugfix, _("Bugfix")
+          end
+          from :errata_counts do
+            field :enhancement, _("Enhancement")
+          end
         end
       end
     end


### PR DESCRIPTION
At this moment the `hammer host list` will show errata information.

```
# hammer host list
-----|-----------------------------|------------------|--------------------------------------------------|----------------|-------------------|---------------------------|-----------------------|----------|--------|------------
ID   | NAME                        | OPERATING SYSTEM | HOST GROUP                                       | IP             | MAC               | CONTENT VIEW              | LIFECYCLE ENVIRONMENT | SECURITY | BUGFIX | ENHANCEMENT
-----|-----------------------------|------------------|--------------------------------------------------|----------------|-------------------|---------------------------|-----------------------|----------|--------|------------
58   | aldrey.local.domain         | RHEL Server 7.6  |                                                  | 192.168.56.215 | 52:54:00:41:ed:5e | Default Organization View | Library               | 0        | 0      | 0          
1049 | angie-molyneux.local.domain | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_puppet        | 192.168.56.222 | 52:54:00:08:2d:73 | Default Organization View | Library               | 0        | 0      | 0          
1052 | benny-mangen.local.domain   | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_ansible_roles | 192.168.56.203 | 52:54:00:6b:bc:d0 | Default Organization View | Library               | 65       | 240    | 39         
1047 | bryce-hatstat.local.domain  | RHEL Server 7.4  | hg_prov_rhel74/hg_prov_rhel74_with_ansible_roles | 192.168.56.236 | 52:54:00:85:df:8a | Default Organization View | Library               | 65       | 240    | 39 
```