### PR TITLE
Fixes #33792 - update ruby versions in CI, we need 2.5 and 2.7

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,23 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.3, 2.4, 2.5]
+        ruby: ["2.5", "2.7"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
-      with:
-        ruby-version: ${{ matrix.ruby }}
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Add hammer-cli-foreman to local gem file
       run: echo "gem 'hammer_cli_foreman', :git => 'https://github.com/theforeman/hammer-cli-foreman.git'" > Gemfile.local
     - name: Add hammer-cli to local gem file
       run: echo "gem 'hammer_cli', :git => 'https://github.com/theforeman/hammer-cli.git'" >> Gemfile.local
-    - name: Install dependencies
-      run: bundle install
-    - name: Bundle update
-      run: gem update bundler
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Run tests
       run: COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }} bundle exec rake


### PR DESCRIPTION
also let setup-ruby install and cache deps for us