### PR TITLE
Refs #31333 - Add assert single commit action

### DIFF
--- a/.github/workflows/single-commit.yml
+++ b/.github/workflows/single-commit.yml
@@ -1,0 +1,20 @@
+name: Assert Single Commit (non-blocking)
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 30
+    - name: Checkout master
+      run: git fetch origin master
+    - name: create local master branch
+      run: git branch master origin/master
+    - name: Commit Count Check
+      run: test `git log  --oneline --no-merges HEAD ^master   | wc -l ` = 1
+    runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a non-blocking check to assert a single commit like we have in Katello:

https://github.com/Katello/katello/blob/master/.github/workflows/pull_request.yml

Screenshot of it working:

https://nimbusweb.me/s/share/4938240/abcdg9p85tb43fs35vfm