### PR TITLE
Fixes #34337 - CRUD simplified ACSs via hammer

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -43,7 +43,7 @@ module HammerCLIKatello
                                           'hammer_cli_katello/organization'
                                          )
 
-  HammerCLI::MainCommand.lazy_subcommand!("alternate-content-sources", _("Manipulate alternate content sources"), # rubocop:disable LineLength
+  HammerCLI::MainCommand.lazy_subcommand!("alternate-content-source", _("Manipulate alternate content sources"), # rubocop:disable LineLength
                                          'HammerCLIKatello::AcsCommand',
                                          'hammer_cli_katello/acs'
                                          )

--- a/lib/hammer_cli_katello/acs.rb
+++ b/lib/hammer_cli_katello/acs.rb
@@ -34,14 +34,17 @@ module HammerCLIKatello
           field nil, _('')
         end
 
+        collection :products, _('Products') do
+          field :id, _('Id')
+          field :organization_id, _('Organization ID')
+          field :name, _('Name')
+          field :label, _('Label')
+        end
+
         collection :smart_proxies, _('Smart proxies') do
           field :id, _('Id')
           field :name, _('Name')
           field :url, _('URL')
-          field :created_at, _('Created at')
-          field :updated_at, _('Updated at')
-          field :expired_logs, _('Expired logs')
-          field :puppet_path, _('Puppet path'), Fields::Field, :hide_blank => true
           field :download_policy, _('Download policy')
         end
       end

--- a/test/functional/acs/create_test.rb
+++ b/test/functional/acs/create_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), '../test_helper')
 
 describe 'create content-credentials' do
   before do
-    @cmd = %w(alternate-content-sources create)
+    @cmd = %w(alternate-content-source create)
   end
 
   let(:name) { 'pizza' }

--- a/test/functional/acs/delete_test.rb
+++ b/test/functional/acs/delete_test.rb
@@ -7,7 +7,7 @@ describe 'delete an acs' do
     api_expects(:alternate_content_sources, :destroy, 'delete acs').
       with_params('id' => id)
 
-    command = %W(alternate-content-sources delete --id #{id})
+    command = %W(alternate-content-source delete --id #{id})
     assert_equal(0, run_cmd(command).exit_code)
   end
 end

--- a/test/functional/acs/info_test.rb
+++ b/test/functional/acs/info_test.rb
@@ -3,7 +3,7 @@ require 'hammer_cli_katello/associating_commands'
 
 describe 'get acs info' do
   before do
-    @cmd = %w(alternate-content-sources info)
+    @cmd = %w(alternate-content-source info)
   end
 
   it 'shows acs info by id' do
@@ -14,20 +14,17 @@ describe 'get acs info' do
       'name' => 'Pizza ACS',
       'label' => 'Pizza ACS',
       'base_url' => 'https://proxy.example.com',
-      'alternate_content_source_type' => 'custom',
       'content_type' => 'yum',
+      'alternate_content_source_type' => 'custom',
+      'subpaths' => [
+        'test/repo1'
+      ],
       'smart_proxies' => {
         'id' => 1,
         'name' => 'centos7.example.com',
         'url' => 'https://centos7.example.com:9090',
-        'created_at' => '2022-05-09T17:40:21.007Z',
-        'updated_at' => '2022-05-09T17:40:21.007Z',
-        'expired_logs' => 0,
         'download_policy' => 'on_demand'
-      },
-      'subpaths' => [
-        'test/repo1'
-      ]
+      }
     )
     result = run_cmd(@cmd + params)
     # rubocop:disable Style/WordArray
@@ -35,18 +32,60 @@ describe 'get acs info' do
                        ['Name', 'Pizza ACS'],
                        ['Label', 'Pizza ACS'],
                        ['Base URL', 'https://proxy.example.com'],
-                       ['Alternate content source type', 'custom'],
                        ['Content type', 'yum'],
+                       ['Alternate content source type', 'custom'],
+                       ['Subpaths', ''],
+                       ['', 'test/repo1'],
                        ['Smart proxies', ''],
                        ['Id', '1'],
                        ['Name', 'centos7.example.com'],
                        ['URL', 'https://centos7.example.com:9090'],
-                       ['Created at', '2022-05-09T17:40:21.007Z'],
-                       ['Updated at', '2022-05-09T17:40:21.007Z'],
-                       ['Expired logs', '0'],
-                       ['Download policy', 'on_demand'],
-                       ['Subpaths', ''],
-                       ['', 'test/repo1']]
+                       ['Download policy', 'on_demand']]
+
+    # rubocop:enable Style/WordArray
+    expected_results = expected_fields.map { |field| success_result(FieldMatcher.new(*field)) }
+    expected_results.each { |expected|  assert_cmd(expected, result) }
+  end
+
+  it 'shows simplified acs info by id' do
+    params = ['--id=2']
+    ex = api_expects(:alternate_content_sources, :show, 'Get info')
+    ex.returns(
+      'id' => 2,
+      'name' => 'Pizza ACS',
+      'label' => 'Pizza ACS',
+      'content_type' => 'yum',
+      'alternate_content_source_type' => 'simplified',
+      'products' => {
+        'id' => 999,
+        'organization_id' => 9,
+        'name' => 'Buttermilk Biscuits',
+        'label' => 'Buttermilk_Biscuits'
+      },
+      'smart_proxies' => {
+        'id' => 1,
+        'name' => 'centos7.example.com',
+        'url' => 'https://centos7.example.com:9090',
+        'download_policy' => 'on_demand'
+      }
+    )
+    result = run_cmd(@cmd + params)
+    # rubocop:disable Style/WordArray
+    expected_fields = [['ID', '2'],
+                       ['Name', 'Pizza ACS'],
+                       ['Label', 'Pizza ACS'],
+                       ['Content type', 'yum'],
+                       ['Alternate content source type', 'simplified'],
+                       ['Products', ''],
+                       ['Id', '999'],
+                       ['Organization ID', '9'],
+                       ['Name', 'Buttermilk Biscuits'],
+                       ['Label', 'Buttermilk_Biscuits'],
+                       ['Smart proxies', ''],
+                       ['Id', '1'],
+                       ['Name', 'centos7.example.com'],
+                       ['URL', 'https://centos7.example.com:9090'],
+                       ['Download policy', 'on_demand']]
 
     # rubocop:enable Style/WordArray
     expected_results = expected_fields.map { |field| success_result(FieldMatcher.new(*field)) }

--- a/test/functional/acs/list_test.rb
+++ b/test/functional/acs/list_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), '../test_helper')
 
 describe 'listing acs' do
   before do
-    @cmd = %w(alternate-content-sources list)
+    @cmd = %w(alternate-content-source list)
   end
 
   let(:empty_response) do

--- a/test/functional/acs/update_test.rb
+++ b/test/functional/acs/update_test.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), '../test_helper')
 
 describe 'listing acs' do
   before do
-    @cmd = %w(alternate-content-sources update)
+    @cmd = %w(alternate-content-source update)
   end
 
   let(:id) { 1 }


### PR DESCRIPTION
Adds support for showing products, and removes some unnecessary smart proxy params.

Katello PR: https://github.com/Katello/katello/pull/10172