### PR TITLE
Fixes #32089 - Fail on pulp2 export/import when pulp3 is enabled

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -291,9 +291,7 @@ module HammerCLIKatello
       build_options
 
       def execute
-        validate_pulp3_not_enabled(_(
-          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
-          ))
+        validate_pulp3_not_enabled(fail_msg_export)
         export_dir = options['option_export_dir']
 
         Dir.mkdir(export_dir) unless Dir.exist?(export_dir)
@@ -326,9 +324,7 @@ module HammerCLIKatello
       extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
 
       def request_params
-        validate_pulp3_not_enabled(_(
-          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
-          ))
+        validate_pulp3_not_enabled(fail_msg_export)
         super
       end
     end
@@ -361,9 +357,7 @@ module HammerCLIKatello
         cvv = show(:content_view_versions, 'id' => options['option_id'])
         cv = show(:content_views, 'id' => cvv['content_view_id'])
 
-        validate_pulp3_not_enabled(_(
-          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
-          ))
+        validate_pulp3_not_enabled(fail_msg_export)
 
         composite = cv["composite"]
 
@@ -458,11 +452,17 @@ module HammerCLIKatello
 
       build_options
 
+      def fail_msg_import
+        _("This command is not supported with Pulp 3. Use `hammer content-import` instead.")
+      end
+
+      def fail_msg_export
+        _("This command is not supported with Pulp 3. Use `hammer content-export` instead.")
+      end
+
       # rubocop:disable Metrics/AbcSize
       def execute
-        validate_pulp3_not_enabled(_(
-          "This command is not supported with Pulp 3. Use `hammer content-import` instead."
-          ))
+        validate_pulp3_not_enabled(fail_msg_import)
 
         unless File.exist?(options['option_export_tar'])
           raise _("Export tar #{options['option_export_tar']} does not exist.")

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -452,14 +452,6 @@ module HammerCLIKatello
 
       build_options
 
-      def fail_msg_import
-        _("This command is not supported with Pulp 3. Use `hammer content-import` instead.")
-      end
-
-      def fail_msg_export
-        _("This command is not supported with Pulp 3. Use `hammer content-export` instead.")
-      end
-
       # rubocop:disable Metrics/AbcSize
       def execute
         validate_pulp3_not_enabled(fail_msg_import)

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -274,6 +274,7 @@ module HammerCLIKatello
     class ExportDefaultCommand < HammerCLIForeman::Command
       include HammerCLIKatello::LocalHelper
       include HammerCLIKatello::ApipieHelper
+      include HammerCLIKatello::CVImportExportHelper
 
       PUBLISHED_REPOS_DIR = "/var/lib/pulp/published/yum/https/repos/".freeze
 
@@ -290,6 +291,9 @@ module HammerCLIKatello
       build_options
 
       def execute
+        validate_pulp3_not_enabled(_(
+          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
+          ))
         export_dir = options['option_export_dir']
 
         Dir.mkdir(export_dir) unless Dir.exist?(export_dir)
@@ -307,6 +311,7 @@ module HammerCLIKatello
     class LegacyExportCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async
       include LifecycleEnvironmentNameMapping
+      include HammerCLIKatello::CVImportExportHelper
       desc _('Export a content view (legacy method)')
 
       action :export
@@ -314,12 +319,18 @@ module HammerCLIKatello
 
       success_message _("Content view is being exported in task %{id}.")
       failure_message _("Could not export the content view")
-
       build_options do |o|
         o.expand(:all).including(:environments, :content_views, :organizations)
       end
 
       extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
+
+      def request_params
+        validate_pulp3_not_enabled(_(
+          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
+          ))
+        super
+      end
     end
 
     class ExportCommand < HammerCLIForeman::Command
@@ -349,6 +360,10 @@ module HammerCLIKatello
       def execute
         cvv = show(:content_view_versions, 'id' => options['option_id'])
         cv = show(:content_views, 'id' => cvv['content_view_id'])
+
+        validate_pulp3_not_enabled(_(
+          "This command is not supported with Pulp 3. Use `hammer content-export` instead."
+          ))
 
         composite = cv["composite"]
 
@@ -445,6 +460,10 @@ module HammerCLIKatello
 
       # rubocop:disable Metrics/AbcSize
       def execute
+        validate_pulp3_not_enabled(_(
+          "This command is not supported with Pulp 3. Use `hammer content-import` instead."
+          ))
+
         unless File.exist?(options['option_export_tar'])
           raise _("Export tar #{options['option_export_tar']} does not exist.")
         end

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -165,14 +165,15 @@ module HammerCLIKatello
 
     def validate_pulp3_not_enabled(failure_message)
       pulp3_enabled = HammerCLIForeman
-        .foreman_api_connection
-        .resource(:content_exports)
-        .call(:api_status)['api_usable']
+                      .foreman_api_connection
+                      .resource(:content_exports)
+                      .call(:api_status)['api_usable']
       if pulp3_enabled
         raise failure_message
       end
     rescue NoMethodError
       # if the api endpoint isn't there, the validation passes
+      true
     end
   end
 end

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -162,5 +162,17 @@ module HammerCLIKatello
       end
       json
     end
+
+    def validate_pulp3_not_enabled(failure_message)
+      pulp3_enabled = HammerCLIForeman
+        .foreman_api_connection
+        .resource(:content_exports)
+        .call(:api_status)['api_usable']
+      if pulp3_enabled
+        raise failure_message
+      end
+    rescue NoMethodError
+      # if the api endpoint isn't there, the validation passes
+    end
   end
 end

--- a/lib/hammer_cli_katello/cv_import_export_helper.rb
+++ b/lib/hammer_cli_katello/cv_import_export_helper.rb
@@ -163,6 +163,14 @@ module HammerCLIKatello
       json
     end
 
+    def fail_msg_import
+      _("This command is not supported with Pulp 3. Use `hammer content-import` instead.")
+    end
+
+    def fail_msg_export
+      _("This command is not supported with Pulp 3. Use `hammer content-export` instead.")
+    end
+
     def validate_pulp3_not_enabled(failure_message)
       pulp3_enabled = HammerCLIForeman
                       .foreman_api_connection

--- a/test/functional/content_view/version/cv_import_export_helper_test.rb
+++ b/test/functional/content_view/version/cv_import_export_helper_test.rb
@@ -1,0 +1,20 @@
+require_relative '../../test_helper'
+describe 'CVImportExportHelper' do
+  describe 'validate_pulp3_not_enabled' do
+    include HammerCLIKatello::CVImportExportHelper
+    it 'returns true when the api endpoint does not return a value' do
+      api_expects(:content_exports, :api_status)
+      assert_equal true, validate_pulp3_not_enabled('fail_msg')
+    end
+
+    it 'raises error when the api reports Pulp 3 is enabled' do
+      api_expects(:content_exports, :api_status).returns('api_usable' => true)
+      assert_raises(RuntimeError, 'fail msg') { validate_pulp3_not_enabled('fail msg') }
+    end
+
+    it 'returns nil when the api reports Pulp 3 is not enabled' do
+      api_expects(:content_exports, :api_status).returns('api_usable' => false)
+      assert_equal nil, validate_pulp3_not_enabled('fail_msg')
+    end
+  end
+end

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -8,8 +8,10 @@ describe 'content-view version export' do
   end
 
   it "performs export" do
-    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ExportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--id=5',
       '--export-dir=/tmp/exports'
@@ -67,8 +69,10 @@ describe 'content-view version export' do
   end
 
   it "performs composite export" do
-    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ExportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--id=999',
       '--export-dir=/tmp/exports'
@@ -105,8 +109,10 @@ describe 'content-view version export' do
   end
 
   it "fails export if content view version has no repository" do
-    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ExportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--id=5',
       '--export-dir=/tmp/exports'

--- a/test/functional/content_view/version/export_test.rb
+++ b/test/functional/content_view/version/export_test.rb
@@ -8,6 +8,8 @@ describe 'content-view version export' do
   end
 
   it "performs export" do
+    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--id=5',
       '--export-dir=/tmp/exports'
@@ -65,6 +67,8 @@ describe 'content-view version export' do
   end
 
   it "performs composite export" do
+    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--id=999',
       '--export-dir=/tmp/exports'
@@ -101,6 +105,8 @@ describe 'content-view version export' do
   end
 
   it "fails export if content view version has no repository" do
+    HammerCLIKatello::ContentViewVersion::ExportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--id=5',
       '--export-dir=/tmp/exports'

--- a/test/functional/content_view/version/import_test.rb
+++ b/test/functional/content_view/version/import_test.rb
@@ -8,6 +8,8 @@ describe 'content-view version import' do
   end
 
   it "performs import" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -75,6 +77,8 @@ describe 'content-view version import' do
   end
 
   it "performs composite import" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-999.tar',
       '--organization-id=1'
@@ -135,6 +139,8 @@ describe 'content-view version import' do
   end
 
   it "performs composite import, component not found" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-999.tar',
       '--organization-id=1'
@@ -184,6 +190,8 @@ describe 'content-view version import' do
   end
 
   it "fails import if cv has not been created" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -210,6 +218,8 @@ describe 'content-view version import' do
   end
 
   it "fails import if repo is set to mirror-on-sync" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -244,6 +254,8 @@ describe 'content-view version import' do
   end
 
   it "fails import if cv version already exists" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -278,6 +290,8 @@ describe 'content-view version import' do
   end
 
   it "fails import if any repository does not exist" do
+    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
+      .expects(:validate_pulp3_not_enabled).returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'

--- a/test/functional/content_view/version/import_test.rb
+++ b/test/functional/content_view/version/import_test.rb
@@ -8,8 +8,10 @@ describe 'content-view version import' do
   end
 
   it "performs import" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -77,8 +79,10 @@ describe 'content-view version import' do
   end
 
   it "performs composite import" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-999.tar',
       '--organization-id=1'
@@ -139,8 +143,10 @@ describe 'content-view version import' do
   end
 
   it "performs composite import, component not found" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-999.tar',
       '--organization-id=1'
@@ -190,8 +196,10 @@ describe 'content-view version import' do
   end
 
   it "fails import if cv has not been created" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -218,8 +226,10 @@ describe 'content-view version import' do
   end
 
   it "fails import if repo is set to mirror-on-sync" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -254,8 +264,10 @@ describe 'content-view version import' do
   end
 
   it "fails import if cv version already exists" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'
@@ -290,8 +302,10 @@ describe 'content-view version import' do
   end
 
   it "fails import if any repository does not exist" do
-    HammerCLIKatello::ContentViewVersion::ImportCommand.any_instance
-      .expects(:validate_pulp3_not_enabled).returns(true)
+    HammerCLIKatello::ContentViewVersion::ImportCommand
+      .any_instance
+      .expects(:validate_pulp3_not_enabled)
+      .returns(true)
     params = [
       '--export-tar=/tmp/exports/export-2.tar',
       '--organization-id=1'


### PR DESCRIPTION
Adds a failure message to the following commands when Pulp3 is enabled:
```
hammer content-view version import
hammer content-view version export
hammer content-view version export-default
hammer content-view version export-legacy
```

Only works as long as Katello still has the `/content-exports/api-status` endpoint
