### PR TITLE
Fixes #36777 - Add reclaim-space to capsule content command

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -74,6 +74,18 @@ module HammerCLIKatello
         extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
       end
 
+      class ReclaimSpaceCommand < HammerCLIKatello::SingleResourceCommand
+        include HammerCLIForemanTasks::Async
+
+        resource :capsule_content, :reclaim_space
+        command_name "reclaim-space"
+
+        success_message _("Capsule reclaim space has been started in task %{id}.")
+        failure_message _("Capsule reclaim space was unsuccessful.")
+
+        build_options
+      end
+
       class SyncCommand < HammerCLIKatello::SingleResourceCommand
         include HammerCLIForemanTasks::Async
         include LifecycleEnvironmentNameMapping

--- a/test/functional/capsule/content/reclaim_space_test.rb
+++ b/test/functional/capsule/content/reclaim_space_test.rb
@@ -1,0 +1,23 @@
+require_relative '../../test_helper'
+require_relative 'capsule_content_helpers'
+require 'hammer_cli_katello/capsule'
+
+module HammerCLIKatello
+  module Capsule
+    class Content
+      describe Content::ReclaimSpaceCommand do
+        include CapsuleContentHelpers
+
+        it 'allows minimal options' do
+          api_expects(:capsule_content, :reclaim_space, 'Reclaim space').with_params('id' => 1)
+          run_cmd(%w(capsule content reclaim-space --id 1))
+        end
+
+        it 'fails on missing ID' do
+          api_expects_no_call
+          assert_failure run_cmd(%w(capsule content reclaim-space)), "Missing arguments for '--id'."
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Apply PR
* Sync some content on your katello box
* Pass in the command `hammer capsule content reclaim-space --id 1` and see if it generates a task on your katello
* Try without an ID to make sure it uses validation