### PR TITLE
Fixes #35750 - ignore pagination when looking up cvv for cv purge

### DIFF
--- a/lib/hammer_cli_katello/content_view_purge.rb
+++ b/lib/hammer_cli_katello/content_view_purge.rb
@@ -84,7 +84,18 @@ module HammerCLIKatello
     private def old_unused_versions
       return @old_unused_versions if @old_unused_versions
 
-      all_versions = index(:content_view_versions, :content_view_id => options['option_id'])
+      all_versions = []
+      per_page = 100
+      page = 1
+
+      loop do
+        versions = index(:content_view_versions, :content_view_id => options['option_id'],
+                                                 :per_page => per_page, :page => page)
+        all_versions << versions
+        break if versions.count < per_page
+        page += 1
+      end
+      all_versions.flatten!
       all_versions.sort_by! { |v| [v['major'], v['minor']] }
       @old_unused_versions = all_versions.select do |v|
         v["environments"].empty? &&


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* Sent off per page of `100` to get all the content view versions in our collection call

#### What are the testing steps for this pull request?
* Create a content view and make 5 versions
* Change `Entries per page` to 2
* Apply PR
* Try to purge the content view, before the patch it would say, no versions found, with patch it should delete the version.