### PR TITLE
Fixes #28294 - Create repo with ssl cert name

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -201,7 +201,35 @@ module HammerCLIKatello
              :attribute_name => :option_unprotected,
              :format => HammerCLI::Options::Normalizers::Bool.new
 
+      option "--ssl-client-cert", "SSL_CLIENT_CERT",
+             _("Name of content credential containing client certificate"),
+             :attribute_name => :option_ssl_client_cert
+
+      option "--ssl-client-key", "SSL_CLIENT_KEY",
+             _("Name of content credential containing client key"),
+             :attribute_name => :option_ssl_client_key
+
+      option "--ssl-ca-cert", "SSL_CA_CERT",
+             _("Name of content credential containing CA certificate"),
+             :attribute_name => :option_ssl_ca_cert
+
       build_options :without => [:unprotected]
+
+      def request_params
+        params = super
+
+        params["ssl_client_cert_id"] ||= get_gpg_key_id("ssl_client_cert") if option_ssl_client_cert
+        params["ssl_client_key_id"] ||= get_gpg_key_id("ssl_client_key") if option_ssl_client_key
+        params["ssl_ca_cert_id"] ||= get_gpg_key_id("ssl_ca_cert") if option_ssl_ca_cert
+
+        params
+      end
+
+      def get_gpg_key_id(ssl_type)
+        options_clone = options.clone
+        options_clone["option_gpg_key_name"] = self.send("option_#{ssl_type}")
+        resolver.gpg_key_id(resolver.scoped_options("gpg_key", options_clone))
+      end
     end
 
     class UpdateCommand < HammerCLIKatello::UpdateCommand

--- a/test/functional/repository/create_test.rb
+++ b/test/functional/repository/create_test.rb
@@ -1,0 +1,51 @@
+require_relative '../test_helper'
+
+describe "create repository" do
+  let(:org_id) { 1 }
+  let(:product_id) { 2 }
+  let(:name) { "repo1" }
+  let(:content_type) { "yum" }
+
+  it 'with basic options' do
+    api_expects(:repositories, :create)
+      .with_params(
+        name: name,
+        product_id: product_id,
+        content_type: content_type)
+
+    command = %W(repository create --organization-id #{org_id} --product-id #{product_id}
+                 --content-type #{content_type} --name #{name})
+
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+
+  it 'with ssl options by name' do
+    def stub_gpg_key(gpg_key_name)
+      gpg_key_index = api_expects(:gpg_keys, :index)
+                      .with_params(
+                        name: gpg_key_name.to_s,
+                        organization_id: 1,
+                        per_page: 1000,
+                        page: 1)
+      gpg_response = File.join(File.dirname(__FILE__), 'data', "#{gpg_key_name}.json")
+      gpg_key_index.returns(JSON.parse(File.read(gpg_response)))
+    end
+
+    api_expects(:repositories, :create)
+      .with_params(
+        name: name,
+        product_id: product_id,
+        ssl_ca_cert_id: 1,
+        ssl_client_cert_id: 2,
+        ssl_client_key_id: 3,
+        content_type: content_type)
+
+    %w(test_cert test_key test_ca).each { |cred| stub_gpg_key(cred) }
+
+    command = %W(repository create --organization-id #{org_id} --product-id #{product_id}
+                 --content-type #{content_type} --name #{name} --ssl-client-cert test_cert
+                 --ssl-client-key test_key --ssl-ca-cert test_ca)
+
+    assert_equal(0, run_cmd(command).exit_code)
+  end
+end

--- a/test/functional/repository/data/test_ca.json
+++ b/test/functional/repository/data/test_ca.json
@@ -1,0 +1,43 @@
+{
+  "name":"test_ca",
+  "content_type":"cert",
+  "content":"hi",
+  "id":1,
+  "organization_id":1,
+  "organization":{
+     "name":"org2",
+     "label":"org2",
+     "id":1
+  },
+  "created_at":"2020-01-28 09:30:54 -0500",
+  "updated_at":"2020-01-28 09:30:54 -0500",
+  "gpg_key_products":[
+
+  ],
+  "gpg_key_repos":[
+
+  ],
+  "ssl_ca_products":[
+
+  ],
+  "ssl_ca_root_repos":[
+
+  ],
+  "ssl_client_products":[
+
+  ],
+  "ssl_client_root_repos":[
+
+  ],
+  "ssl_key_products":[
+
+  ],
+  "ssl_key_root_repos":[
+
+  ],
+  "permissions":{
+     "view_content_credenials":true,
+     "edit_content_credenials":true,
+     "destroy_content_credenials":true
+  }
+}

--- a/test/functional/repository/data/test_cert.json
+++ b/test/functional/repository/data/test_cert.json
@@ -1,0 +1,43 @@
+{ 
+  "name":"test_cert",
+  "content_type":"cert",
+  "content":"hi",
+  "id":2,
+  "organization_id":1,
+  "organization":{ 
+     "name":"org2",
+     "label":"org2",
+     "id":1
+  },
+  "created_at":"2020-01-28 09:30:54 -0500",
+  "updated_at":"2020-01-28 09:30:54 -0500",
+  "gpg_key_products":[ 
+
+  ],
+  "gpg_key_repos":[ 
+
+  ],
+  "ssl_ca_products":[ 
+
+  ],
+  "ssl_ca_root_repos":[ 
+
+  ],
+  "ssl_client_products":[ 
+
+  ],
+  "ssl_client_root_repos":[ 
+
+  ],
+  "ssl_key_products":[ 
+
+  ],
+  "ssl_key_root_repos":[ 
+
+  ],
+  "permissions":{ 
+     "view_content_credenials":true,
+     "edit_content_credenials":true,
+     "destroy_content_credenials":true
+  }
+}

--- a/test/functional/repository/data/test_key.json
+++ b/test/functional/repository/data/test_key.json
@@ -1,0 +1,43 @@
+{
+  "name":"test_key",
+  "content_type":"cert",
+  "content":"hi again",
+  "id":3,
+  "organization_id":1,
+  "organization":{
+     "name":"org2",
+     "label":"org2",
+     "id":1
+  },
+  "created_at":"2020-01-28 09:31:05 -0500",
+  "updated_at":"2020-01-28 09:31:05 -0500",
+  "gpg_key_products":[
+
+  ],
+  "gpg_key_repos":[
+
+  ],
+  "ssl_ca_products":[
+
+  ],
+  "ssl_ca_root_repos":[
+
+  ],
+  "ssl_client_products":[
+
+  ],
+  "ssl_client_root_repos":[
+
+  ],
+  "ssl_key_products":[
+
+  ],
+  "ssl_key_root_repos":[
+
+  ],
+  "permissions":{
+     "view_content_credenials":true,
+     "edit_content_credenials":true,
+     "destroy_content_credenials":true
+  }
+}


### PR DESCRIPTION
This adds the ability to create a repository with a content credential names, not just ids

For example:

hammer repository create --product-id 3 --name my_repo --url https://example.com/myawesomerepo --content-type yum --ssl-client-key-name "my product key" --ssl-client-cert-name "my product cert" --ssl-ca-cert-name "my ca"