### PR TITLE
Remove redundant text

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -53,8 +53,7 @@ module HammerCLIKatello
                                         )
 
   HammerCLI::MainCommand.lazy_subcommand("content-credentials",
-                                         _("Manipulate content credentials (i.e. GPG Keys)' \
-                                          'on the server"),
+                                         _("Manipulate content credentials on the server"),
                                          'HammerCLIKatello::ContentCredentialCommand',
                                          'hammer_cli_katello/content_credential'
                                         )


### PR DESCRIPTION
Hello

I came here to fix the formatting; stray back tics in help output:

`Manipulate content credentials (i.e. GPG Keys)' 'on the server`

but as `i.e. GPG` is incorrect, because  content-credentials is more than just GPG keys (`e.g. GPG` would be OK), I thought to just remove it.

Thank you