### PR TITLE
Fixes #29884 - Add ability to list traces by host

### DIFF
--- a/lib/hammer_cli_katello/host.rb
+++ b/lib/hammer_cli_katello/host.rb
@@ -4,6 +4,7 @@ require 'hammer_cli_katello/host_errata'
 require 'hammer_cli_katello/host_subscription'
 require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_package_group'
+require 'hammer_cli_katello/host_traces'
 
 module HammerCLIKatello
   HammerCLIForeman::Host.subcommand "errata",
@@ -21,4 +22,8 @@ module HammerCLIKatello
   HammerCLIForeman::Host.subcommand "subscription",
                                     HammerCLIKatello::HostSubscription.desc,
                                     HammerCLIKatello::HostSubscription
+
+  HammerCLIForeman::Host.subcommand "traces",
+                                    HammerCLIKatello::HostTraces.desc,
+                                    HammerCLIKatello::HostTraces
 end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -5,6 +5,7 @@ require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_package_group'
 require 'hammer_cli_katello/host_kickstart_repository_options'
 require 'hammer_cli_katello/host_content_source_options'
+require 'hammer_cli_katello/host_traces'
 
 module HammerCLIKatello
   module HostExtensions
@@ -31,6 +32,7 @@ module HammerCLIKatello
             field :enhancement, _("Enhancement"), nil, :sets => ['ALL']
           end
         end
+        field :traces_status_label, _('Trace Status')
       end
     end
 
@@ -90,6 +92,8 @@ module HammerCLIKatello
             end
           end
         end
+
+        field :traces_status_label, _('Trace Status')
 
         collection :host_collections, _('Host Collections') do
           field :id, _('Id')

--- a/lib/hammer_cli_katello/host_traces.rb
+++ b/lib/hammer_cli_katello/host_traces.rb
@@ -1,0 +1,19 @@
+module HammerCLIKatello
+  class HostTraces < HammerCLIKatello::Command
+    desc "List traces on your hosts"
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      resource :host_tracer, :index
+      command_name "list"
+
+      output do
+        field :id, _("Trace ID")
+        field :application, _("Application")
+        field :helper, _("Helper")
+        field :app_type, _("Type")
+      end
+      build_options
+    end
+    autoload_subcommands
+  end
+end

--- a/test/functional/host/extensions/data/host.json
+++ b/test/functional/host/extensions/data/host.json
@@ -100,6 +100,7 @@
       "applicable_package_count": 5,
       "upgradable_package_count": 4
    },
+   "traces_status_label":"Updated",
    "subscription_facet_attributes":{
       "id":2,
       "uuid":"179834bf-779a-457f-a1fa-b06ae0acb21a",

--- a/test/functional/host/extensions/data/host_list.json
+++ b/test/functional/host/extensions/data/host_list.json
@@ -74,6 +74,8 @@
          "errata_status_label":"Could not calculate errata status, ensure host is registered and katello-agent is installed",
          "subscription_status":0,
          "subscription_status_label":"Fully entitled",
+         "traces_status":0,
+         "traces_status_label":"updated",
          "name":"robot.example.com",
          "id":1,
          "hostgroup_name":null,

--- a/test/functional/host/extensions/info_test.rb
+++ b/test/functional/host/extensions/info_test.rb
@@ -27,7 +27,8 @@ describe 'host info' do
                        ['Upgradable Packages', '4'],
                        ['Purpose Usage', 'Production'],
                        ['Purpose Role', 'Role'],
-                       ['Purpose Addons', 'Test Addon1, Test Addon2']]
+                       ['Purpose Addons', 'Test Addon1, Test Addon2'],
+                       ['Trace Status', 'Updated']]
     expected_results = expected_fields.map { |field| success_result(FieldMatcher.new(*field)) }
     expected_results.each { |expected|  assert_cmd(expected, result) }
   end

--- a/test/functional/host/extensions/list_test.rb
+++ b/test/functional/host/extensions/list_test.rb
@@ -13,8 +13,8 @@ describe 'host list' do
 
     result = run_cmd(@cmd)
 
-    fields = ['CONTENT VIEW', 'LIFECYCLE ENVIRONMENT']
-    values = ['Default Organization View', 'Library']
+    fields = ['CONTENT VIEW', 'LIFECYCLE ENVIRONMENT', 'TRACE STATUS']
+    values = ['Default Organization View', 'Library', 'updated']
     expected_result = success_result(IndexMatcher.new([fields, values]))
     assert_cmd(expected_result, result)
   end

--- a/test/functional/host/traces/list_test.rb
+++ b/test/functional/host/traces/list_test.rb
@@ -1,0 +1,37 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe 'host trace listing' do
+  before do
+    @cmd = %w(host traces list)
+  end
+
+  let(:host_id) { 2 }
+  let(:empty_response) do
+    {
+      "total" => 0,
+      "subtotal" => 0,
+      "page" => "1",
+      "per_page" => "1000",
+      "error" => nil,
+      "search" => nil,
+      "sort" => {
+        "by" => nil,
+        "order" => nil
+      },
+      "results" => []
+    }
+  end
+
+  it 'allows listing by host' do
+    params = ["--host-id=#{host_id}"]
+    ex = api_expects(:host_tracer, :index, 'host traces list')
+
+    ex.returns(empty_response)
+    expected_result = success_result("---------|-------------|--------|-----
+TRACE ID | APPLICATION | HELPER | TYPE
+---------|-------------|--------|-----
+")
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+end


### PR DESCRIPTION
Output with PR:

```bash
[vagrant@centos7-hammer-devel ~]$ hammer host list
---|----------------------------------|------------------|------------|-----------------|-------------------|---------------|---------------------------|-----------------------|----------------
ID | NAME                             | OPERATING SYSTEM | HOST GROUP | IP              | MAC               | GLOBAL STATUS | CONTENT VIEW              | LIFECYCLE ENVIRONMENT | TRACE STATUS   
---|----------------------------------|------------------|------------|-----------------|-------------------|---------------|---------------------------|-----------------------|----------------
1  | centos7.thinkstation.example.com | CentOS 7         |            | 192.168.121.249 | 52:54:00:00:85:7f | Error         | Default Organization View | Library               | Reboot required
---|----------------------------------|------------------|------------|-----------------|-------------------|---------------|---------------------------|-----------------------|----------------
```
```bash
[vagrant@centos7-hammer-devel ~]$ hammer host info --id 1
Id:                       1
Name:                     centos7.thinkstation.example.com
Organization:             Default Organization
Location:                 Default Location
Cert name:                centos7.thinkstation.example.com
Managed:                  no
Installed at:             
Last report:              
Uptime (seconds):         329570
Status:                   
    Global Status: Error
Network:                  
    IPv4 address: 192.168.121.249
    MAC:          52:54:00:00:85:7f
Network interfaces:       
 1) Id:           1
    Identifier:   eth0
    Type:         interface (primary, provision)
    MAC address:  52:54:00:00:85:7f
    IPv4 address: 192.168.121.249
    FQDN:         centos7.thinkstation.example.com
Operating system:         
    Architecture:           x86_64
    Operating System:       CentOS 7
    Build:                  no
    Custom partition table:
Subscription Information: 
    UUID:            f3a4de5f-0ff3-40b9-828f-ee1fb3ef6337
    Last Checkin:    2020-05-15 21:29:34 UTC
    Release Version: 
    Autoheal:        true
    Registered To:   centos7-katello-devel-stable.example.com
    Registered At:   2020-05-15 21:25:15 UTC
    System Purpose:  
        Service Level:  
        Purpose Usage:  
        Purpose Role:   
        Purpose Addons:
Trace Status:             Reboot required
Host Collections:
```