### PR TITLE
Drop hammer_cli_foreman_docker

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -50,7 +50,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hammer_cli_foreman'
   gem.add_dependency 'hammer_cli_foreman_tasks'
-  gem.add_dependency 'hammer_cli_foreman_docker'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'thor'


### PR DESCRIPTION
The foreman_docker plugin has been discontinued and it's Hammer
plugin.