### PR TITLE
Fixes #35092 - Add lifecycle environment and content view in CLI CDN configuration

### DIFF
--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -28,6 +28,10 @@ module HammerCLIKatello
             field :url, _("URL"), Fields::Field, hide_blank: true
             field :upstream_organization_label, _("Upstream Organization"),
                                                Fields::Field, hide_blank: true
+            field :upstream_lifecycle_environment_label,
+                  _("Upstream Lifecycle Environment"), Fields::Field, hide_blank: true
+            field :upstream_content_view_label, _("Upstream Content View"),
+                  Fields::Field, hide_blank: true
             field :username, _("Username"), Fields::Field, hide_blank: true
             field :ssl_ca_credential_id, _("SSL CA Credential ID"), Fields::Field, hide_blank: true
           end


### PR DESCRIPTION
**Steps to Reproduce:**
1. prepare an upstream satellite with organization, lifecycle environment and content view
2. configure downstream to use specified LCE and CV from upstream server
3. run ```hammer organization info --name <downstream org>```

**Before** 
```
CDN configuration:     
    Type:                  Network Sync
    URL:                   https://centos7-katello-devel.lfu.example.com
    Upstream Organization: Default_Organization
    Username:              admin
    SSL CA Credential ID:  1
```

**After**
```
CDN configuration:     
    Type:                           Network Sync
    URL:                            https://centos7-katello-devel.lfu.example.com
    Upstream Organization:          Default_Organization
    Upstream Lifecycle Environment: test
    Upstream Content View:          test-content-view
    Username:                       admin
    SSL CA Credential ID:           1
```