### PR TITLE
Fixes #27187 - Fixing Content View version Export for default organiz…

### DIFF
--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -45,7 +45,9 @@ module HammerCLIKatello
 
     def check_repo_download_policy(repositories)
       non_immediate = repositories.select do |repo|
-        show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] != 'immediate'
+        unless repo['library_instance_id'].nil?
+          show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] != 'immediate'
+        end
       end
       unless non_immediate.empty?
         non_immediate_names = non_immediate.collect { |repo| repo['name'] }


### PR DESCRIPTION
Fixed the content-view version export for default organization view by putting a check to ensure no nil library instance for the repository is passed through while checking the repo download policy.