### PR TITLE
[WIP] Add content-view version export/import skip-rpms options.

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -351,8 +351,8 @@ module HammerCLIKatello
       option '--export-dir', 'EXPORT_DIR', _("Directory to put content view version export into.")
       option '--skip-rpms',
         :flag,
-        _("Do not include RPMs in export (content must be synchronized " + 
-          "prior to import)")
+        _("Do not include RPMs in export (content must be synchronized \
+prior to import)")
 
       validate_options do
         option(:option_export_dir).required

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -349,6 +349,7 @@ module HammerCLIKatello
 
       option "--id", "ID", _("Content View Version numeric identifier")
       option '--export-dir', 'EXPORT_DIR', _("Directory to put content view version export into.")
+      option '--skip-rpms', :flag, _("Do not include RPMs in export (content must be synchronized to destination prior to import)")
 
       validate_options do
         option(:option_export_dir).required
@@ -399,7 +400,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories&.any?
+        if repositories&.any? && ! options['option_skip_rpms']
 
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
@@ -446,6 +447,7 @@ module HammerCLIKatello
         '--export-tar', 'EXPORT_TAR',
         _("Location of export tar on disk")
       )
+      option '--skip-rpms', :flag, _("Skip import of RPMs (content must be synchronized prior to import)")
 
       validate_options do
         option(:option_export_tar).required
@@ -477,7 +479,7 @@ module HammerCLIKatello
           publish(cv['id'], export_json['major'], export_json['minor'])
         else
           sync_repositories(export_json['repositories'], options['option_organization_id'],
-            import_tar_params)
+            import_tar_params) unless options['option_skip_rpms']
 
           unless cv['default']
             publish(

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -349,7 +349,10 @@ module HammerCLIKatello
 
       option "--id", "ID", _("Content View Version numeric identifier")
       option '--export-dir', 'EXPORT_DIR', _("Directory to put content view version export into.")
-      option '--skip-rpms', :flag, _("Do not include RPMs in export (content must be synchronized to destination prior to import)")
+      option '--skip-rpms',
+        :flag,
+        _("Do not include RPMs in export (content must be synchronized " + 
+          "prior to import)")
 
       validate_options do
         option(:option_export_dir).required
@@ -400,7 +403,7 @@ module HammerCLIKatello
 
         Dir.mkdir("#{export_dir}/#{export_prefix}")
 
-        if repositories&.any? && ! options['option_skip_rpms']
+        if repositories&.any? && !options['option_skip_rpms']
 
           Dir.chdir(PUBLISHED_REPOS_DIR) do
             repo_tar = "#{export_dir}/#{export_prefix}/#{export_repos_tar}"
@@ -447,7 +450,9 @@ module HammerCLIKatello
         '--export-tar', 'EXPORT_TAR',
         _("Location of export tar on disk")
       )
-      option '--skip-rpms', :flag, _("Skip import of RPMs (content must be synchronized prior to import)")
+      option '--skip-rpms',
+        :flag,
+        _("Skip import of RPMs (content must be synchronized prior to import)")
 
       validate_options do
         option(:option_export_tar).required


### PR DESCRIPTION
Use case:

Two separate Foreman servers which have repositories synchronized from upstream sources need to have the same content-view versions to be able to facilitate consistent life cycle management.  For example, one Foreman server may be used for development environments patching and a separate Foreman server may be required to manage production environments patching due to security restrictions.

The new content-view version export/import process works nicely for this, except that if content is synchronized already via a sync plan, the export and import of the RPM repositories can create significant and unnecessary overhead in the export / import / and transfer of the tar ball from the export between export and import systems.

This PR is a work in progress.  It is able to export and import content-view versions without including the RPMs using the --skip-rpms option to both content-view version export and import commands.  I'm looking for feedback about this idea and implementation.

RFE BZ for this functionality: https://bugzilla.redhat.com/show_bug.cgi?id=1744255