### PR TITLE
Refs #31453 - Fix fetch_export_history

### DIFF
--- a/lib/hammer_cli_katello/content_export_helper.rb
+++ b/lib/hammer_cli_katello/content_export_helper.rb
@@ -40,7 +40,7 @@ module HammerCLIKatello
     end
 
     def fetch_export_history(export_history_id)
-      resource.call(:index, :id => export_history_id)["results"].first if export_history_id
+      index(:content_exports, :id => export_history_id).first if export_history_id
     end
 
     def fetch_export_history_from_task(task)


### PR DESCRIPTION
This call to `resource.call` was causing errors when running `hammer content-export incremental version`:

```
[DEBUG 2021-01-11T21:16:13 Exception] Using exception handler HammerCLIKatello::ExceptionHandler#handle_general_exception
[ERROR 2021-01-11T21:16:13 Exception] Error: undefined method `[]' for nil:NilClass
[ERROR 2021-01-11T21:16:13 Exception] 

NoMethodError (undefined method `[]' for nil:NilClass):
    /home/vagrant/.gem/ruby/gems/apipie-bindings-0.4.0/lib/apipie_bindings/action.rb:25:in `routes'
    /home/vagrant/.gem/ruby/gems/apipie-bindings-0.4.0/lib/apipie_bindings/action.rb:48:in `find_route'
    /home/vagrant/.gem/ruby/gems/apipie-bindings-0.4.0/lib/apipie_bindings/api.rb:189:in `call_action'
    /home/vagrant/.gem/ruby/gems/apipie-bindings-0.4.0/lib/apipie_bindings/api.rb:185:in `call'
    /home/vagrant/.gem/ruby/gems/apipie-bindings-0.4.0/lib/apipie_bindings/resource.rb:21:in `call'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/content_export_helper.rb:40:in `fetch_export_history'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/content_export_helper.rb:53:in `fetch_export_history_from_task'
    /home/vagrant/hammer-cli-katello/lib/hammer_cli_katello/content_export_helper.rb:15:in `execute'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /home/vagrant/.gem/ruby/gems/hammer_cli-2.3.0/lib/hammer_cli/abstract.rb:77:in `run'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /home/vagrant/.gem/ruby/gems/hammer_cli-2.3.0/lib/hammer_cli/abstract.rb:77:in `run'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /home/vagrant/.gem/ruby/gems/hammer_cli-2.3.0/lib/hammer_cli/abstract.rb:77:in `run'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
    /home/vagrant/.gem/ruby/gems/hammer_cli-2.3.0/lib/hammer_cli/abstract.rb:77:in `run'
    /home/vagrant/.gem/ruby/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
    /home/vagrant/.gem/ruby/gems/hammer_cli-2.3.0/bin/hammer:147:in `<top (required)>'
    /home/vagrant/.gem/ruby/bin/hammer:23:in `load'
    /home/vagrant/.gem/ruby/bin/hammer:23:in `<main>'
```

This addresses the issue