### PR TITLE
Fixes #36585 - Add cv rules to cvv info filters

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -62,6 +62,27 @@ module HammerCLIKatello
             from :filter do
               field :id, _("Id")
               field :name, _("Name")
+              field :content, _('Type')
+              field :inclusion, _('Inclusion'), Fields::Boolean
+              field :original_packages, _('Original packages'), Fields::Boolean, hide_blank: true
+              # rubocop:disable Layout/LineLength
+              field :original_module_streams, _('Original module streams'), Fields::Boolean, hide_blank: true
+              # rubocop:enable Layout/LineLength
+            end
+            collection :rules, _("Rules"), hide_blank: true, hide_empty: true do
+              field :id, _('Id')
+              field :name, _('Name'), Fields::Field, hide_blank: true
+              field :uuid, _('UUID'), Fields::Field, hide_blank: true
+              field :module_stream_id, _('Module stream Id'), Fields::Field, hide_blank: true
+              collection :types, _('Types'), hide_blank: true, hide_empty: true do
+                field nil, _('')
+              end
+              field :architecture, _('Architecture'), Fields::Field, :hide_blank => true
+              field :content_view_filter_id, _('Content view filter Id')
+              field :errata_id, _('Errata Id'), Fields::Field, :hide_blank => true
+              field :date_type, _('Date type'), Fields::Field, :hide_blank => true
+              field :start_date, _('Start date'), Fields::Field, :hide_blank => true
+              field :end_date, _('End date'), Fields::Field, :hide_blank => true
             end
           end
           field :dependency_solving, _("Dependency Solving"), Fields::Field, :hide_blank => true


### PR DESCRIPTION
* Create a content view with an exclude rpm filter
* With PR it should look like this:
```bash
Applied Filters:        
 1) Id:    1
    Name:  exclude
    Rules: 
     1) Id:                     1
        Name:                   cat
        Architecture:           
        Content view filter Id: 1
     2) Id:                     2
        Name:                   cow
        Architecture:           
        Content view filter Id: 1
Dependency Solving:     false
```

* Create a cv with an errata ID filter it should look like this with the PR:
```bash
Errata id
Applied Filters:        
 1) Id:    2
    Name:  Errata
    Rules: 
     1) Id:                     1
        Content view filter Id: 2
        Errata Id:              RHEA-2012:0002
        Date type:              updated
Dependency Solving:     false
```

* Create a cv with an errata by date filter, it should look like this with the PR:
```bash
By date: Applied Filters:        
 1) Id:    5
    Name:  Custom
    Rules: 
     1) Id:                     3
        Types:                  
         1) : security
         2) : enhancement
         3) : bugfix
        Content view filter Id: 5
        Date type:              issued
        Start date:             2012-01-27T12:00:00.000Z
        End date:               2012-02-16T12:00:00.000Z
Dependency Solving:     false
```