### PR TITLE
Fixes #27807 - Prevent timeout during CVV import

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -498,7 +498,8 @@ module HammerCLIKatello
           library_repos = index(
             :repositories,
             'organization_id' => organization_id,
-            'library' => true
+            'library' => true,
+            'label' => repo['label']
           )
 
           library_repo = library_repos.select do |candidate_repo|


### PR DESCRIPTION
21 repos synced and placed into a content view called `Big-View`

```bash
---|----------------------------------------------------------------------------------|------------------------------------------------|--------------|---------------------------------------------------------------------------------
ID | NAME                                                                             | PRODUCT                                        | CONTENT TYPE | URL                                                                             
---|----------------------------------------------------------------------------------|------------------------------------------------|--------------|---------------------------------------------------------------------------------
1  | dotNET on RHEL RPMs for Red Hat Enterprise Linux 7 Server x86_64 7Server         | dotNET on RHEL (for RHEL Server)               | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/dotnet/1/os    
7  | Red Hat Ansible Engine 2.6 RPMs for Red Hat Enterprise Linux 7 Server x86_64     | Red Hat Ansible Engine                         | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.6/os 
3  | Red Hat Enterprise Linux 6 Server Kickstart x86_64 6.10                          | Red Hat Enterprise Linux Server                | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6.10/x86_64/kickstart         
2  | Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7                           | Red Hat Enterprise Linux Server                | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7.7/x86_64/kickstart          
11 | Red Hat Satellite 6.1 for RHEL 6 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/satellite/6....
10 | Red Hat Satellite 6.1 for RHEL 7 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
13 | Red Hat Satellite 6.2 for RHEL 6 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/satellite/6....
12 | Red Hat Satellite 6.2 for RHEL 7 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
15 | Red Hat Satellite 6.3 for RHEL 7 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
14 | Red Hat Satellite 6.3 - Puppet 4 for RHEL 7 Server RPMs x86_64                   | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
17 | Red Hat Satellite 6.4 for RHEL 7 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
16 | Red Hat Satellite 6.5 for RHEL 7 Server RPMs x86_64                              | Red Hat Satellite                              | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/satellite/6....
20 | Red Hat Satellite Capsule 6.0 for RHEL 6 Server RPMs x86_64 6Server              | Red Hat Satellite Capsule                      | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/sat-capsule/...
21 | Red Hat Satellite Capsule 6.0 for RHEL 7 Server RPMs x86_64 7Server              | Red Hat Satellite Capsule                      | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/...
19 | Red Hat Satellite Capsule 6.1 for RHEL 6 Server RPMs x86_64                      | Red Hat Satellite Capsule                      | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/sat-capsule/...
18 | Red Hat Satellite Capsule 6.1 for RHEL 7 Server RPMs x86_64                      | Red Hat Satellite Capsule                      | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/...
8  | Red Hat Satellite Capsule 6.5 for RHEL 7 Server RPMs x86_64                      | Red Hat Satellite Capsule                      | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/...
9  | Red Hat Satellite Maintenance 6 for RHEL 7 Server RPMs x86_64                    | Red Hat Enterprise Linux Server                | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-maintena...
6  | Red Hat Satellite Tools 6.5 for RHEL 6 Server RPMs x86_64                        | Red Hat Enterprise Linux Server                | yum          | https://cdn.redhat.com/content/dist/rhel/server/6/6Server/x86_64/sat-tools/6....
5  | Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64                        | Red Hat Enterprise Linux Server                | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/sat-tools/6....
4  | Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server x86_6... | Red Hat Software Collections (for RHEL Server) | yum          | https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os     
---|----------------------------------------------------------------------------------|------------------------------------------------|--------------|---------------------------------------------------------------------------------
```

Old way before patch:

```ruby
[ERROR 2019-09-10T03:32:00 Exception] Error: Unable to sync repositories, no library repository found for Red_Hat_Software_Collections_RPMs_for_Red_Hat_Enterprise_Linux_7_Server_x86_64_7Server
Could not import the content view:
  Error: Unable to sync repositories, no library repository found for Red_Hat_Software_Collections_RPMs_for_Red_Hat_Enterprise_Linux_7_Server_x86_64_7Server
[ERROR 2019-09-10T03:32:00 Exception] 

RuntimeError (Unable to sync repositories, no library repository found for Red_Hat_Software_Collections_RPMs_for_Red_Hat_Enterprise_Linux_7_Server_x86_64_7Server):
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-0.18.2/lib/hammer_cli_katello/content_view_version.rb:456:in `block in sync_repositories'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-0.18.2/lib/hammer_cli_katello/content_view_version.rb:441:in `each'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-0.18.2/lib/hammer_cli_katello/content_view_version.rb:441:in `sync_repositories'
    /opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-0.18.2/lib/hammer_cli_katello/content_view_version.rb:426:in `execute'
```

working as expected with patch:

```bash
[root@katello312 ~]# hammer -d content-view version import --organization-id 1 --export-tar /var/lib/pulp/katello-export/export-Big-View-1.0.tar 
[..........................................................................................................................................................................................................] [100%]
Content View Imported.

[root@katello312 ~]# hammer content-view version list
---|-------------------------------|---------|-----------------------
ID | NAME                          | VERSION | LIFECYCLE ENVIRONMENTS
---|-------------------------------|---------|-----------------------
2  | Big-View 1.0                  | 1.0     | Library               
1  | Default Organization View 1.0 | 1.0     | Library               
---|-------------------------------|---------|-----------------------

hammer content-view info --id 2
Versions:                     
 1) ID:        2
    Version:   1.0
    Published: 2019/09/10 02:53:45
```

Adding the search by label helped with the pagination issues. My per_page was set to 20 so with the test above it shows now we can get above the limit. 