### PR TITLE
Fixes #27261 - export-legacy should not be described as deprecated

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -270,7 +270,7 @@ module HammerCLIKatello
     class LegacyExportCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async
       include LifecycleEnvironmentNameMapping
-      desc _('Export a content view (deprecated)')
+      desc _('Export a content view (legacy method)')
 
       action :export
       command_name "export-legacy"


### PR DESCRIPTION
`export-legacy` method has different functionality from `export` and should not be described as deprecated