### PR TITLE
Fixes #28908 - Add pulp3 dep warning to repo create

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -222,7 +222,16 @@ module HammerCLIKatello
         params["ssl_client_key_id"] ||= get_gpg_key_id("ssl_client_key") if option_ssl_client_key
         params["ssl_ca_cert_id"] ||= get_gpg_key_id("ssl_ca_cert") if option_ssl_ca_cert
 
+        dep_warning
+
         params
+      end
+
+      def dep_warning
+        content = options.clone
+        if content['option_content_type'] == 'puppet' || content['option_content_type'] == 'ostree'
+          print_message _('Puppet and OSTree will no longer be supported in Katello 3.16')
+        end
       end
 
       def get_gpg_key_id(ssl_type)

--- a/test/functional/repository/create_test.rb
+++ b/test/functional/repository/create_test.rb
@@ -48,4 +48,36 @@ describe "create repository" do
 
     assert_equal(0, run_cmd(command).exit_code)
   end
+
+  it 'shows deprecation warning on puppet content type' do
+    dep_warning = "Puppet and OSTree will no longer be supported in Katello 3.16\nRepository created.\n" # rubocop:disable LineLength
+
+    api_expects(:repositories, :create)
+      .with_params(
+        name: name,
+        product_id: product_id,
+        content_type: "puppet")
+
+    result = run_cmd(%w(repository create --organization-id 1 --product-id 2
+                        --content-type puppet --name repo1))
+
+    assert_equal(dep_warning, result.out)
+    assert_equal(HammerCLI::EX_OK, result.exit_code)
+  end
+
+  it 'shows deprecation warning on ostree content type' do
+    dep_warning = "Puppet and OSTree will no longer be supported in Katello 3.16\nRepository created.\n" # rubocop:disable LineLength
+
+    api_expects(:repositories, :create)
+      .with_params(
+        name: name,
+        product_id: product_id,
+        content_type: "ostree")
+
+    result = run_cmd(%w(repository create --organization-id 1 --product-id 2
+                        --content-type ostree --name repo1))
+
+    assert_equal(dep_warning, result.out)
+    assert_equal(HammerCLI::EX_OK, result.exit_code)
+  end
 end


### PR DESCRIPTION
With PR:

```bash
hammer repository create --name food --content-type puppet --product-id 1
Puppet and OSTree will no longer be supported in Katello 3.16
Repository created.

hammer repository create --name food1 --content-type ostree --product-id 1 --url 'http://foo.example.com'
Puppet and OSTree will no longer be supported in Katello 3.16
Repository created.
```