### PR TITLE
Fixes #34762 - Add repo republish to Hammer

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -567,6 +567,33 @@ module HammerCLIKatello
       end
     end
 
+    class RepublishCommand < HammerCLIKatello::SingleResourceCommand
+      extend RepositoryScopedToProduct
+      include HammerCLIForemanTasks::Async
+      include OrganizationOptions
+
+      validate_repo_name_requires_product_options
+      action :republish
+      command_name "republish"
+      desc _("Forces a republish of the specified repository.")
+
+      success_message _("Repository republished.")
+      failure_message _("Could not republish the repository.")
+
+      validate_options :before, 'IdResolution' do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+      end
+
+      build_options do |o|
+        o.expand.including(:products)
+      end
+    end
+
     class ReclaimSpaceCommand < HammerCLIKatello::SingleResourceCommand
       extend RepositoryScopedToProduct
       include HammerCLIForemanTasks::Async

--- a/test/functional/repository/republish_test.rb
+++ b/test/functional/repository/republish_test.rb
@@ -1,0 +1,37 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require File.join(File.dirname(__FILE__), './repository_helpers')
+require File.join(File.dirname(__FILE__), '../product/product_helpers')
+
+describe 'Republish a repository' do
+  include RepositoryHelpers
+  include ForemanTaskHelpers
+  include ProductHelpers
+
+  before do
+    @cmd = %w(repository republish)
+  end
+
+  let(:repo_id) { 1 }
+  let(:sync_response) do
+    {
+      'id' => repo_id.to_s,
+      'label' => 'Actions::Katello::Repository::MetadataGenerate',
+      'state' => 'planned'
+    }
+  end
+
+  it "republishes a repository" do
+    params = ["--id=#{repo_id}", "--force=true"]
+
+    ex = api_expects(:repositories, :republish, 'Repository republished.') do |par|
+      par['id'] == repo_id && par['force'] == true
+    end
+
+    ex.returns(sync_response)
+
+    expect_foreman_task('3')
+
+    result = run_cmd(@cmd + params)
+    assert_equal(result.exit_code, 0)
+  end
+end


### PR DESCRIPTION
Steps to test:

* Apply patch to your hammer devel box or hammer location
* Try new hammer command out `hammer repository republish --id x --force true"
* See if you see the dynflow task kick off on your katello devel box