### PR TITLE
Fixes #28178 - Correct http_proxy search by name

### DIFF
--- a/lib/hammer_cli_katello/foreman_search_options_creators.rb
+++ b/lib/hammer_cli_katello/foreman_search_options_creators.rb
@@ -87,5 +87,9 @@ module HammerCLIKatello
     def create_users_search_options(options, mode = nil)
       create_search_options_without_katello_api(options, api.resource(:users), mode)
     end
+
+    def create_http_proxies_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:http_proxies), mode)
+    end
   end
 end


### PR DESCRIPTION
This PR addresses an issue where when you search http-proxy by name it returns all of the entries instead of just 1 which will cause a failure.

This is because of https://github.com/Katello/hammer-cli-katello/blob/165de784748030762a52f6642e9951001bd50c6e/lib/hammer_cli_katello/id_resolver.rb#L52, so the search_options (or search parameters) are wrongly built.

@jjeffers want to test it?