### PR TITLE
Fixes #32102: Drop requirement on hammer_cli_bootdisk

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -50,7 +50,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hammer_cli_foreman'
   gem.add_dependency 'hammer_cli_foreman_tasks'
-  gem.add_dependency 'hammer_cli_foreman_bootdisk'
   gem.add_dependency 'hammer_cli_foreman_docker'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
There is no code requirements on bootdisk, and while this functionality
might be useful to a Katello user, dropping this can loosen coupling
to other plugins and give Katello more flexibility.