### PR TITLE
Fixes #36814 - add content counts to capsule content info

### DIFF
--- a/test/functional/capsule/content/data/sync_status.json
+++ b/test/functional/capsule/content/data/sync_status.json
@@ -2,5 +2,9 @@
     "last_sync_time": "2016-01-10 00:27:51 +0100",
     "active_sync_tasks": [],
     "last_failed_sync_tasks": [],
-    "lifecycle_environments": []
+    "lifecycle_environments": [],
+    "content_counts": {
+        "content_view_versions":{
+            "2":{"repositories":{"42":{"metadata":{"env_id":4,"product_id":1,"content_type":"yum","library_instance_id":1},"counts":{"rpm":32,"erratum":4}}}}}
+    }
 }

--- a/test/functional/capsule/content/data/unsynced_env.json
+++ b/test/functional/capsule/content/data/unsynced_env.json
@@ -1,8 +1,8 @@
 {
-    "library":true,
-    "id":4,
-    "name":"Library",
-    "label":"Library",
+    "library":false,
+    "id":5,
+    "name":"Test",
+    "label":"Test",
     "description":null,
     "organization_id":1,
     "organization":{
@@ -23,7 +23,7 @@
             "name":"Zoo View",
             "composite":false,
             "last_published":"2023-10-09 19:18:15 UTC",
-            "default":false,"up_to_date":true,
+            "default":false,"up_to_date":false,
             "counts":{"repositories":1},
             "repositories":[{"id":2,"name":"Zoo","library_id":1}]
         }

--- a/test/functional/capsule/content/info_test.rb
+++ b/test/functional/capsule/content/info_test.rb
@@ -12,7 +12,8 @@ describe 'capsule content info' do
   it "lists content counts" do
     @sync_status = load_json('./data/sync_status.json', __FILE__)
     @sync_status['lifecycle_environments'] = [
-      load_json('./data/library_env.json', __FILE__)
+      load_json('./data/library_env.json', __FILE__),
+      load_json('./data/unsynced_env.json', __FILE__)
     ]
 
     ex = api_expects(:capsule_content, :sync_status, 'Get sync info') do |par|
@@ -25,17 +26,26 @@ describe 'capsule content info' do
       " 1) Name:          Library",
       "    Organization:  Default Organization",
       "    Content Views:",
-      "     1) Name:           CV1",
+      "     1) Name:           Zoo View",
       "        Composite:      no",
-      "        Last Published: 2016/01/08 15:44:10",
-      "        Content:",
-      "            Hosts:                 0",
-      "            Products:              3",
-      "            Yum repos:             1",
-      "            Container Image repos: 0",
-      "            Packages:              32",
-      "            Package groups:        2",
-      "            Errata:                4"
+      "        Last Published: 2023/10/09 19:18:15",
+      "        Repositories:",
+      "         1) Repository ID:   2",
+      "            Repository Name: Zoo",
+      "            Content Counts:",
+      "                Packages: 32",
+      "                Errata:   4",
+      " 2) Name:          Test",
+      "    Organization:  Default Organization",
+      "    Content Views:",
+      "     1) Name:           Zoo View",
+      "        Composite:      no",
+      "        Last Published: 2023/10/09 19:18:15",
+      "        Repositories:",
+      "         1) Repository ID:   2",
+      "            Repository Name: Zoo",
+      "            Content Counts:",
+      "                Warning: Content view must be synced to see content counts"
     ])
     expected_result = success_result(output)
 


### PR DESCRIPTION
... and `...update-counts`

Content counts for every indexed content type should be available.

To test:

1) Sync a smart proxy with different repository types
2) Run `hammer capsule content info --id <id>`
3) See something like the following:
```
Lifecycle Environments: 
 1) Name:          Precipitation
    Organization:  Default Organization
    Content Views: 
     1) Name:           Zoo View
        Composite:      no
        Last Published: 2023/10/09 19:18:15
        Repositories:   
         1) Repository ID:   2
            Repository Name: Zoo
            Content Counts:  
                Packages: 32
                Errata:   4
     2) Name:           Everything View
        Composite:      no
        Last Published: 2023/10/10 15:59:58
        Repositories:   
         1) Repository ID:   41
            Repository Name: Zoo
            Content Counts:  
                Packages: 32
                Errata:   4
         2) Repository ID:   40
            Repository Name: Debian Repo
            Content Counts:  
                Debian Packages: 8
         3) Repository ID:   42
            Repository Name: OSTree Repo
            Content Counts:  
                OSTree Refs: 2
         4) Repository ID:   44
            Repository Name: prometheus/busybox
            Content Counts:  
                Container Tags:           3
                Container Manifests:      9
                Container Manifest Lists: 3
         5) Repository ID:   47
            Repository Name: File Repo
            Content Counts:  
                Files: 250
         6) Repository ID:   46
            Repository Name: ansible repo
            Content Counts:  
                Ansible Collections: 446
         7) Repository ID:   45
            Repository Name: Python Repo
            Content Counts:  
                Python Packages: 2
         8) Repository ID:   43
            Repository Name: EPEL 8 Modular x86_64
            Content Counts:  
                Packages:       290
                Module Streams: 24
                Errata:         14
```
4) Run `hammer capsule content update-counts --id <id>`
5) Hammer should either follow the counts update task or return the task info when providing `--async`.