### PR TITLE
Refs #36401 - Update info command to show multiple cv envs

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -42,14 +42,20 @@ module HammerCLIKatello
       output do
         label _('Content Information') do
           from :content_facet_attributes do
-            label _("Content View") do
-              field :content_view_id, _("Id")
-              field :content_view_name, _("Name")
-            end
-
-            label _("Lifecycle Environment") do
-              field :lifecycle_environment_id, _("Id")
-              field :lifecycle_environment_name, _("Name")
+            collection :content_view_environments, _('Content view environments') do
+              from :content_view do
+                label _("Content view") do
+                  field :id, _("Id")
+                  field :name, _("Name")
+                  field :composite, _("Composite"), Fields::Boolean
+                end
+              end
+              from :lifecycle_environment do
+                label _("Lifecycle environment") do
+                  field :id, _("Id")
+                  field :name, _("Name")
+                end
+              end
             end
 
             label _("Content Source") do

--- a/test/functional/host/extensions/info_test.rb
+++ b/test/functional/host/extensions/info_test.rb
@@ -16,8 +16,7 @@ describe 'host info' do
 
     result = run_cmd(@cmd + params)
     # rubocop:disable Style/WordArray
-    expected_fields = [['Name', 'Library'],
-                       ['Name', 'Default Organization View'],
+    expected_fields = [['Name', 'robot.example.com'],
                        ['Release Version', '7Server'],
                        ['Name', 'Rhel 7'],
                        ['Name', 'capsule'],


### PR DESCRIPTION
Needs Katello PR: https://github.com/Katello/katello/pull/10604

Output with PR:
```bash
Additional info:
    Owner:      Admin User
    Owner Id:   4
    Owner Type: User
    Enabled:    yes
    Model:      VMware Virtual Platform
    Comment:
Content Information:
    Content view environments:
     1) Content View:
            Id:        2
            Name:      Zoo
            Composite: no
        Lifecycle environment:
            Id:   1
            Name: Library
     2) Content View:
            Id:        3
            Name:      Plumbing
            Composite: no
        Lifecycle environment:
            Id:   2
            Name: Custom
    Content Source:
```