### PR TITLE
Fixes #27548 - Better handling of server exceptions

### DIFF
--- a/lib/hammer_cli_katello/exception_handler.rb
+++ b/lib/hammer_cli_katello/exception_handler.rb
@@ -31,14 +31,21 @@ module HammerCLIKatello
     end
 
     def handle_katello_error(e)
-      response = JSON.parse(e.response)
-      response = HammerCLIForeman.record_to_common_format(response)
-      # Check multiple possible keys that can contain error message:
-      # - displayMessage for katello specific messages
-      # - full_messages for for messages that come from rails
-      # - message for foreman specific messages
-      print_error response["displayMessage"] || response["full_messages"] || response["message"]
-      log_full_error e
+      begin
+        response = JSON.parse(e.response)
+        response = HammerCLIForeman.record_to_common_format(response)
+        # Check multiple possible keys that can contain error message:
+        # - displayMessage for katello specific messages
+        # - full_messages for for messages that come from rails
+        # - message for foreman specific messages
+        msg = response["displayMessage"] || response["full_messages"] || response["message"]
+      rescue JSON::ParserError
+        msg = e.message
+      ensure
+        msg ||= e.message
+      end
+      print_error(msg)
+      log_full_error(e)
     end
   end
 end


### PR DESCRIPTION
TL;DR: Handle `JSON::ParserError` for server responses with code 500.

While trying to reproduce the original issue I've noticed that the root of the problem is inconsistency in server responses if something went wrong/hammer handlers of those responses.

In hammer-cli-foreman we handle 500 errors with https://github.com/theforeman/hammer-cli-foreman/blob/59e6cdc704c67a7db96d15b685aac13bda1d999c/lib/hammer_cli_foreman/exception_handler.rb#L96.

But if we use a command coming from hammer-cli-katello (as in original issue: hammer ping) then the different handler is used.

My proposal is to tweak the hammer-cli-katello's handler to be almost the same.