### PR TITLE
Fixes #28177 - Add http-proxy to repo info command

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -54,6 +54,13 @@ module HammerCLIKatello
               Fields::Field, :hide_blank => true
         field :ignorable_content, _("Ignorable Content Units"), Fields::List, :hide_blank => true
 
+        label _("Http Proxy") do
+          from :http_proxy do
+            field :id, _("ID"), Fields::Field, :hide_blank => true
+            field :name, _("Name"), Fields::Field, :hide_blank => true
+          end
+        end
+
         label _("Product") do
           from :product do
             field :id, _("ID")


### PR DESCRIPTION
Output with PR:

```shell
[vagrant@devel ~]$ hammer repository info --id 1
ID:                 1
Name:               Animals
Label:              Animals
Organization:       Default Organization
Red Hat Repository: no
Content Type:       yum
Mirror on Sync:     yes
URL:                https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/
Publish Via HTTP:   yes
Published At:       http://devel.katello.lan/pulp/repos/Default_Organization/Library/custom/Animals/Animals/
Relative Path:      Default_Organization/Library/custom/Animals/Animals
Download Policy:    immediate
Http Proxy:
    ID:   1
    Name: testproxy
Product:
    ID:   1
    Name: Animals
GPG Key:

Sync:
    Status:         Success
    Last Sync Date: 23 minutes
Created:            2019/12/03 17:02:42
Updated:            2019/12/03 17:03:38
Content Counts:
    Packages:       32
    Source RPMS:    0
    Package Groups: 2
    Errata:         4
    Module Streams: 0
```

Tests are super basic :( so not worth the update in this pr, we should start to make the tests deeper on the info commands.