### PR TITLE
Fixes #31456 - Hide name on content export/import list/version

### DIFF
--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -28,7 +28,9 @@ module HammerCLIKatello
       :subscription =>          [s_name(_("Subscription name to search by"))],
       :sync_plan =>             [s_name(_("Sync plan name to search by"))],
       :task =>                  [s_name(_("Task name to search by"))],
-      :content_view_version => [s("version", _("Content view version number"))]
+      :content_view_version => [s("version", _("Content view version number"))],
+      :content_export       => [],
+      :content_import       => []
     }.freeze
 
     DEFAULT_SEARCHABLES = [s_name(_("Name to search by"))].freeze


### PR DESCRIPTION
## Output of new help

### content-export list
```bash
[vagrant@hammer ~]$ hammer content-export list -h
Usage:
    hammer content-export <list|index> [OPTIONS]

Options:
 --content-view[-id]                                 Name/Id of associated content view
 --content-view-version[-id]                         Version/Id of associated content view version
 --destination-server DESTINATION_SERVER             Destination Server name
 --fields FIELDS                                     Show specified fields or predefined field sets only. (See below)
                                                     Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
                                                     JSON is acceptable and preferred way for complex parameters
 --full-result FULL_RESULT                           Whether or not to show all results
                                                     One of true/false, yes/no, 1/0.
 --id ID                                             Content view version export history identifier
 --order ORDER                                       Sort field and order, eg. ‘Order DESC’
 --organization[-id|-title|-label]                   Name/Title/Label/Id of associated organization
 --page PAGE                                         Page number, starting at 1
 --per-page PER_PAGE                                 Number of results per page to return
 --search SEARCH                                     Search string
 --type TYPE                                         Export Types
                                                     Possible value(s): 'complete', 'incremental'
 -h, --help                                          Print help
```

### content-export complete version
```bash
[vagrant@hammer ~]$ hammer content-export complete version -h
Usage:
    hammer content-export complete version [OPTIONS]

Options:
 --async                                             Do not wait for the task
 --chunk-size-mb CHUNK_SIZE_MB                       Split the exported content into archives no greater than the specified size in megabytes.
 --content-view[-id]                                 Name/Id of associated content view
 --destination-server DESTINATION_SERVER             Destination Server name
 --fail-on-missing-content                           Fails if any of the repositories belonging to this version are unexportable.
 --id ID                                             Content view version identifier
 --lifecycle-environment[-id]                        Name/Id of associated lifecycle environment
 --organization[-id|-title|-label]                   Name/Title/Label/Id of associated organization
 --version VERSION                                   Filter versions by version number.
 -h, --help                                          Print help
```
### content-import list

```bash
[vagrant@hammer ~]$ hammer content-import list -h
Usage:
    hammer content-import <list|index> [OPTIONS]

Options:
 --content-view[-id]                                 Name/Id of associated content view
 --content-view-version[-id]                         Version/Id of associated content view version
 --fields FIELDS                                     Show specified fields or predefined field sets only. (See below)
                                                     Comma separated list of values. Values containing comma should be quoted or escaped with backslash.
                                                     JSON is acceptable and preferred way for complex parameters
 --full-result FULL_RESULT                           Whether or not to show all results
                                                     One of true/false, yes/no, 1/0.
 --id ID                                             Content view version import history identifier
 --order ORDER                                       Sort field and order, eg. ‘Order DESC’
 --organization[-id|-title|-label]                   Name/Title/Label/Id of associated organization
 --page PAGE                                         Page number, starting at 1
 --per-page PER_PAGE                                 Number of results per page to return
 --search SEARCH                                     Search string
 --type TYPE                                         Import Types
                                                     Possible value(s): 'complete', 'incremental'
 -h, --help                                          Print help
```

