### PR TITLE
Add aggregated product sync status

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -33,8 +33,10 @@ module HammerCLIKatello
         field :label, _("Label")
         field :description, _("Description")
 
+        field :sync_state_aggregated, _("Sync State (all)")
+
         from :sync_status do
-          field :state, _("Sync State")
+          field :state, _("Sync State (last)")
         end
 
         field :sync_plan_id, _("Sync Plan ID")


### PR DESCRIPTION
depends on https://github.com/Katello/katello/pull/8536, therefore opening it as draft.

This adds the product sync-status based on the **"worst"** sync-result of any repository's latest sync-tasks.

Currently only the sync state of the **last** sync-task  of any repository's latest sync-tasks is returned.