### PR TITLE
Fixes #28293 - rename gpg command

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -43,9 +43,20 @@ module HammerCLIKatello
                                           'hammer_cli_katello/organization'
                                          )
 
-  HammerCLI::MainCommand.lazy_subcommand("gpg", _("Manipulate GPG Key actions on the server"),
+  HammerCLI::MainCommand.lazy_subcommand("gpg",
+                                         _("Manipulate GPG Key actions on the server"),
                                          'HammerCLIKatello::GpgKeyCommand',
-                                         'hammer_cli_katello/gpg_key'
+                                         'hammer_cli_katello/gpg_key',
+                                         :warning =>
+  _('The gpg sub-command is deprecated and will be removed in one of the future versions.' \
+    ' Please use the content-credentials command instead.')
+                                        )
+
+  HammerCLI::MainCommand.lazy_subcommand("content-credentials",
+                                         _("Manipulate content credentials (i.e. GPG Keys)' \
+                                          'on the server"),
+                                         'HammerCLIKatello::ContentCredentialCommand',
+                                         'hammer_cli_katello/content_credential'
                                         )
 
   HammerCLI::MainCommand.lazy_subcommand("lifecycle-environment",

--- a/lib/hammer_cli_katello/content_credential.rb
+++ b/lib/hammer_cli_katello/content_credential.rb
@@ -1,0 +1,67 @@
+module HammerCLIKatello
+  class ContentCredentialCommand < HammerCLIForeman::Command
+    resource :content_credentials
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+      end
+
+      build_options
+    end
+
+    class InfoCommand < HammerCLIKatello::InfoCommand
+      output do
+        field :id, _("ID")
+        field :name, _("Name")
+        from :organization do
+          field :name, _("Organization")
+        end
+
+        collection :repositories, "Repositories" do
+          field :id, _("ID")
+          field :name, _("Name")
+          field :content_type, _("Content Type")
+          from :product do
+            field :name, _("Product")
+          end
+        end
+
+        field :content, _("Content"), Fields::LongText
+      end
+
+      build_options
+    end
+
+    class CreateCommand < HammerCLIKatello::CreateCommand
+      success_message _("Content credential created.")
+      failure_message _("Could not create GPG key")
+
+      build_options :without => [:content]
+      option "--key", "GPG_KEY_FILE", _("GPG Key file"),
+             :attribute_name => :option_content,
+             :required => true,
+             :format => HammerCLI::Options::Normalizers::File.new
+    end
+
+    class UpdateCommand < HammerCLIKatello::UpdateCommand
+      success_message _("GPG Key updated.")
+      failure_message _("Could not update GPG Key")
+
+      build_options :without => [:content]
+      option "--key", "GPG_KEY_FILE", _("GPG Key file"),
+             :attribute_name => :option_content,
+             :format => HammerCLI::Options::Normalizers::File.new
+    end
+
+    class DeleteCommand < HammerCLIKatello::DeleteCommand
+      success_message _("GPG Key deleted.")
+      failure_message _("Could not delete the GPG Key")
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end

--- a/test/functional/content_credentials/info_test.rb
+++ b/test/functional/content_credentials/info_test.rb
@@ -1,0 +1,50 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), '../product/product_helpers')
+
+def expect_credentials_search(org_id, name, id)
+  api_expects(:content_credentials, :index, 'List content credentials')
+    .with_params('name' => name, 'organization_id' => org_id)
+    .returns(index_response([{'id' => id}]))
+end
+
+describe "get content-credentials info" do
+  include ProductHelpers
+
+  before do
+    @cmd = %w(content-credentials info)
+  end
+
+  let(:org_id) { 1 }
+  let(:product_id) { 2 }
+  let(:key_id) { 3 }
+
+  it "Shows information about a content credental" do
+    params = ["--organization-id=#{org_id}", "--name=test_key"]
+
+    expect_credentials_search(org_id, 'test_key', key_id)
+
+    ex = api_expects(:content_credentials, :show, "Get info") do |par|
+      par["id"] == key_id
+    end
+
+    ex.returns({})
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.exit_code, 0)
+  end
+
+  it "Shows information about a key with organization-id and key name" do
+    params = ["--name=test_key", "--organization-id=#{org_id}"]
+
+    expect_credentials_search(org_id, "test_key", key_id)
+
+    ex2 = api_expects(:content_credentials, :show, "Get info") do |par|
+      par["id"] == key_id
+    end
+
+    ex2.returns({})
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.exit_code, 0)
+  end
+end

--- a/test/functional/content_credentials/list_test.rb
+++ b/test/functional/content_credentials/list_test.rb
@@ -1,0 +1,68 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), '../lifecycle_environment/lifecycle_environment_helpers')
+
+require 'hammer_cli_katello/content_view_puppet_module'
+
+describe 'listing content credentials' do
+  include LifecycleEnvironmentHelpers
+
+  before do
+    @cmd = %w(content-credentials list)
+  end
+
+  let(:org_id) { 1 }
+  let(:lifecycle_env_id) { 1 }
+  let(:empty_response) do
+    {
+      "total" => 0,
+      "subtotal" => 0,
+      "page" => "1",
+      "per_page" => "1000",
+      "error" => nil,
+      "search" => nil,
+      "sort" => {
+        "by" => nil,
+        "order" => nil
+      },
+      "results" => []
+    }
+  end
+
+  it "lists an organizations keys" do
+    params = ["--organization-id=#{org_id}"]
+
+    ex = api_expects(:content_credentials, :index, 'Organization content credentials list') do |par|
+      par['organization_id'] == org_id && par['page'] == 1 &&
+        par['per_page'] == 1000
+    end
+
+    ex.returns(empty_response)
+
+    expected_result = success_result("---|-----
+ID | NAME
+---|-----
+")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "lists the keys by content-type" do
+    params = ['--content-type=gpg', "--organization-id=#{org_id}"]
+
+    ex = api_expects(:content_credentials, :index, 'content-type') do |par|
+      par['organization_id'] == org_id && par['page'] == 1 &&
+        par['per_page'] == 1000
+    end
+
+    ex.returns(empty_response)
+
+    expected_result = CommandExpectation.new("---|-----
+ID | NAME
+---|-----
+")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+end

--- a/test/functional/gpg_test.rb
+++ b/test/functional/gpg_test.rb
@@ -1,0 +1,39 @@
+require_relative 'test_helper'
+require 'hammer_cli_katello/gpg_key'
+
+module HammerCLIKatello
+  describe GpgKeyCommand::ListCommand do
+    it 'warns of deprecation' do
+      result = run_cmd(%w(gpg list))
+      assert_match(/deprecated/, result.err)
+    end
+  end
+
+  describe GpgKeyCommand::InfoCommand do
+    it 'warns of deprecation' do
+      result = run_cmd(%w(gpg info))
+      assert_match(/deprecated/, result.err)
+    end
+  end
+
+  describe GpgKeyCommand::CreateCommand do
+    it 'warns of deprecation' do
+      result = run_cmd(%w(gpg create))
+      assert_match(/deprecated/, result.err)
+    end
+  end
+
+  describe GpgKeyCommand::UpdateCommand do
+    it 'warns of deprecation' do
+      result = run_cmd(%w(gpg update))
+      assert_match(/deprecated/, result.err)
+    end
+  end
+
+  describe GpgKeyCommand::DeleteCommand do
+    it 'warns of deprecation' do
+      result = run_cmd(%w(gpg delete))
+      assert_match(/deprecated/, result.err)
+    end
+  end
+end


### PR DESCRIPTION
This PR marks the `gpg` command as deprecated, and duplicates the implementation to respond to `content-credentials`.

New tests were added as a skeleton for more comprehensive testing for the `content-credentials` API resource. No tests existed for the `gpg` command prior.

To test, for example:
```
hammer content-credentials list --organization-id <your org id here>
```
Any `gpg` command should not be usable, but return a deprecation warning via STDERR. The same subcommands exist for `content-credentials`.
