### PR TITLE
Fixes #32868 - Make --unlimited-hosts a flag so it doesn't require a value

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -52,6 +52,10 @@ module HammerCLIKatello
 
       option "--unlimited-hosts", :flag, "Set hosts max to unlimited"
 
+      validate_options :before, 'IdResolution' do
+        all(:option_unlimited_hosts, :option_max_hosts).rejected
+      end
+
       build_options
     end
 

--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -50,6 +50,8 @@ module HammerCLIKatello
       success_message _("Host collection created.")
       failure_message _("Could not create the host collection")
 
+      option "--unlimited-hosts", :flag, "Set hosts max to unlimited"
+
       build_options
     end
 

--- a/test/functional/host_collection/create_test.rb
+++ b/test/functional/host_collection/create_test.rb
@@ -29,6 +29,17 @@ module HammerCLIKatello
       run_cmd(%w(host-collection create --name hc1 --organization org1))
     end
 
+    it 'allows unlimited-hosts flag with no arguments' do
+      api_expects(:organizations, :index) { |par| par[:search] == "name = \"org1\"" }
+        .returns(index_response([{'id' => 1}]))
+
+      api_expects(:host_collections, :create) do |par|
+        par['unlimited_hosts'] == true
+      end
+
+      run_cmd(%w(host-collection create --name hc1 --organization org1 --unlimited-hosts))
+    end
+
     it 'allows organization label' do
       api_expects(:organizations, :index) { |par| par[:search] == "label = \"org1\"" }
         .returns(index_response([{'id' => 1}]))


### PR DESCRIPTION
Previously:

#### `hammer activation-key create`: 
* takes unlimited-hosts argument
* errors if you pass a value such as `--unlimited-hosts=yes`
* Behaves correctly.

#### `hammer host-collection create`:
* takes unlimited-hosts argument
* errors if you do NOT pass a value
* Behaves incorrectly.

With this patch, `hammer host-collection create` now takes `--unlimited-hosts` as a flag rather than a parameter, meaning that it behaves the same way as `hammer activation-key create`. Thus, hammer's behavior is more consistent.