### PR TITLE
Fixes #28852 - Add Next Sync date in hammer command

### DIFF
--- a/lib/hammer_cli_katello/sync_plan.rb
+++ b/lib/hammer_cli_katello/sync_plan.rb
@@ -21,6 +21,7 @@ module HammerCLIKatello
         field :description, _("Description")
         field :created_at, _("Created at"), Fields::Date
         field :updated_at, _("Updated at"), Fields::Date
+        field :next_sync, _("Next Sync"), Fields::Date
 
         collection :products, _("Products") do
           field :id, _("ID")


### PR DESCRIPTION
With this patch `hammer sync-plan info` shows **Next Sync** date

~~~
# hammer sync-plan info --id 3
ID:                 3
Name:               Test
Start Date:         2020/01/23 18:30:00
Interval:           hourly
Enabled:            yes
Cron Expression:    
Recurring Logic ID: 30
Description:        
Created at:         2020/01/24 03:56:05
Updated at:         2020/01/24 03:56:05
Next Sync:          2020/01/24 04:30:00
Products:
~~~