### PR TITLE
Fixes #36964 - SCA deprecation message - next release

### DIFF
--- a/lib/hammer_cli_katello/organization.rb
+++ b/lib/hammer_cli_katello/organization.rb
@@ -77,7 +77,9 @@ module HammerCLIKatello
           params["organization"] = params.fetch('organization', {}).merge(
             "_simple_content_access" => params['simple_content_access'])
           unless params['simple_content_access']
-            warn "Simple Content Access will be required for all organizations in Katello 4.12."
+            warn(
+              _("Simple Content Access will be required for all organizations in the next release.")
+            )
           end
         end
         params

--- a/lib/hammer_cli_katello/simple_content_access.rb
+++ b/lib/hammer_cli_katello/simple_content_access.rb
@@ -1,5 +1,7 @@
 module HammerCLIKatello
   class SimpleContentAccess < HammerCLIKatello::Command
+    resource :simple_content_access
+
     desc "Toggle simple content access mode across organization"
 
     module EligibleCheck
@@ -47,7 +49,7 @@ module HammerCLIKatello
       build_options
 
       def execute
-        warn "Simple Content Access will be required for all organizations in Katello 4.12."
+        warn _("Simple Content Access will be required for all organizations in the next release.")
         super
       end
     end


### PR DESCRIPTION
Changes the Katello 4.12 message to say "next release" so that projects using Katello don't have to worry about translating the name.

To test:

1) `hammer simple-content-access disable --organization-id 1`
  -> See the warning
2) `hammer organization update --id 1 --simple-content-access false`
  -> See the same warning

**This will need to be CP'd to the 1.11.z branch.**

Also fixes an issue I found:

```
[vagrant@centos7-hammer-devel hammer-cli-katello]$ hammer simple-content-access
...
Options:
 -h, --help                    Print help



Unfortunately the server does not support such operation.
```
The simple content access class was missing a `:resource`.