### PR TITLE
Fixes #27096 - hammer host-collection hosts including erratas info

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -101,6 +101,13 @@ module HammerCLIKatello
       output do
         field :id, _("ID")
         field :name, _("Name")
+        from :content_facet_attributes do
+          from :errata_counts do
+            field :security, _("Security"), nil, :sets => ['ALL']
+            field :bugfix, _("Bugfix"), nil, :sets => ['ALL']
+            field :enhancement, _("Enhancement"), nil, :sets => ['ALL']
+          end
+        end
       end
 
       build_options { |o| o.expand(:all).including(:organizations) }


### PR DESCRIPTION
With this PR the customer will be able to generate a host collection report including errata info.
```
# hammer host-collection hosts --name rh_test --organization ACME
-----|-----------------------------|----------|--------|------------
ID   | NAME                        | SECURITY | BUGFIX | ENHANCEMENT
-----|-----------------------------|----------|--------|------------
1049 | angie-molyneux.local.domain | 0        | 0      | 0          
1047 | bryce-hatstat.local.domain  | 65       | 240    | 39         
1045 | cody-windly.local.domain    | 65       | 240    | 39         
1051 | ellen-lofstrom.local.domain | 65       | 240    | 39         
50   | heath-derion.local.domain   | 65       | 240    | 39         
-----|-----------------------------|----------|--------|------------
```