### PR TITLE
Refs #34889 - Makes host collection update --unlimited-hosts a flag

### DIFF
--- a/lib/hammer_cli_katello/host_collection.rb
+++ b/lib/hammer_cli_katello/host_collection.rb
@@ -143,6 +143,8 @@ module HammerCLIKatello
       success_message _("Host collection updated.")
       failure_message _("Could not update the the host collection")
 
+      option "--unlimited-hosts", :flag, "Set hosts max to unlimited"
+
       build_options { |o| o.expand(:all).including(:organizations) }
     end
 


### PR DESCRIPTION
This PR changes `unlimited-hosts` to a  flag instead of option in host collection update.

```
$ hammer host-collection info --name=great --organization-id=1 | grep Limit
Limit:       100

$ hammer  host-collection update --name=great --unlimited-hosts --organization-id=1
Host collection updated.

$ hammer host-collection info --name=great --organization-id=1 |grep Limit
Limit:       None

```

Works with https://github.com/Katello/katello/pull/10100