### PR TITLE
Fixes #36284 - expose repository content label that could be overridden

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -31,6 +31,7 @@ module HammerCLIKatello
           field :name, _("Product")
         end
         field :content_type, _("Content Type")
+        field :content_label, _("Content Label")
         field :url, _("Url")
       end
 
@@ -67,6 +68,7 @@ module HammerCLIKatello
         end
         field :_redhat_repo, _("Red Hat Repository")
         field :content_type, _("Content Type")
+        field :content_label, _("Content Label")
         field :checksum_type, _("Checksum Type"), Fields::Field, :hide_blank => true
         field :_mirroring_policy, _("Mirroring Policy"), Fields::Field, :hide_blank => true
         field :url, _("Url")

--- a/test/functional/repository/list_test.rb
+++ b/test/functional/repository/list_test.rb
@@ -36,13 +36,13 @@ describe 'listing repositories' do
 
     ex.returns(empty_response)
 
-    expected_result = success_result("---|------|---------|--------------|----
-ID | NAME | PRODUCT | CONTENT TYPE | URL
----|------|---------|--------------|----
+    expected = success_result("---|------|---------|--------------|---------------|----
+ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL
+---|------|---------|--------------|---------------|----
 ")
 
     result = run_cmd(@cmd + params)
-    assert_cmd(expected_result, result)
+    assert_cmd(expected, result)
   end
 
   it "lists the repositories belonging to a lifecycle-environment by name" do
@@ -57,13 +57,13 @@ ID | NAME | PRODUCT | CONTENT TYPE | URL
 
     ex.returns(empty_response)
 
-    expected_result = CommandExpectation.new("---|------|---------|--------------|----
-ID | NAME | PRODUCT | CONTENT TYPE | URL
----|------|---------|--------------|----
+    expected = CommandExpectation.new("---|------|---------|--------------|---------------|----
+ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL
+---|------|---------|--------------|---------------|----
 ", "Warning: Option --environment is deprecated. Use --lifecycle-environment instead\n")
 
     result = run_cmd(@cmd + params)
-    assert_cmd(expected_result, result)
+    assert_cmd(expected, result)
   end
 
   it "lists the repositories with a certain repository type" do
@@ -76,13 +76,13 @@ ID | NAME | PRODUCT | CONTENT TYPE | URL
 
     ex.returns(empty_response)
 
-    expected_result = CommandExpectation.new("---|------|---------|--------------|----
-ID | NAME | PRODUCT | CONTENT TYPE | URL
----|------|---------|--------------|----
+    expected = CommandExpectation.new("---|------|---------|--------------|---------------|----
+ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL
+---|------|---------|--------------|---------------|----
 ")
 
     result = run_cmd(@cmd + params)
-    assert_cmd(expected_result, result)
+    assert_cmd(expected, result)
   end
 
   it "lists the repositories with a certain content unit type" do
@@ -95,12 +95,12 @@ ID | NAME | PRODUCT | CONTENT TYPE | URL
 
     ex.returns(empty_response)
 
-    expected_result = CommandExpectation.new("---|------|---------|--------------|----
-ID | NAME | PRODUCT | CONTENT TYPE | URL
----|------|---------|--------------|----
+    expected = CommandExpectation.new("---|------|---------|--------------|---------------|----
+ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL
+---|------|---------|--------------|---------------|----
 ")
 
     result = run_cmd(@cmd + params)
-    assert_cmd(expected_result, result)
+    assert_cmd(expected, result)
   end
 end


### PR DESCRIPTION
Expose repository content label for content overrides.

```
hammer repository list --organization-id 1
hammer repository info --id 5 --organization-id 1
```
Look for `Content Label`  in the hammer output.