### PR TITLE
Refs #31896 - Show katello_agent status in hammer ping

### DIFF
--- a/lib/hammer_cli_katello/ping.rb
+++ b/lib/hammer_cli_katello/ping.rb
@@ -6,8 +6,23 @@ module HammerCLIKatello
 
     output do
       from "services" do
+        label "katello_agent", hide_blank: true do
+          from "katello_agent" do
+            field "status", _("Status"), Fields::Field, hide_blank: true
+            field "message", _("message"), Fields::Field, hide_blank: true
+            field "_response", _("Server Response"), Fields::Field, hide_blank: true
+          end
+        end
+
         label "candlepin" do
           from "candlepin" do
+            field "status", _("Status")
+            field "_response", _("Server Response")
+          end
+        end
+
+        label "candlepin_auth" do
+          from "candlepin_auth" do
             field "status", _("Status")
             field "_response", _("Server Response")
           end
@@ -17,13 +32,6 @@ module HammerCLIKatello
           from "candlepin_events" do
             field "status", _("Status")
             field "message", _("message")
-            field "_response", _("Server Response")
-          end
-        end
-
-        label "candlepin_auth" do
-          from "candlepin_auth" do
-            field "status", _("Status")
             field "_response", _("Server Response")
           end
         end

--- a/test/functional/ping_test.rb
+++ b/test/functional/ping_test.rb
@@ -1,20 +1,59 @@
 require_relative 'test_helper'
 
 describe 'ping' do
-  it 'does not require authentication' do
-    api_expects(:ping, :index).returns(
+  let(:standard_response_services) do
+    {
+      'katello_agent' =>
+        {'status' => 'ok', 'message' => '0 Processed, 0 Failed', 'duration_ms' => '34'},
+      'foreman_tasks' =>
+        {'status' => 'ok', 'duration_ms' => '34'},
+      'candlepin' => {'status' => 'ok', 'duration_ms' => '34'},
+      'candlepin_events' =>
+        {'status' => 'ok', 'message' => '0 Processed, 0 Failed', 'duration_ms' => '34'},
+      'candlepin_auth' =>
+        {'status' => 'ok', 'duration_ms' => '34'},
+      'katello_events' =>
+        {'status' => 'ok', 'message' => '0 Processed, 0 Failed', 'duration_ms' => '34'},
+      'pulp3' =>
+        {'status' => 'ok', 'duration_ms' => '34'}
+    }
+  end
+  let(:standard_response) do
+    {
       'status' => 'ok',
-      'services' => {
-        'foreman_tasks' => {'status' => 'ok', 'duration_ms' => '34'},
-        'foreman_auth' => {'status' => 'ok', 'duration_ms' => '34'},
-        'candlepin' => {'status' => 'ok', 'duration_ms' => '34'},
-        'candlepin_events' => {'status' => 'ok', 'message' => '0 messages', 'duration_ms' => '34'},
-        'candlepin_auth' => {'status' => 'ok', 'duration_ms' => '34'},
-        'katello_events' => {'status' => 'ok', 'message' => '0 messages', 'duration_ms' => '34'},
-        'pulp3' => {'status' => 'ok', 'duration_ms' => '34'}
-      }
-    )
+      'services' => standard_response_services
+    }
+  end
+  let(:standard_response_keys) do
+    %w(katello_agent foreman_tasks candlepin candlepin_events
+       candlepin_auth katello_events pulp3).sort
+  end
+  let(:hammer_ping) { %w(ping katello) }
 
-    run_cmd(%w(ping katello))
+  it 'does not require authentication' do
+    api_expects(:ping, :index).returns(standard_response)
+
+    run_cmd(hammer_ping)
+  end
+
+  it "includes all keys" do
+    api_expects(:ping, :index).returns(standard_response)
+
+    result = JSON.parse(run_cmd(%w(--output=json ping katello))&.out)&.first&.keys&.sort
+    expected = standard_response_keys
+
+    assert_equal result, expected
+  end
+
+  it "skips katello_agent if not included in API response" do
+    response_without_katello_agent = {
+      'status' => 'ok',
+      'services' => standard_response_services.select { |k, _v| k != 'katello_agent' }
+    }
+    api_expects(:ping, :index).returns(response_without_katello_agent)
+    result = JSON.parse(run_cmd(%w(--output=json ping katello))&.out)&.first&.keys&.sort
+    expected = standard_response_keys.select { |k| k != 'katello_agent' }
+
+    assert_equal result, expected
   end
 end


### PR DESCRIPTION
- [x] show katello_agent status
- [x] write tests

Adds `katello_agent` status to `hammer ping`.  Also, skips the status if the `katello_agent` service is not present.

## To test
1. Note new katello_agent section in hammer ping output:
```
katello_agent:    
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 34ms
candlepin:        
    Status:          ok
    Server Response: Duration: 34ms
candlepin_auth:   
    Status:          ok
    Server Response: Duration: 34ms
candlepin_events: 
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 34ms
katello_events:   
    Status:          ok
    message:         0 Processed, 0 Failed
    Server Response: Duration: 34ms
pulp3:            
    Status:          ok
    Server Response: Duration: 34ms
foreman_tasks:    
    Status:          ok
    Server Response: Duration: 34ms
```
2. In katello, modify https://github.com/Katello/katello/blob/43bb25c49b3a953313dca86f6e4311884b237abb/app/models/katello/ping.rb#L17 to remove `:katello_agent`
3. `hammer ping` should now have no `katello_agent` section.