### PR TITLE
Fixes #30735 - Add resolve traces command to Hammer

### DIFF
--- a/lib/hammer_cli_katello/host_traces.rb
+++ b/lib/hammer_cli_katello/host_traces.rb
@@ -14,6 +14,23 @@ module HammerCLIKatello
       end
       build_options
     end
+
+    class ResolveCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+      resource :host_tracer, :resolve
+      command_name "resolve"
+
+      success_message _("Traces are being resolved with task %{id}.")
+      failure_message _("Could not resolve traces")
+
+      validate_options do
+        option(:option_trace_ids).required
+        option(:option_host_id).required
+      end
+
+      build_options
+    end
+
     autoload_subcommands
   end
 end

--- a/test/functional/host/traces/resolve_test.rb
+++ b/test/functional/host/traces/resolve_test.rb
@@ -1,0 +1,31 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe 'host trace resolve' do
+  include ForemanTaskHelpers
+
+  before do
+    @cmd = %w(host traces resolve)
+  end
+
+  let(:host_id) { '2' }
+  let(:task_id) { '5' }
+  let(:response) do
+    {
+      'id' => task_id,
+      'state' => 'stopped'
+    }
+  end
+
+  it "resolves traces on a host" do
+    trace_ids = [3]
+    params = ["--host-id=#{host_id}", "--trace-ids=#{trace_ids}"]
+
+    ex = api_expects(:host_tracer, :resolve)
+
+    ex.returns(response)
+
+    expect_foreman_task(task_id)
+
+    run_cmd(@cmd + params)
+  end
+end


### PR DESCRIPTION
Requires Katello PR: https://github.com/Katello/katello/pull/8945

Output with patch:

```ruby
[vagrant@hammer ~]$ hammer host traces resolve --trace-ids [299]
[..................................................................................................................................................................................................................................................................................] [100%]1 task(s), 1 success, 0 fail
```