### PR TITLE
Fixes #27712 - module stream rules

### DIFF
--- a/lib/hammer_cli_katello/filter_rule.rb
+++ b/lib/hammer_cli_katello/filter_rule.rb
@@ -61,7 +61,10 @@ module HammerCLIKatello
         super
       end
 
-      build_options
+      build_options do |o|
+        o.expand.except(:module_streams)
+        o.without(:module_streams)
+      end
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand


### PR DESCRIPTION
This PR updates the filter rules create test to add support for module
streams. The user is now required to specify both the
'module-stream-name' and 'module-stream-stream' options instead of
trying to pass multiple module:stream strings in a single string.