### PR TITLE
Fixes #31443 - Add 'complete' to content-export

### DIFF
--- a/lib/hammer_cli_katello/content_export.rb
+++ b/lib/hammer_cli_katello/content_export.rb
@@ -1,26 +1,10 @@
+require 'hammer_cli_katello/content_export_complete'
 require 'hammer_cli_katello/content_export_incremental'
-require 'hammer_cli_katello/content_export_helper'
 
 module HammerCLIKatello
   class ContentExport < HammerCLIKatello::Command
     desc "Prepare content for export to a disconnected Katello"
     resource :content_exports
-
-    class VersionCommand < HammerCLIKatello::SingleResourceCommand
-      desc _('Performs a full export a content view version')
-      command_name "version"
-
-      include HammerCLIForemanTasks::Async
-      include ContentExportHelper
-    end
-
-    class LibraryCommand < HammerCLIKatello::SingleResourceCommand
-      desc _("Performs a full export of the organization's library environment")
-      command_name "library"
-
-      include HammerCLIForemanTasks::Async
-      include ContentExportHelper
-    end
 
     class ListCommand < HammerCLIKatello::ListCommand
       desc "View content view export histories"
@@ -38,6 +22,10 @@ module HammerCLIKatello
     end
 
     autoload_subcommands
+
+    subcommand HammerCLIKatello::ContentExportComplete.command_name,
+               HammerCLIKatello::ContentExportComplete.desc,
+               HammerCLIKatello::ContentExportComplete
 
     subcommand HammerCLIKatello::ContentExportIncremental.command_name,
                HammerCLIKatello::ContentExportIncremental.desc,

--- a/lib/hammer_cli_katello/content_export_complete.rb
+++ b/lib/hammer_cli_katello/content_export_complete.rb
@@ -1,11 +1,11 @@
 module HammerCLIKatello
-  class ContentExportIncremental < HammerCLIKatello::Command
-    desc "Prepare content for an incremental export to a disconnected Katello"
-    resource :content_export_incrementals
-    command_name 'incremental'
+  class ContentExportComplete < HammerCLIKatello::Command
+    desc "Prepare content for a full export to a disconnected Katello"
+    resource :content_exports
+    command_name 'complete'
 
     class VersionCommand < HammerCLIKatello::SingleResourceCommand
-      desc _('Performs an incremental export of a content view version')
+      desc _('Performs a full export a content view version')
       command_name "version"
 
       include HammerCLIForemanTasks::Async
@@ -13,7 +13,7 @@ module HammerCLIKatello
     end
 
     class LibraryCommand < HammerCLIKatello::SingleResourceCommand
-      desc _("Performs an incremental export of the organization's library environment")
+      desc _("Performs a full export of the organization's library environment")
       command_name "library"
 
       include HammerCLIForemanTasks::Async

--- a/test/functional/content_export/complete/library_test.rb
+++ b/test/functional/content_export/complete/library_test.rb
@@ -1,13 +1,13 @@
-require_relative '../test_helper'
-require_relative '../organization/organization_helpers'
-require 'hammer_cli_katello/content_export'
+require File.join(File.dirname(__FILE__), '../../../test_helper')
+require_relative '../../organization/organization_helpers'
+require 'hammer_cli_katello/content_export_complete'
 
-describe 'content-export library' do
+describe 'content-export complete library' do
   include ForemanTaskHelpers
   include OrganizationHelpers
 
   before do
-    @cmd = %w(content-export library)
+    @cmd = %w(content-export complete library)
   end
 
   let(:task_id) { '5' }
@@ -59,7 +59,7 @@ describe 'content-export library' do
 
     expect_foreman_task(task_id).at_least_once
 
-    HammerCLIKatello::ContentExport::LibraryCommand.
+    HammerCLIKatello::ContentExportComplete::LibraryCommand.
       any_instance.
       expects(:fetch_export_history).
       returns(export_history)

--- a/test/functional/content_export/complete/version_test.rb
+++ b/test/functional/content_export/complete/version_test.rb
@@ -1,11 +1,11 @@
-require_relative '../test_helper'
-require 'hammer_cli_katello/content_export'
+require File.join(File.dirname(__FILE__), '../../../test_helper')
+require 'hammer_cli_katello/content_export_complete'
 
-describe 'content-export version' do
+describe 'content-export complete version' do
   include ForemanTaskHelpers
 
   before do
-    @cmd = %w(content-export version)
+    @cmd = %w(content-export complete version)
   end
 
   let(:task_id) { '5' }
@@ -60,7 +60,7 @@ describe 'content-export version' do
 
     expect_foreman_task(task_id).at_least_once
 
-    HammerCLIKatello::ContentExport::VersionCommand.
+    HammerCLIKatello::ContentExportComplete::VersionCommand.
       any_instance.
       expects(:fetch_export_history).
       returns(export_history)


### PR DESCRIPTION
Moves the the following hammer commands
"content-export library" => "content-export complete library"
"content-export version" => "content-export complete version"