### PR TITLE
Fixes #27523 - removing options from ContentView update

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -111,20 +111,8 @@ module HammerCLIKatello
         end
       end
 
-      validate_options :before, 'IdResolution' do
-        product_options = [:option_product_id, :option_product_name]
-        if option(:option_repository_ids).exist?
-          any(*product_options).rejected
-          option(:option_repository_names).rejected
-        end
-
-        if option(:option_repository_names).exist?
-          any(*product_options).required
-        end
-      end
-
       build_options do |o|
-        o.expand.including(:products)
+        o.expand.except(:repositories)
       end
     end
 
@@ -174,20 +162,10 @@ module HammerCLIKatello
         if option(:option_name).exist? || option(:option_product_name).exist?
           any(*organization_options).required
         end
-
-        product_options = [:option_product_id, :option_product_name]
-        if option(:option_repository_ids).exist?
-          any(*product_options).rejected
-          option(:option_repository_names).rejected
-        end
-
-        if option(:option_repository_names).exist?
-          any(*product_options).required
-        end
       end
 
       build_options do |o|
-        o.expand.including(:products)
+        o.expand.except(:repositories)
       end
     end
 

--- a/test/functional/content_view/create_test.rb
+++ b/test/functional/content_view/create_test.rb
@@ -8,14 +8,11 @@ describe 'content-view create' do
   let(:error_heading) { "Could not create the content view" }
   let(:name) { 'test-cv' }
   let(:org_id) { 1 }
-  let(:product) do
-    { 'name' => 'product-1', 'id' => 1 }
-  end
   let(:repositories) do
     [
-      {'name' => 'repo-1', 'id' => '1'},
-      {'name' => 'repo-2', 'id' => '2'},
-      {'name' => 'repo-3', 'id' => '3'}
+      {'id' => '1'},
+      {'id' => '2'},
+      {'id' => '3'}
     ]
   end
 
@@ -32,89 +29,6 @@ describe 'content-view create' do
 
     expected_result = success_result("Content view created.\n")
     result = run_cmd(@cmd + @base_params + params)
-    assert_cmd(expected_result, result)
-  end
-
-  it 'create the content view with repositories specified by product id and names' do
-    wanted = repositories.take(2)
-    ids = wanted.map { |repo| repo['id'] }
-    names = wanted.map { |repo| repo['name'] }
-    params = %W(--product-id=#{product['id']} --repositories=#{names.join(',')})
-
-    api_repositories = api_expects(:repositories, :index,
-                                   'Find repositories belonging to product') do |par|
-      par['product_id'] == product['id'] &&
-        par['names'] == names &&
-        !par.key?('name')
-    end
-    api_repositories.returns(repositories)
-
-    api_expects(:content_views, :create, 'Create content view') do |par|
-      par['organization_id'] == org_id &&
-        par['name'] == name &&
-        par['repository_ids'] == ids
-    end
-
-    expected_result = success_result("Content view created.\n")
-    result = run_cmd(@cmd + @base_params + params)
-    assert_cmd(expected_result, result)
-  end
-
-  it 'create the content view with repositories specified by product name and names' do
-    wanted = repositories.take(2)
-    ids = wanted.map { |repo| repo['id'] }
-    names = wanted.map { |repo| repo['name'] }
-    params = %W(--product=#{product['name']} --repositories=#{names.join(',')})
-
-    api_products = api_expects(:products, :index, 'Find ID of product') do |par|
-      par['organization_id'] == org_id && par['name'] == product['name']
-    end
-    api_products.returns(product)
-
-    api_repositories = api_expects(:repositories, :index,
-                                   'Find repositories belonging to product') do |par|
-      par['product_id'] == product['id'] &&
-        par['names'] == names &&
-        !par.key?('name')
-    end
-    api_repositories.returns(repositories)
-
-    api_expects(:content_views, :create, 'Create content view') do |par|
-      par['organization_id'] == org_id &&
-        par['name'] == name &&
-        par['repository_ids'] == ids
-    end
-
-    expected_result = success_result("Content view created.\n")
-    result = run_cmd(@cmd + @base_params + params)
-    assert_cmd(expected_result, result)
-  end
-
-  it 'fails on providing repository names without product' do
-    params = %w(--repositories=repo-1,repo-2)
-
-    expected_result = usage_error_result(
-      @cmd,
-      'At least one of options --product-id, --product is required.',
-      error_heading
-    )
-
-    api_expects_no_call
-    result = run_cmd(@cmd + @base_params + params)
-    assert_cmd(expected_result, result)
-  end
-
-  it 'fails on providing product and repository ids' do
-    params = %w(--product=testproduct --repository-ids=1,2,3,4,5)
-
-    expected_result = usage_error_result(
-      @cmd,
-      "You can't set any of options --product-id, --product.",
-      error_heading
-    )
-
-    api_expects_no_call
-    result = run_cmd(@cmd + params)
     assert_cmd(expected_result, result)
   end
 end

--- a/test/functional/content_view/update_test.rb
+++ b/test/functional/content_view/update_test.rb
@@ -48,32 +48,6 @@ module HammerCLIKatello
         end
         run_cmd(%w(content-view update --name cv2 --organization-label org1))
       end
-
-      it 'requires organization if product name is supplied along with repository' do
-        id = 122
-        repo_id = 100
-        product_name = "foo"
-        api_expects_no_call
-        cmd = %W(content-view update --id=#{id}\
-                 --repository-ids=#{repo_id} --product=#{product_name})
-        result = run_cmd(cmd)
-        expected_error = "--organization-id, --organization, --organization-label is required"
-        assert(result.err.include?(expected_error),
-               "Invalid Error Message")
-      end
-
-      it 'requires product if repository names are provided' do
-        id = 122
-        repo_id = 100
-        organization_id = 5
-        api_expects_no_call
-        cmd = %W(content-view update --id=#{id}\
-                 --repositories=#{repo_id} --organization-id=#{organization_id})
-        result = run_cmd(cmd)
-        expected_error = "--product-id, --product is required"
-        assert(result.err.include?(expected_error),
-               "Invalid Error Message")
-      end
     end
   end
 end


### PR DESCRIPTION
This PR was created to remove repositories, product-id and product from `hammer content-view update --help`