### PR TITLE
Fixes #27729 - Upload rpm without --content-type

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -443,9 +443,9 @@ module HammerCLIKatello
         params = {:id => get_identifier,
                   :uploads => uploads,
                   publish_repository: publish_repository,
-                  sync_capsule: sync_capsule,
-                  content_type: option_content_type
+                  sync_capsule: sync_capsule
         }
+        params[:content_type] = options["option_content_type"] if options["option_content_type"]
         resource.call(:import_uploads, params)
       end
 


### PR DESCRIPTION
hammer repository upload-content --id=245 --path ./t.rpm
This command failed with
`undefined local variable or method `option_content_type`

This commit addresses this issue