### PR TITLE
fixes #27504 - Hammer Package Info to show all data

### DIFF
--- a/lib/hammer_cli_katello/package.rb
+++ b/lib/hammer_cli_katello/package.rb
@@ -43,6 +43,8 @@ module HammerCLIKatello
     class InfoCommand < HammerCLIKatello::InfoCommand
       output do
         field :id, _("ID")
+        field :pulp_id, _("Pulp ID")
+        field :uuid, _("UUID")
         field :name, _("Name")
         field :version, _("Version")
         field :arch, _("Architecture")
@@ -50,11 +52,24 @@ module HammerCLIKatello
         field :release, _("Release")
         field :author, _("Author")
         field :filename, _("Filename")
+        field :sourcerpm, _("Source rpm")
+        field :nvrea, _("nvrea")
         field :buildhost, _("Build Host")
+        field :hosts_available_count, _("Available Host Count")
+        field :hosts_applicable_count, _("Applicable Host Count")
+        field :children, _("Children")
         field :vendor, _("Vendor")
         field :license, _("License")
         field :relativepath, _("Relative Path")
         field :description, _("Description")
+        field :summary, _("Summary")
+        field :url, _("URL")
+        field :build_time, _("Build Time")
+        field :group, _("Group")
+        field :requires, _("Requires")
+        field :provides, _("Provides")
+        field :files, _("Files")
+        field :human_readable_size, _("Size")
         field :modular, _("Modular"), Fields::Boolean
       end
 


### PR DESCRIPTION
This PR was created to make `hammer package info ` command to show all the returned data from Katello api call.