### PR TITLE
Fixes #32129 - Fix legacy import when importing 20+ repos

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -494,7 +494,8 @@ module HammerCLIKatello
           library_repos = index(
             :repositories,
             'organization_id' => organization_id,
-            'library' => true
+            'library' => true,
+            'label' => repo['label']
           )
 
           library_repo = library_repos.select do |candidate_repo|


### PR DESCRIPTION
## To test:

Spin up 2 6.8 Red Hat Satellites

### Export Satellite

* Import manifest

* Set Default Red Hat Repository download policy setting to `immediate`

* Run seed script to enable repos

https://gist.github.com/chris1984/9c41a8432b3d5fd409f6ac35ea6044cd

* Sync repos

* Create content view, add repos and publish

* Export view with `hammer content-view version export --export-dir /var/lib/pulp/katello-export --id <cvv id>

SCP to other satellite in `/var/lib/pulp/katello-export` directory to prevent SELinux issues

### Import Satellite

* Directory to apply patch:

`/opt/theforeman/tfm/root/usr/share/gems/gems/hammer_cli_katello-0.22.2.3/`

* Import manifest

* Set Default Red Hat Repository download policy setting to `immediate`

* Run seed script to enable repos and turn off mirror on sync

https://gist.github.com/chris1984/8165d6149b064a7220244dee59ce2cde

* Create content view with same name and add repos but don't publish

* Run import:
`hammer content-view version import --organization-id 1 --export-tar /var/lib/pulp/katello-export/xxx`

🍻 

Output of testing results:

* Adding back in this line had the import pass without changing the pagination

`'label' => repo['label']`
```bash
[root@dhcp-8-30-248 ~]# hammer -d content-view version import --organization-id 1 --export-tar /var/lib/pulp/katello-export/export-view-1.0.tar
[...............................................................................................................] [100%]
```
Screenshot of CV:

https://nimb.ws/i9xvja

* Testing Default View to make sure we do not regress on anything.
```bash
[root@dhcp-8-30-248 ~]# hammer -d content-view version import --organization-id 1 --export-tar /var/lib/pulp/katello-export/export-Default_Organization_View-1.0.tar
[...............................................................................................................] [100%]
New packages: 1 (29.1 MB).
```
 * Passed
 
* Screenshot of CV page showing no CV:

https://nimb.ws/nZBzId

* Screenshot of repo page showing RPM's in the repos:

https://nimb.ws/nyITjX

* List of repos I used for testing:

```bash
[root@dhcp-8-29-99 ~]# hammer repository list --fields name
----------------------------------------------------------------------------
NAME
----------------------------------------------------------------------------
Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server x86_64
Red Hat Satellite Capsule 6.8 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Maintenance 6 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.3 - Puppet 4 for RHEL 6 Server RPMs x86_64
Red Hat Satellite Tools 6.3 - Puppet 4 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.4 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.5 for RHEL 6 Server RPMs x86_64
Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.5 for RHEL 8 x86_64 RPMs
Red Hat Satellite Tools 6.6 for RHEL 6 Server RPMs x86_64
Red Hat Satellite Tools 6.6 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.6 for RHEL 8 x86_64 RPMs
Red Hat Satellite Tools 6.7 for RHEL 6 Server RPMs x86_64
Red Hat Satellite Tools 6.7 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.7 for RHEL 8 x86_64 RPMs
Red Hat Satellite Tools 6.8 for RHEL 6 Server RPMs x86_64
Red Hat Satellite Tools 6.8 for RHEL 7 Server RPMs x86_64
Red Hat Satellite Tools 6.8 for RHEL 8 x86_64 RPMs
Red Hat Virtualization 4 Tools for RHEL 8 x86_64 RPMs 
Red Hat Virtualization 4 Tools RHEL 7 Server RPMs x86_64
Red Hat Virtualization Manager 4 Tools RHEL 7 Server RPMs x86_64
----------------------------------------------------------------------------
```