### PR TITLE
Fixes #26952 - Restriction to export default org view

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -304,6 +304,7 @@ module HammerCLIKatello
           repositories = fetch_cvv_repositories(cvv)
           puppet_check(cvv)
           check_repo_type(repositories)
+          check_default_org_view(repositories)
           check_repo_download_policy(repositories)
           collect_packages(repositories)
 

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -43,6 +43,15 @@ module HammerCLIKatello
       end
     end
 
+    def check_default_org_view(repositories)
+      repositories.select do |repo|
+        if repo['library_instance_id'].nil?
+          raise _("The Repositories for Default Organization "\
+          "view can not be exported.")
+        end
+      end
+    end
+
     def check_repo_download_policy(repositories)
       non_immediate = repositories.select do |repo|
         show(:repositories, 'id' => repo['library_instance_id'])['download_policy'] != 'immediate'

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -324,4 +324,48 @@ describe 'content-view version export' do
                              " has at least one repository.\n")
     assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
   end
+
+  it "fails export for default organization view version" do
+    params = [
+      '--id=5',
+      '--export-dir=/tmp/exports'
+    ]
+
+    ex = api_expects(:content_view_versions, :show)
+    ex.returns(
+      'id' => '5',
+      'repositories' => [{'id' => '2'}],
+      'major' => 1,
+      'minor' => 0,
+      'content_view' => {'name' => 'cv'},
+      'content_view_id' => 4321,
+      'puppet_modules' => []
+    )
+
+    ex = api_expects(:content_views, :show)
+    ex.returns(
+      'id' => '4321',
+      'composite' => false
+    )
+
+    ex = api_expects(:repositories, :show).with_params('id' => '2')
+    ex.returns(
+      'id' => '2',
+      'label' => 'Test_Repo',
+      'content_type' => 'yum',
+      'backend_identifier' => 'Default_Organization-Library-Test_Repo',
+      'relative_path' => 'Default_Organization/Library/Test_Repo',
+      'library_instance_id' => nil
+    )
+
+    File.expects(:exist?).with('/usr/share/foreman').returns(true)
+    File.stubs(:exist?).with('/var/log/hammer/hammer.log._copy_').returns(false)
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.err, "Could not export the content view:\n" \
+                                "  Error: The Repositories for Default Organization "\
+                                "view can not be exported.\n" \
+                )
+    assert_equal(HammerCLI::EX_SOFTWARE, result.exit_code)
+  end
 end


### PR DESCRIPTION
Currently, when exporting the default organization view below error is shown-

Could not export the content view:
  Missing arguments for 'id'

which is confusing. Since, exporting the default org view is not supported at the moment. This PR is to show a message to make user aware of the scenario.