### PR TITLE
Refs #26135 - Add srpm listing/info command and tests

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -136,6 +136,11 @@ module HammerCLIKatello
                                          'hammer_cli_katello/module_stream'
                                         )
 
+  HammerCLI::MainCommand.lazy_subcommand("srpm", _("Manipulate source RPMs"),
+                                        'HammerCLIKatello::SrpmCommand',
+                                        'hammer_cli_katello/srpm'
+                                        )
+
   # subcommands to hammer_cli_foreman commands
   require 'hammer_cli_katello/host'
   require 'hammer_cli_katello/hostgroup'

--- a/lib/hammer_cli_katello/srpm.rb
+++ b/lib/hammer_cli_katello/srpm.rb
@@ -1,0 +1,61 @@
+module HammerCLIKatello
+  class SrpmCommand < HammerCLIKatello::Command
+    resource :srpms
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      include LifecycleEnvironmentNameMapping
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+        field :filename, _("Filename")
+      end
+
+      validate_options :before, 'IdResolution' do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+        product_options = [:option_product_id, :option_product_name]
+        content_view_options = [:option_content_view_id, :option_content_view_name]
+
+        if option(:option_product_name).exist? || option(:option_content_view_name).exist?
+          any(*organization_options).required
+        end
+
+        if option(:option_repository_name).exist?
+          any(*product_options).required
+        end
+
+        if option(:option_content_view_version_version).exist?
+          any(*content_view_options).required
+        end
+
+        if any(*content_view_options).exist?
+          any(:option_content_view_version_id,
+              :option_content_view_version_version,
+              :option_environment_id,
+              :option_environment_name).required
+        end
+      end
+
+      build_options do |o|
+        o.expand.including(:products, :content_views)
+      end
+    end
+
+    class InfoCommand < HammerCLIKatello::InfoCommand
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+        field :version, _("Version")
+        field :arch, _("Architecture")
+        field :epoch, _("Epoch")
+        field :release, _("Release")
+        field :filename, _("Filename")
+        field :summary, _("Description")
+      end
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end

--- a/test/functional/srpm/list_test.rb
+++ b/test/functional/srpm/list_test.rb
@@ -1,0 +1,91 @@
+require_relative '../test_helper'
+require_relative '../repository/repository_helpers'
+require_relative '../product/product_helpers'
+require_relative '../organization/organization_helpers'
+require 'hammer_cli_katello/srpm'
+
+module HammerCLIKatello
+  describe PackageCommand::ListCommand do
+    include OrganizationHelpers
+    include RepositoryHelpers
+    include ProductHelpers
+
+    it 'allows minimal options' do
+      api_expects(:srpms, :index)
+
+      run_cmd(%w(srpm list))
+    end
+
+    describe 'repository options' do
+      it 'may be specified by ID' do
+        api_expects(:srpms, :index).with_params('repository_id' => 1)
+
+        run_cmd(%w(srpm list --repository-id 1))
+      end
+
+      it 'require product ID when given repository name' do
+        api_expects_no_call
+
+        r = run_cmd(%w(srpm list --repository repo1))
+        assert(r.err.include?("--product-id, --product is required"), "Invalid error message")
+      end
+
+      it 'may be specified by name and product ID' do
+        expect_repository_search(2, 'repo1', 1)
+
+        api_expects(:srpms, :index).with_params('repository_id' => 1)
+
+        run_cmd(%w(srpm list --repository repo1 --product-id 2))
+      end
+    end
+
+    describe 'organization options' do
+      it 'may be specified by ID' do
+        api_expects(:srpms, :index).with_params('organization_id' => 1)
+
+        run_cmd(%w(srpm list --organization-id 1))
+      end
+
+      it 'may be specified by name' do
+        expect_organization_search('org3', 1)
+        api_expects(:srpms, :index).with_params('organization_id' => 1)
+
+        run_cmd(%w(srpm list --organization org3))
+      end
+
+      it 'may be specified by label' do
+        expect_organization_search('org3', 1, field: 'label')
+        api_expects(:srpms, :index).with_params('organization_id' => 1)
+
+        run_cmd(%w(srpm list --organization-label org3))
+      end
+    end
+
+    describe 'content-view options' do
+      it 'may be specified by ID' do
+        api_expects(:content_view_versions, :index)
+          .with_params('content_view_id' => 1, 'version' => '2.1')
+          .returns(index_response([{'id' => 5}]))
+        api_expects(:srpms, :index).with_params('content_view_version_id' => 5)
+
+        run_cmd(%w(srpm list --content-view-id 1 --content-view-version 2.1))
+      end
+
+      it 'requires organization ID when given content view name' do
+        api_expects_no_call
+
+        r = run_cmd(%w(srpm list --content-view cv1 --content-view-version 2.1))
+        expected_error = "--organization-id, --organization, --organization-label is required"
+        assert(r.err.include?(expected_error), "Invalid error message")
+      end
+
+      it 'requires content view ID when given content view version number' do
+        api_expects_no_call
+
+        r = run_cmd(%w(srpm list --content-view-version cvv1))
+        assert(r.err.include?("--content-view-id, --content-view is required"),
+               "Invalid error message")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Listing:
```bash
[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer srpm list
---|-----------|------------------------------
ID | NAME      | FILENAME                     
---|-----------|------------------------------
1  | garmindev | garmindev-0.3.4-9.el7.src.rpm
---|-----------|------------------------------
```
Info:
```bash
[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer srpm info --id 1
ID:           1
Name:         garmindev
Version:      0.3.4
Architecture: src
Epoch:        0
Release:      9.el7
Filename:     garmindev-0.3.4-9.el7.src.rpm
Description:  Drivers for communication with Garmin GPS devices
```

~~Needs https://github.com/Katello/katello/pull/8249~~ Merged