### PR TITLE
Fixes #32157 - Deprecate agent-based commands

### DIFF
--- a/lib/hammer_cli_katello/host_collection_erratum.rb
+++ b/lib/hammer_cli_katello/host_collection_erratum.rb
@@ -15,6 +15,16 @@ module HammerCLIKatello
         :format => HammerCLI::Options::Normalizers::List.new,
         :attribute_name => :content)
 
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_errata_install`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
+
       def content_type
         'errata'
       end

--- a/lib/hammer_cli_katello/host_collection_package.rb
+++ b/lib/hammer_cli_katello/host_collection_package.rb
@@ -23,6 +23,16 @@ module HammerCLIKatello
       desc _("Install packages on content hosts contained within a host collection")
       success_message _("Successfully scheduled installation of package(s).")
       failure_message _("Could not schedule installation of package(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_install`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     class UpdateCommand < HammerCLIKatello::HostCollection::UpdateContentBaseCommand
@@ -30,6 +40,16 @@ module HammerCLIKatello
       desc _("Update packages on content hosts contained within a host collection")
       success_message _("Successfully scheduled update of package(s).")
       failure_message _("Could not schedule update of package(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_update`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     class RemoveCommand < HammerCLIKatello::HostCollection::RemoveContentBaseCommand
@@ -37,6 +57,16 @@ module HammerCLIKatello
       desc _("Remove packages on content hosts contained within a host collection")
       success_message _("Successfully scheduled removal of package(s).")
       failure_message _("Could not schedule removal of package(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_remove`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_katello/host_collection_package_group.rb
+++ b/lib/hammer_cli_katello/host_collection_package_group.rb
@@ -23,6 +23,16 @@ module HammerCLIKatello
       desc _("Install package-groups on content hosts contained within a host collection")
       success_message _("Successfully scheduled installation of package-group(s).")
       failure_message _("Could not schedule installation of package-group(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_group_install`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     class UpdateCommand < HammerCLIKatello::HostCollection::UpdateContentBaseCommand
@@ -30,6 +40,16 @@ module HammerCLIKatello
       desc _("Update package-groups on content hosts contained within a host collection")
       success_message _("Successfully scheduled update of package-groups(s).")
       failure_message _("Could not schedule update of package-group(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_group_update`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     class RemoveCommand < HammerCLIKatello::HostCollection::RemoveContentBaseCommand
@@ -37,6 +57,16 @@ module HammerCLIKatello
       desc _("Remove package-groups on content hosts contained within a host collection")
       success_message _("Successfully scheduled removal of package-groups(s).")
       failure_message _("Could not schedule removal of package-group(s)")
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_group_remove`. Specify the host collection with the --search-query " \
+          "parameter, e.g. `--search-query \"host_collection = MyCollection\"` or " \
+          "`--search-query \"host_collection_id=6\"`."
+        super
+      end
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -12,6 +12,14 @@ module HammerCLIKatello
       failure_message _("Could not apply errata")
 
       build_options
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_errata_install`."
+        super
+      end
     end
 
     class ListCommand < HammerCLIKatello::ListCommand

--- a/lib/hammer_cli_katello/host_package.rb
+++ b/lib/hammer_cli_katello/host_package.rb
@@ -24,6 +24,14 @@ module HammerCLIKatello
       end
 
       build_options :without => [:groups]
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_install`."
+        super
+      end
     end
 
     class UpgradeCommand < HammerCLIKatello::SingleResourceCommand
@@ -34,6 +42,14 @@ module HammerCLIKatello
       failure_message "Could not upgrade packages"
 
       build_options
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_update`."
+        super
+      end
     end
 
     class UpgradeAllCommand < HammerCLIKatello::SingleResourceCommand
@@ -44,6 +60,14 @@ module HammerCLIKatello
       failure_message "Could not upgrade all packages"
 
       build_options
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_update`."
+        super
+      end
     end
 
     class RemoveCommand < HammerCLIKatello::SingleResourceCommand
@@ -58,6 +82,14 @@ module HammerCLIKatello
       end
 
       build_options :without => [:groups]
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_package_remove`."
+        super
+      end
     end
 
     autoload_subcommands

--- a/lib/hammer_cli_katello/host_package_group.rb
+++ b/lib/hammer_cli_katello/host_package_group.rb
@@ -14,6 +14,14 @@ module HammerCLIKatello
       end
 
       build_options :without => [:packages]
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_group_install`."
+        super
+      end
     end
 
     class RemoveCommand < HammerCLIKatello::SingleResourceCommand
@@ -28,6 +36,14 @@ module HammerCLIKatello
       end
 
       build_options :without => [:packages]
+
+      def execute
+        warn "This command uses katello agent and will be removed in favor of remote execution " \
+          "in a future release."
+        warn "The remote execution equivalent is `hammer job-invocation create --feature " \
+          "katello_group_remove`."
+        super
+      end
     end
 
     autoload_subcommands


### PR DESCRIPTION
This PR deprecates all of the hammer commands that use katello agent and gives pointers to the REX equivalents.

hammer host package {install,remove,upgrade,upgrade-all}
hammer host package-group {install,remove}
hammer host errata apply
hammer host-collection erratum install
hammer host-collection package {install,remove,update}
hammer host-collection package-group {install,remove,update}

Let me know if I missed any, and what you think about the wording. I didn't make any attempt to DRY up the messaging since we will be deleting it sooner than later