### PR TITLE
Fixes #35815 - Restrict simplified ACS to product id

### DIFF
--- a/lib/hammer_cli_katello/acs.rb
+++ b/lib/hammer_cli_katello/acs.rb
@@ -16,7 +16,10 @@ module HammerCLIKatello
       success_message _('Alternate Content Source created.')
       failure_message _('Could not create the Alternate Content Source.')
 
-      build_options
+      build_options do |o|
+        o.expand(:all).except(:products)
+        o.without(:product_name)
+      end
     end
 
     class InfoCommand < HammerCLIKatello::InfoCommand


### PR DESCRIPTION
* Before:
```bash
--product[s|-ids] LIST Names/ids of products to copy repository information from into a Simplified
                                      Alternate Content Source. Products must include at least one repository of the
                                      chosen content type.
```
* After
```bash
 --product-ids LIST      Ids of products to copy repository information from into a Simplified Alternate
                                      Content Source. Products must include at least one repository of the chosen
                                      content type.
```

### Testing steps
* Verify help text reflects above
* Try to create a simplified ACS to make sure nothing broke
`hammer alternate-content-source create --alternate-content-source-type simplified --content-type yum --product-ids 1 --smart-proxy-ids 1 --name foo1`