### PR TITLE
Fixes #27466 - Allow Hammer to update cv version descriptions

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -13,6 +13,7 @@ module HammerCLIKatello
         field :id, _("ID")
         field :name, _("Name")
         field :version, _("Version")
+        field :description, _("Description")
         field :environments, _("Lifecycle Environments"), Fields::List
       end
 
@@ -151,6 +152,20 @@ module HammerCLIKatello
 
       success_message _("Content view is being deleted with task %{id}.")
       failure_message _("Could not delete the content view")
+
+      build_options do |o|
+        o.expand(:all).including(:environments, :content_views, :organizations)
+      end
+
+      extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
+    end
+
+    class UpdateCommand < HammerCLIKatello::UpdateCommand
+      action :update
+      command_name "update"
+
+      success_message _("Content view version updated.")
+      failure_message _("Could not update the content view version")
 
       build_options do |o|
         o.expand(:all).including(:environments, :content_views, :organizations)

--- a/test/functional/content_view/version/update_test.rb
+++ b/test/functional/content_view/version/update_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../test_helper'
+require 'hammer_cli_katello/content_view_version'
+
+module HammerCLIKatello
+  describe ContentViewVersion::UpdateCommand do
+    include OrganizationHelpers
+    it 'allows minimal options' do
+      ex = api_expects(:content_view_versions, :update).with_params('description' => 'pizza')
+      ex.returns('id' => '2', 'description' => 'pizza')
+
+      result = run_cmd(%w(content-view version update --id 2 --description pizza))
+      assert_equal(result.exit_code, 0)
+    end
+  end
+
+  describe 'content view options' do
+    it 'allows content view id with one version' do
+      ex = api_expects(:content_view_versions, :index)
+      ex.returns('id' => '1', 'content_view' => [{'id' => '2'}])
+
+      ex = api_expects(:content_view_versions, :update).with_params('description' => 'pizza')
+      ex.returns('id' => '1', 'description' => 'pizza', 'content_view' => [{'id' => '2'}])
+
+      result = run_cmd(%w(content-view version update --description pizza --content-view-id 2))
+      assert_equal(result.exit_code, 0)
+    end
+
+    it 'allows content view id with multiple versions' do
+      ex = api_expects(:content_view_versions, :index)
+      ex.returns('id' => '2', 'content_view' => [{'id' => '3'}])
+
+      ex = api_expects(:content_view_versions, :update).with_params('description' => 'pizza')
+      ex.returns('id' => '2', 'description' => 'pizza', 'content_view' => [{'id' => '3'}])
+
+      result = run_cmd(%w(content-view version update --description pizza
+                          --content-view-id 3 --version 2))
+      assert_equal(result.exit_code, 0)
+    end
+
+    it 'blocks update without description' do
+      ex = api_expects(:content_view_versions, :index)
+      ex.returns('id' => '1', 'content_view' => [{'id' => '2'}])
+
+      result = run_cmd(%w(content-view version update --content-view-id 2))
+      assert_equal(result.exit_code, 64)
+    end
+  end
+end


### PR DESCRIPTION
The output of the PR:

```bash
---|-------------------------------|---------|-------------|-----------------------
ID | NAME                          | VERSION | DESCRIPTION | LIFECYCLE ENVIRONMENTS
---|-------------------------------|---------|-------------|-----------------------
2  | Zoo 1.0                       | 1.0     | test        | Library               
1  | Default Organization View 1.0 | 1.0     |             | Library               
---|-------------------------------|---------|-------------|-----------------------

hammer -d content-view version update --id 2 --organization-id 1 --content-view 1 --description "pizza"
Content view version updated.

[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer content-view version list
---|-------------------------------|---------|-------------|-----------------------
ID | NAME                          | VERSION | DESCRIPTION | LIFECYCLE ENVIRONMENTS
---|-------------------------------|---------|-------------|-----------------------
2  | Zoo 1.0                       | 1.0     | pizza       | Library               
1  | Default Organization View 1.0 | 1.0     |             | Library               
---|-------------------------------|---------|-------------|-----------------------
```

Didn't include tests for content-view/id etc because there is an issue in Katello with validation, raised bugs:

https://projects.theforeman.org/issues/27521

https://projects.theforeman.org/issues/27522