### PR TITLE
Fixes #28224 - host errata call accepts org

### DIFF
--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -15,6 +15,8 @@ module HammerCLIKatello
     end
 
     class ListCommand < HammerCLIKatello::ListCommand
+      include OrganizationOptions
+      include LifecycleEnvironmentNameMapping
       resource :host_errata, :index
       command_name "list"
 
@@ -27,6 +29,7 @@ module HammerCLIKatello
       end
 
       build_options
+      extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
     end
 
     class InfoCommand < HammerCLIKatello::ErratumInfoCommand

--- a/test/functional/host/errata/list_test.rb
+++ b/test/functional/host/errata/list_test.rb
@@ -32,10 +32,11 @@ describe 'host errata listing' do
 
     expect_lifecycle_environment_search(org_id.to_s, 'test', lifecycle_env_id)
 
-    ex = api_expects(:host_errata, :index, 'host errata list') do |par|
-      par['host_id'] == host_id && par['environment_id'] == lifecycle_env_id &&
-        par['page'] == 1 && par['per_page'] == 1000
-    end
+    ex = api_expects(:host_errata, :index, 'host errata list').
+         with_params('host_id': host_id,
+                     'environment_id': lifecycle_env_id,
+                     'page': 1,
+                     'per_page': 1000)
 
     ex.returns(empty_response)
     expected_result = success_result("---|------------|------|-------|------------

--- a/test/functional/host/errata/list_test.rb
+++ b/test/functional/host/errata/list_test.rb
@@ -27,7 +27,6 @@ describe 'host errata listing' do
     }
   end
 
-
   it "lists the host errata belonging to a lifecycle-environment by name" do
     params = ["--host-id=#{host_id}", "--organization-id=#{org_id}", '--lifecycle-environment=test']
 
@@ -39,12 +38,10 @@ describe 'host errata listing' do
     end
 
     ex.returns(empty_response)
-    expected_result = success_result(
-"---|------------|------|-------|------------
+    expected_result = success_result("---|------------|------|-------|------------
 ID | ERRATUM ID | TYPE | TITLE | INSTALLABLE
 ---|------------|------|-------|------------
 ")
-
     result = run_cmd(@cmd + params)
     assert_cmd(expected_result, result)
   end

--- a/test/functional/host/errata/list_test.rb
+++ b/test/functional/host/errata/list_test.rb
@@ -1,0 +1,51 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+require_relative '../../lifecycle_environment/lifecycle_environment_helpers'
+
+describe 'host errata listing' do
+  include LifecycleEnvironmentHelpers
+
+  before do
+    @cmd = %w(host errata list)
+  end
+
+  let(:org_id) { 1 }
+  let(:host_id) { 2 }
+  let(:lifecycle_env_id) { 3 }
+  let(:empty_response) do
+    {
+      "total" => 0,
+      "subtotal" => 0,
+      "page" => "1",
+      "per_page" => "1000",
+      "error" => nil,
+      "search" => nil,
+      "sort" => {
+        "by" => nil,
+        "order" => nil
+      },
+      "results" => []
+    }
+  end
+
+
+  it "lists the host errata belonging to a lifecycle-environment by name" do
+    params = ["--host-id=#{host_id}", "--organization-id=#{org_id}", '--lifecycle-environment=test']
+
+    expect_lifecycle_environment_search(org_id.to_s, 'test', lifecycle_env_id)
+
+    ex = api_expects(:host_errata, :index, 'host errata list') do |par|
+      par['host_id'] == host_id && par['environment_id'] == lifecycle_env_id &&
+        par['page'] == 1 && par['per_page'] == 1000
+    end
+
+    ex.returns(empty_response)
+    expected_result = success_result(
+"---|------------|------|-------|------------
+ID | ERRATUM ID | TYPE | TITLE | INSTALLABLE
+---|------------|------|-------|------------
+")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+end


### PR DESCRIPTION
hammer host errata call previously accepted an environment but not an
organization to go with it. This commit fixes that by requiring the
organizaiton options.