### PR TITLE
Remove Ruby 2.5 in unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.5", "2.7"]
+        ruby: ["2.7"]
 
     steps:
     - uses: actions/checkout@v2

--- a/test/functional/organization/cdn_configuration_test.rb
+++ b/test/functional/organization/cdn_configuration_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require_relative './organization_helpers'
 require 'hammer_cli_katello/organization'
 require 'hammer_cli_katello/associating_commands'
 


### PR DESCRIPTION
* Ruby 2.5 is not longer being used in Katello/Satellite since Satellite 6.8
* Ruby 2.5 unit tests started failing with:
```ruby
/home/runner/work/hammer-cli-katello/hammer-cli-katello/vendor/bundle/ruby/2.5.0/gems/mocha-2.0.0/lib/mocha/mock.rb:1:in `require': cannot load such file -- ruby2_keywords (LoadError)
```
* Fixed the failing 2.7 unit test as well in thi spr