### PR TITLE
Fixes #28486 - Add proxy_policy to repo info.

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -66,6 +66,7 @@ module HammerCLIKatello
             field :id, _("ID")
             field :name, _("Name")
           end
+          field :http_proxy_policy, _("Http Proxy Policy")
         end
 
         label _("GPG Key") do


### PR DESCRIPTION
Forgot to add http_proxy_policy from https://projects.theforeman.org/issues/28177

With PR:

```ruby
ID:                 1
Name:               Animals
Label:              Animals
Organization:       Default Organization
Red Hat Repository: no
Content Type:       yum
Mirror on Sync:     yes
URL:                https://repos.fedorapeople.org/pulp/pulp/demo_repos/zoo/
Publish Via HTTP:   yes
Published At:       http://devel.katello.lan/pulp/repos/Default_Organization/Library/custom/Animals/Animals/
Relative Path:      Default_Organization/Library/custom/Animals/Animals
Download Policy:    immediate
Http Proxy:
    ID:                1
    Name:              testproxy1
    Http Proxy Policy: use_selected_http_proxy
Product:
    ID:   1
    Name: Animals
GPG Key:

Sync:
    Status:         Success
    Last Sync Date: 8 days
Created:            2019/12/03 17:02:42
Updated:            2019/12/11 15:08:58
Content Counts:
    Packages:       32
    Source RPMS:    0
    Package Groups: 2
    Errata:         4
    Module Streams: 0

```