### PR TITLE
Fixes #36900 - hammer content-view version info not working with --lifecycle-environment flag

### DIFF
--- a/lib/hammer_cli_katello/option_sources/lifecycle_environment_params.rb
+++ b/lib/hammer_cli_katello/option_sources/lifecycle_environment_params.rb
@@ -25,12 +25,18 @@ module HammerCLIKatello
           result['option_environment_id'] = @command.resolver.lifecycle_environment_id(
             @command.resolver.scoped_options(lifecycle_environment_resource_name, result, :single))
         end
+        if result['option_lifecycle_environment_id'] && result['option_environment_id'].nil?
+          result['option_environment_id'] = result['option_lifecycle_environment_id']
+        end
       end
 
       def legacy_option_ids(result)
         if result['option_environment_names'] && result['option_environment_ids'].nil?
           result['option_environment_ids'] = @command.resolver.lifecycle_environment_ids(
             @command.resolver.scoped_options(lifecycle_environment_resource_name, result, :multi))
+        end
+        if result['option_lifecycle_environment_ids'] && result['option_environment_ids'].nil?
+          result['option_environment_ids'] = result['option_lifecycle_environment_ids']
         end
       end
 


### PR DESCRIPTION
To reproduce:

Try life-cycle environment params for content view version info commands.

Ex:
`hammer -d content-view version info --organization-id 1  --lifecycle-environment-id 2 --content-view-id 2`
and 
`hammer -d content-view version info --organization-id 1  --lifecycle-environment dev_env --content-view-id 2`
where ids and env_name would be test record ids and name