### PR TITLE
Fixes #25588 - updates content-view-id description

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -283,6 +283,11 @@ module HammerCLIKatello
       command_name 'add-version'
       desc _('Add a content view version to a composite view')
 
+      option "--content-view-id", "CONTENT_VIEW_ID",
+        _("Content view numeric identifier to search by"),
+        attribute_name: :option_content_view_id,
+        format: HammerCLI::Options::Normalizers::Number.new
+
       validate_options :before, 'IdResolution' do
         if option(:option_content_view_version_version).exist?
           any(:option_content_view_id, :option_content_view_name).required


### PR DESCRIPTION
This PR updates the `content-view-id` description displayed, for example:
```
$ bundle exec hammer content-view add-version -h
Warning: An error occured while loading module hammer_cli_csv.
Warning: An error occured while loading module hammer_cli_foreman_admin.
Warning: An error occured while loading module hammer_cli_foreman_remote_execution.
Usage:
    hammer content-view add-version [OPTIONS]

Options:
 --content-view CONTENT_VIEW_NAME                    Content view name to search by
 --content-view-id CONTENT_VIEW_ID                   Content view numeric identifier to search by
 --content-view-version CONTENT_VIEW_VERSION_VERSION Content view version number
 --content-view-version-id CONTENT_VIEW_VERSION_ID   Content view version identifier
 --id ID                                             Content view numeric identifier
 --name NAME                                         Content view name to search by
 --organization ORGANIZATION_NAME                    Organization name to search by
 --organization-id ORGANIZATION_ID                   Organization ID to search by
 --organization-label ORGANIZATION_LABEL             Organization label to search by
 -h, --help                                          Print help
```