### PR TITLE
Fixes #35666 - hammer repository types command is missing creatable

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -353,6 +353,8 @@ module HammerCLIKatello
           field :indexed, _('Indexed?')
         end
       end
+
+      build_options
     end
 
     # rubocop:disable ClassLength


### PR DESCRIPTION
What are the changes introduced in this pull request?
* Added `build_options` to the class method so it can pull in all the params

What are the testing steps for this pull request?
* Run `hammer hammer repository types -h and see if the creatable param is now listed'