### PR TITLE
Fixes #36743 - Show full repository id list in hammer content-view list

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -16,7 +16,7 @@ module HammerCLIKatello
         field :label, _("Label")
         field :composite, _("Composite")
         field :last_published, _("Last Published"), Fields::Date, :hide_blank => true
-        field :repository_ids, _("Repository IDs"), Fields::List
+        field :repository_ids, _("Repository IDs"), Fields::List, :max_width => 300
       end
 
       build_options


### PR DESCRIPTION
`hammer content-view list` truncates repository list if there are a lot of repos in the cv.

The API returns the full list of repository ids, there's no pagination. Hammer however truncates the column if it's too long. Found the param max_width in hammer_cli to control how wide the column can be. Increasing to 300 but open to go higher if needed. 
Before PR:
![Before_PR](https://github.com/Katello/hammer-cli-katello/assets/21146741/69e9315f-1c5e-4642-b2ef-40ee03387d26)

After PR:
![After_PR](https://github.com/Katello/hammer-cli-katello/assets/21146741/873742aa-5ffa-40d0-bed7-ffb52515e3c2)
