### PR TITLE
Fixes #31133 - Add Pulp 3 status to ping command

### DIFF
--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -36,15 +36,22 @@ module HammerCLIKatello
           end
         end
 
-        label "pulp" do
+        label "pulp", :hide_blank => true do
           from "pulp" do
-            field "status", _("Status")
-            field "_response", _("Server Response")
+            field "status", _("Status"), Fields::Field, :hide_blank => true
+            field "_response", _("Server Response"), Fields::Field, :hide_blank => true
           end
         end
 
         label "pulp_auth", :hide_blank => true do
           from "pulp_auth" do
+            field "status", _("Status"), Fields::Field, :hide_blank => true
+            field "_response", _("Server Response"), Fields::Field, :hide_blank => true
+          end
+        end
+
+        label "pulp3", :hide_blank => true do
+          from "pulp3" do
             field "status", _("Status"), Fields::Field, :hide_blank => true
             field "_response", _("Server Response"), Fields::Field, :hide_blank => true
           end

--- a/test/functional/ping_test.rb
+++ b/test/functional/ping_test.rb
@@ -12,7 +12,8 @@ describe 'ping' do
         'candlepin_auth' => {'status' => 'ok', 'duration_ms' => '34'},
         'katello_events' => {'status' => 'ok', 'message' => '0 messages', 'duration_ms' => '34'},
         'pulp' => {'status' => 'ok', 'duration_ms' => '34'},
-        'pulp_auth' => {'status' => 'ok', 'duration_ms' => '34'}
+        'pulp_auth' => {'status' => 'ok', 'duration_ms' => '34'},
+        'pulp3' => {'status' => 'ok', 'duration_ms' => '34'}
       }
     )
 


### PR DESCRIPTION
New output:

```shell
database:         
    Status:          ok
    Server Response: Duration: 0ms
candlepin:        
    Status:          ok
    Server Response: Duration: 57ms
candlepin_events: 
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 0ms
candlepin_auth:   
    Status:          ok
    Server Response: Duration: 32ms
katello_events:   
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 1ms
pulp:             
    Status:          ok
    Server Response: Duration: 508ms
pulp_auth:        
    Status:          ok
    Server Response: Duration: 96ms
pulp3:            
    Status:          ok
    Server Response: Duration: 83ms
foreman_tasks:    
    Status:          ok
    Server Response: Duration: 5ms
```