### PR TITLE
Fixes #35141 - Add list command for host enabled_repositories

### DIFF
--- a/lib/hammer_cli_katello/host_subscription.rb
+++ b/lib/hammer_cli_katello/host_subscription.rb
@@ -102,6 +102,38 @@ module HammerCLIKatello
       setup
     end
 
+    class EnabledRepositoriesCommand < HammerCLIKatello::ListCommand
+      resource :host_subscriptions, :enabled_repositories
+      command_name 'enabled-repositories'
+
+      output do
+        field :id, _('ID')
+        field :name, _('Name')
+        field :label, _('Label')
+        field :content_type, _('Content type')
+        field :checksum, _("Checksum")
+
+        from :content_view do
+          field :id, _('Content View id')
+          field :name, _("Content View name")
+        end
+
+        from :content_view_version do
+          field :name, _("Content View version")
+        end
+
+        from :kt_environment do
+          field :name, _("Environment name")
+        end
+
+        from :product do
+          field :name, _("Product name")
+        end
+      end
+
+      build_options
+    end
+
     class ContentOverrideCommand < ::HammerCLIKatello::ContentOverrideBase::ContentOverrideCommand
       resource :host_subscriptions, :content_override
       setup

--- a/test/functional/host/subscription/enabled_repositories_test.rb
+++ b/test/functional/host/subscription/enabled_repositories_test.rb
@@ -1,0 +1,39 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe 'host enabled-repositories listing' do
+  before do
+    @cmd = %w(host subscription enabled-repositories)
+  end
+
+  let(:host_id) { 1 }
+  let(:empty_response) do
+    {
+      "total" => 0,
+      "subtotal" => 0,
+      "page" => "1",
+      "per_page" => "1000",
+      "error" => nil,
+      "search" => nil,
+      "sort" => {
+        "by" => nil,
+        "order" => nil
+      },
+      "results" => []
+    }
+  end
+
+  it 'allows listing by host' do
+    params = ["--host-id=#{host_id}"]
+    ex = api_expects(:host_subscriptions,
+                     :enabled_repositories, 'host subscription enabled-repositories')
+    ex.returns(empty_response)
+    # rubocop:disable Layout/LineLength
+    expected_result = success_result("---|------|-------|--------------|----------|-----------------|-------------------|----------------------|------------------|-------------
+ID | NAME | LABEL | CONTENT TYPE | CHECKSUM | CONTENT VIEW ID | CONTENT VIEW NAME | CONTENT VIEW VERSION | ENVIRONMENT NAME | PRODUCT NAME
+---|------|-------|--------------|----------|-----------------|-------------------|----------------------|------------------|-------------
+")
+    # rubocop:enable Layout/LineLength
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+end


### PR DESCRIPTION
* Adding support for the new endpoint `enabled_repositories`

Testing steps:

* Apply pr
* Register a host to your katello server if you have not already
* Attach a subscription or if in SCA enable some repos in repo sets
* Run `hammer host subscription enabled-repositories --host-id X`
* See if you get the new content type showing.

```bash
hammer host subscription enabled-repositories --host-id 1
---|------|-------|--------------|-----------------|-------------------|----------------------|------------------|-------------
ID | NAME | LABEL | CONTENT TYPE | CONTENT VIEW ID | CONTENT VIEW NAME | CONTENT VIEW VERSION | ENVIRONMENT NAME | PRODUCT NAME
---|------|-------|--------------|-----------------|-------------------|----------------------|------------------|-------------
4  | zoo  | zoo   | yum          | 2               | view              | view 1.0             | Library          | Custom      
---|------|-------|--------------|-----------------|-------------------|----------------------|------------------|-------------

hammer host subscription enabled-repositories --host-id 1

---|-------|-------|--------------|-----------------|---------------------------|------------------|-------------
ID | NAME  | LABEL | CONTENT TYPE | CONTENT VIEW ID | CONTENT VIEW NAME         | ENVIRONMENT NAME | PRODUCT NAME
---|-------|-------|--------------|-----------------|---------------------------|------------------|-------------
1  | zoo   | zoo   | yum          | 1               | Default Organization View | Library          | Custom      
2  | Large | Large | yum          | 1               | Default Organization View | Library          | Custom      
---|-------|-------|--------------|-----------------|---------------------------|------------------|-------------
```