### PR TITLE
Fixes #36052 - Add SSL info to ACS show command

### DIFF
--- a/lib/hammer_cli_katello/acs.rb
+++ b/lib/hammer_cli_katello/acs.rb
@@ -32,6 +32,21 @@ module HammerCLIKatello
         field :content_type, _('Content type')
         field :alternate_content_source_type, _('Alternate content source type')
         field :upstream_username, _('Upstream username'), Fields::Field, :hide_blank => true
+        field :verify_ssl, _('Verify SSL'), Fields::Field, :hide_blank => true
+        collection :ssl_ca_cert, _('SSL CA Cert') do
+          field :id, _('Id'), Fields::Field, :hide_blank => true
+          field :name, _('Name'), Fields::Field, :hide_blank => true
+        end
+
+        collection :ssl_client_cert, _('SSL Client Cert') do
+          field :id, _('Id'), Fields::Field, :hide_blank => true
+          field :name, _('Name'), Fields::Field, :hide_blank => true
+        end
+
+        collection :ssl_client_key, _('SSL Client Key') do
+          field :id, _('Id'), Fields::Field, :hide_blank => true
+          field :name, _('Name'), Fields::Field, :hide_blank => true
+        end
 
         collection :subpaths, _('Subpaths') do
           field nil, _('')

--- a/test/functional/acs/info_test.rb
+++ b/test/functional/acs/info_test.rb
@@ -16,6 +16,18 @@ describe 'get acs info' do
       'base_url' => 'https://proxy.example.com',
       'content_type' => 'yum',
       'alternate_content_source_type' => 'custom',
+      'ssl_ca_cert' => {
+        'id' => 1,
+        'name' => 'CA'
+      },
+      "ssl_client_cert" => {
+        "id" => 3,
+        "name" => "cert"
+      },
+      "ssl_client_key" => {
+        "id" => 2,
+        "name" => "KEY"
+      },
       'subpaths' => [
         'test/repo1'
       ],
@@ -34,6 +46,15 @@ describe 'get acs info' do
                        ['Base URL', 'https://proxy.example.com'],
                        ['Content type', 'yum'],
                        ['Alternate content source type', 'custom'],
+                       ['SSL CA Cert', ''],
+                       ['Id', '1'],
+                       ['Name', 'CA'],
+                       ['SSL Client Cert', ''],
+                       ['Id', '1'],
+                       ['Name', 'cert'],
+                       ['SSL Client Key', ''],
+                       ['Id', '1'],
+                       ['Name', 'KEY'],
                        ['Subpaths', ''],
                        ['', 'test/repo1'],
                        ['Smart proxies', ''],


### PR DESCRIPTION
Before patch:

```bash
[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer alternate-content-source show --id 1
ID:                            1
Name:                          foo
Label:                         foo
Description:                   
Base URL:                      http://yum.microsoft.com
Content type:                  yum
Alternate content source type: custom
Subpaths:                      
 1) : test/repo1/
Smart proxies:                 
 1) Id:              1
    Name:            centos8-katello-devel.area52.example.com
    URL:             https://centos8-katello-devel.area52.example.com:9090
    Download policy: on_demand
```

With patch:
```bash
[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer alternate-content-source show --id 1
ID:                            1
Name:                          foo
Label:                         foo
Description:                   
Base URL:                      http://yum.microsoft.com
Content type:                  yum
Alternate content source type: custom
SSL CA Cert:                   
 1) Id:   1
    Name: CA
SSL Client Cert:               
 1) Id:   3
    Name: cert
SSL Client Key:                
 1) Id:   2
    Name: KEY
Subpaths:                      
 1) : test/repo1/
Smart proxies:                 
 1) Id:              1
    Name:            centos8-katello-devel.area52.example.com
    URL:             https://centos8-katello-devel.area52.example.com:9090
    Download policy: on_demand
```