### PR TITLE
Fixes #34433 - Update gpg_key to content_credentials for repo info

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -86,7 +86,7 @@ module HammerCLIKatello
         end
 
         label _("GPG Key") do
-          from :gpg_key do
+          from :content_credential do
             field :id, _("Id"), Fields::Field, :hide_blank => true
             field :name, _("Name"), Fields::Field, :hide_blank => true
           end

--- a/test/functional/repository/info_test.rb
+++ b/test/functional/repository/info_test.rb
@@ -42,6 +42,10 @@ describe "get repository info" do
         'package_group' => 0,
         'erratum' => 1,
         'module_stream' => 0
+      },
+      'content_credential' => {
+        'id' => 1,
+        'name' => 'pizza'
       }
     )
     result = run_cmd(@cmd + params)
@@ -62,6 +66,8 @@ describe "get repository info" do
                        ['Id', '79'],
                        ['Name', 'test'],
                        ['GPG Key', ''],
+                       ['Id', '1'],
+                       ['Name', 'pizza'],
                        ['Sync', ''],
                        ['Status', 'Not Synced'],
                        ['Last Sync Date', '3 minutes'],


### PR DESCRIPTION
Before patch:
```bash
Id:                      10
Name:                    CentOS-Repo
Label:                   CentOS-Repo
Description:             
Organization:            Default Organization
Red Hat Repository:      no
Content Type:            yum
Mirror on Sync:          no
Url:                     http://mirror.centos.org/centos/7/os/x86_64/
Publish Via HTTP:        yes
Published At:            https://centos7-katello-devel.area52.example.com/pulp/content/Default_Organization/Library/custom/CentOS-Product/CentOS-Repo/
Relative Path:           Default_Organization/Library/custom/CentOS-Product/CentOS-Repo
Download Policy:         on_demand
Ignorable Content Units: 
HTTP Proxy:              
    HTTP Proxy Policy: global_default_http_proxy
Product:                 
    Id:   295
    Name: CentOS-Product
GPG Key:
```

After patch:
```bash
Id:                      10
Name:                    CentOS-Repo
Label:                   CentOS-Repo
Description:             
Organization:            Default Organization
Red Hat Repository:      no
Content Type:            yum
Mirror on Sync:          no
Url:                     http://mirror.centos.org/centos/7/os/x86_64/
Publish Via HTTP:        yes
Published At:            https://centos7-katello-devel.area52.example.com/pulp/content/Default_Organization/Library/custom/CentOS-Product/CentOS-Repo/
Relative Path:           Default_Organization/Library/custom/CentOS-Product/CentOS-Repo
Download Policy:         on_demand
Ignorable Content Units: 
HTTP Proxy:              
    HTTP Proxy Policy: global_default_http_proxy
Product:                 
    Id:   295
    Name: CentOS-Product
GPG Key:                 
    Id:   1
    Name: CentOS
```