### PR TITLE
Fixes #27778 - Org command no longer shows deprication warning

### DIFF
--- a/lib/hammer_cli_katello/commands.rb
+++ b/lib/hammer_cli_katello/commands.rb
@@ -1,5 +1,8 @@
 module HammerCLIKatello
-  RESOURCE_NAME_MAPPING = {}.freeze
+  RESOURCE_NAME_MAPPING = {
+    environment: :lifecycle_environment,
+    environments: :lifecycle_environments
+  }.freeze
 
   RESOURCE_ALIAS_NAME_MAPPING = {
     environment: :lifecycle_environment,

--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -37,7 +37,8 @@ module HammerCLIKatello
       build_options
     end
 
-    class CreateCommand < HammerCLIKatello::CreateCommand
+    class CreateCommand < HammerCLIForeman::Organization::CreateCommand
+      include HammerCLIKatello::ResolverCommons
       resource :organizations, :create
 
       success_message _("Organization created.")


### PR DESCRIPTION
@akofink, could you or someone from your team please ensure that this will not break commands when `environments` should be mapped to `lifecycle-environments`? I think some commands that use `--lifecycle-environments` as an option will be enough.