### PR TITLE
Fixes #35032 - Add content-view override to ak info command

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -54,10 +54,10 @@ module HammerCLIKatello
       output do
         field :name, _("Name")
         field :id, _("Id")
-        field :description, _("Description")
+        field :description, _("Description"), Fields::Field, :hide_blank => true
         field :format_limit, _("Host Limit")
         field :auto_attach, _("Auto Attach")
-        field :release_version, _("Release Version")
+        field :release_version, _("Release Version"), Fields::Field, :hide_blank => true
 
         from :environment do
           field :name, _("Lifecycle Environment")
@@ -69,6 +69,12 @@ module HammerCLIKatello
         collection :host_collections, _("Host Collections") do
           field :id, _("Id")
           field :name, _("Name")
+        end
+
+        collection :content_overrides, _("Content Overrides") do
+          field :content_label, _("Content Label")
+          field :name, _("Name")
+          field :value, _("Value")
         end
 
         label _("System Purpose") do


### PR DESCRIPTION
* Apply patch to hammer devel box or in the hammer directory on your katello server
* In the UI create an activation key, attach a subscription, and disable or enable (override) a repo
* Run the command from hammer `hammer activation-key info --id 1`
* Verify it looks like the output below:

```
Name:                  foo
Id:                    1
Host Limit:            Unlimited
Auto Attach:           true
Lifecycle Environment: Library
Content View:          Default Organization View
Host Collections:

Content Overrides:
 1) Content Label: Default_Organization_Custom_Zoo
    Name:          enabled
    Value:         0
System Purpose:
    Service Level:
    Purpose Usage:
    Purpose Role:
    Purpose Addons:
```