### PR TITLE
Fixes #37031 - hammer proxy content info fails when DB has no content counts

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -218,7 +218,7 @@ module HammerCLIKatello
           data["lifecycle_environments"].each do |lce|
             lce["content_views"].each do |cv|
               cv["repositories"].each do |repo|
-                if cv["up_to_date"]
+                if cv["up_to_date"] && !data.dig("content_counts").nil?
                   cvv_count_repos = data.dig("content_counts", "content_view_versions",
                     cv["cvv_id"].to_s, "repositories")
                   cvv_count_repos.each do |_repo_id, counts_and_metadata|

--- a/test/functional/capsule/content/data/sync_status_no_counts.json
+++ b/test/functional/capsule/content/data/sync_status_no_counts.json
@@ -1,0 +1,6 @@
+{
+    "last_sync_time": "2016-01-10 00:27:51 +0100",
+    "active_sync_tasks": [],
+    "last_failed_sync_tasks": [],
+    "lifecycle_environments": []
+}

--- a/test/functional/capsule/content/info_test.rb
+++ b/test/functional/capsule/content/info_test.rb
@@ -53,6 +53,49 @@ describe 'capsule content info' do
     assert_cmd(expected_result, result)
   end
 
+  it "works with no content counts" do
+    @sync_status = load_json('./data/sync_status_no_counts.json', __FILE__)
+    @sync_status['lifecycle_environments'] = [
+      load_json('./data/library_env.json', __FILE__),
+      load_json('./data/unsynced_env.json', __FILE__)
+    ]
+
+    ex = api_expects(:capsule_content, :sync_status, 'Get sync info') do |par|
+      par['id'] == 3
+    end
+    ex.returns(@sync_status)
+
+    output = OutputMatcher.new([
+      "Lifecycle Environments:",
+      " 1) Name:          Library",
+      "    Organization:  Default Organization",
+      "    Content Views:",
+      "     1) Name:           Zoo View",
+      "        Composite:      no",
+      "        Last Published: 2023/10/09 19:18:15",
+      "        Repositories:",
+      "         1) Repository ID:   2",
+      "            Repository Name: Zoo",
+      "            Content Counts:",
+      "                Warning: Content view must be synced to see content counts",
+      " 2) Name:          Test",
+      "    Organization:  Default Organization",
+      "    Content Views:",
+      "     1) Name:           Zoo View",
+      "        Composite:      no",
+      "        Last Published: 2023/10/09 19:18:15",
+      "        Repositories:",
+      "         1) Repository ID:   2",
+      "            Repository Name: Zoo",
+      "            Content Counts:",
+      "                Warning: Content view must be synced to see content counts"
+    ])
+    expected_result = success_result(output)
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
   it "resolves id from name" do
     params = ['--name=capsule1']
 

--- a/test/functional/content_view/version/republish_repositories_test.rb
+++ b/test/functional/content_view/version/republish_repositories_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper'
+require 'hammer_cli_katello/content_view_version'
 
 module HammerCLIKatello
   describe ContentViewVersion::RepublishRepositoriesCommand do


### PR DESCRIPTION
Test by upgrading from Katello 4.10 to 4.11 with a synced smart proxy. Run `hammer proxy content info...` and see the error "undefined method each for nil"

Related to https://github.com/Katello/katello/pull/10835/