### PR TITLE
Fixes #36773 - hammer erratum list should support --lifecycle-environment

### DIFF
--- a/lib/hammer_cli_katello/erratum.rb
+++ b/lib/hammer_cli_katello/erratum.rb
@@ -6,6 +6,7 @@ module HammerCLIKatello
 
     class ListCommand < HammerCLIKatello::ListCommand
       extend RepositoryScopedToProduct
+      include LifecycleEnvironmentNameMapping
 
       validate_repo_name_requires_product_options(:option_repository_name)
 
@@ -30,6 +31,8 @@ module HammerCLIKatello
       build_options do |o|
         o.expand.including(:products, :organizations, :content_views)
       end
+
+      extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
     end
 
     class InfoCommand < HammerCLIKatello::ErratumInfoCommand


### PR DESCRIPTION
Before

```
$ hammer erratum list --organization-id=1 --content-view=test-content-view --lifecycle-environment=test-env
Error: Unrecognised option '--lifecycle-environment'.

See: 'hammer erratum <list|index> --help'.
```

After
```
$ hammer erratum list --organization-id=1 --content-view=test-content-view --lifecycle-environment=test-env
-----|----------------|-------------|---------------------------------------------------------|------------|-----------
ID   | ERRATA ID      | TYPE        | TITLE                                                   | ISSUED     | UPDATED   
-----|----------------|-------------|---------------------------------------------------------|------------|-----------
1758 | RHBA-2020:5558 | bugfix      | Ansible 2.8.18 release for Ansible Engine 2.8           | 2020-12-15 | 2020-12-15
1763 | RHBA-2020:4921 | bugfix      | Ansible 2.8.17 release for Ansible Engine 2.8           | 2020-11-04 | 2020-11-04
1762 | RHBA-2020:4195 | bugfix      | Ansible 2.8.16 release for Ansible Engine 2.8           | 2020-10-06 | 2020-10-06
1770 | RHSA-2020:3600 | security    | Important: Ansible security and bug fix update (2.8.15) | 2020-09-01 | 2020-09-01
1768 | RHBA-2020:2978 | bugfix      | Ansible 2.8.13 release for Ansible Engine 2.8           | 2020-07-16 | 2020-07-16
1769 | RHBA-2020:2141 | bugfix      | Ansible 2.8.12 release for Ansible Engine 2.8           | 2020-05-13 | 2020-05-13
1764 | RHSA-2020:1543 | security    | Important: Ansible security and bug fix update (2.8.11) | 2020-04-22 | 2020-04-22
1760 | RHBA-2020:0783 | bugfix      | Ansible 2.8.10 release for Ansible Engine 2.8           | 2020-03-11 | 2020-03-11
1765 | RHSA-2020:0216 | security    | Moderate: Ansible security and bug fix update (2.8.8)   | 2020-01-23 | 2020-01-23
1756 | RHSA-2019:3926 | security    | Moderate: ansible security and bug fix update           | 2019-11-20 | 2019-11-20
1754 | RHSA-2019:3203 | security    | Important: Ansible security and bug fix update          | 2019-10-24 | 2019-10-24
1757 | RHBA-2019:2882 | bugfix      | Ansible 2.8.5 release for Ansible Engine 2.8            | 2019-09-23 | 2019-09-23
1761 | RHSA-2019:2542 | security    | Moderate: Ansible security and bug fix update           | 2019-08-21 | 2019-08-21
1767 | RHBA-2019:1934 | bugfix      | Ansible 2.8.3 release for Ansible Engine 2.8            | 2019-07-29 | 2019-07-29
1766 | RHSA-2019:1708 | security    | Moderate: ansible security and bug fix update           | 2019-07-09 | 2019-07-09
1755 | RHBA-2019:1432 | bugfix      | Ansible 2.8.1 release for Ansible Engine 2.8            | 2019-06-11 | 2019-06-11
1759 | RHEA-2019:1254 | enhancement | Ansible Engine 2.8.0 for Ansible Engine 2.8 on RHEL8    | 2019-05-21 | 2019-05-21
-----|----------------|-------------|---------------------------------------------------------|------------|-----------
```