### PR TITLE
Fixes #33327 - host errata recalculate does not need --async flag

### DIFF
--- a/lib/hammer_cli_katello/host_errata.rb
+++ b/lib/hammer_cli_katello/host_errata.rb
@@ -46,10 +46,9 @@ module HammerCLIKatello
     end
 
     class RecalculateCommand < HammerCLIKatello::SingleResourceCommand
-      include HammerCLIForemanTasks::Async
       resource :host_errata, :applicability
       command_name "recalculate"
-      success_message _("Errata recalculated with task %{id}.")
+      success_message _("Errata recalculation started.")
       failure_message _("Could not recalculate errata")
 
       build_options

--- a/test/functional/host/errata/recalculate_test.rb
+++ b/test/functional/host/errata/recalculate_test.rb
@@ -8,33 +8,19 @@ describe 'recalculate errata' do
   end
 
   let(:host_id) { 1 }
-  let(:task_id) { '5' }
-  let(:response) do
-    {
-      'id' => task_id,
-      'state' => 'stopped'
-    }
-  end
 
   it "recalculates errata for a host" do
     params = ["--host-id=#{host_id}"]
 
     api_expects(:host_errata, :applicability, 'Host errata recalculate')
       .with_params('host_id' => host_id)
-      .returns(response)
+      .returns({})
 
-    expect_foreman_task(task_id)
-
-    run_cmd(@cmd + params)
-  end
-
-  it "applies an errata to a host with async flag" do
-    params = ["--host-id=#{host_id}", "--async"]
-
-    api_expects(:host_errata, :applicability, 'Host errata recalculate')
-      .with_params('host_id' => host_id)
-      .returns(response)
-
-    run_cmd(@cmd + params)
+    expected_result = success_result(
+      'Errata recalculation started.
+'
+    )
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
   end
 end


### PR DESCRIPTION
Hammer host errata recalculate calls `/hosts/:host_id/errata/applicability` which puts a `generate_host_applicability` event into the queue.

Option `--async` is no longer necessary for `/hosts/:host_id/errata/applicability`.

`/hosts/:host_id/errata/applicability` does not return back a [task](https://github.com/Katello/katello/blob/c35f3100fda7fcdd89b34e8324b3e82c4b8b491e/app/controllers/katello/api/v2/host_errata_controller.rb#L77).

**To Test**
- sync https://partha.fedorapeople.org/test-repos/multi-errata/ 
- Point a host to this repo and yum install armadillo-0.2-1 
- hammer host errata recalculate --host-id <host_id>

**Before**
`Error: Please mention appropriate attribute value`
**After**
`Errata recalculated.`