### PR TITLE
Fixes #37053 - Add CV/LCE back host list params

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -26,8 +26,12 @@ module HammerCLIKatello
     ::HammerCLIForeman::Host::ListCommand.instance_eval do
       output do
         from :content_facet_attributes do
-          field :content_view_name, _('Content View')
-          field :lifecycle_environment_name, _('Lifecycle Environment')
+          from :content_view do
+            field :name, _('Content View'), Fields::List
+          end
+          from :lifecycle_environment do
+            field :name, _('Lifecycle environment'), Fields::List
+          end
           from :errata_counts do
             field :security, _("Security"), nil, :sets => ['ALL']
             field :bugfix, _("Bugfix"), nil, :sets => ['ALL']


### PR DESCRIPTION
What are the changes introduced in this pull request?
* With the new `content_view_environments` collection we were no longer pulling the data correctly; this has been updated. 

Considerations taken when implementing this change?

* This might not work with multiple cv/lce's since `hammer list` does not support using `collection` only the `info` command does. If this does not work with multiple cve's then when we get to that point, we will have to raise a redmine to `hammer-cli core` to add support to use collection with the list command. 

What are the testing steps for this pull request?
* Check out PR
* Register a host to your Katello devel/production box
* run `hammer host list` and see if the host Content view and Lifecycle environment fields are back

Before PR:
```bash
---|-------------------|------------------|------------|----------------|-------------------|--------------
ID | NAME              | OPERATING SYSTEM | HOST GROUP | IP             | MAC               | GLOBAL STATUS
---|-------------------|------------------|------------|----------------|-------------------|--------------
12 | devel.croberts.io | CentOS_Stream 8  |            | 192.168.41.128 | 00:0c:29:82:76:c6 | Warning
---|-------------------|------------------|------------|----------------|-------------------|--------------
```

With PR:
```bash
---|-------------------|------------------|------------|----------------|-------------------|---------------|---------------------------|----------------------
ID | NAME              | OPERATING SYSTEM | HOST GROUP | IP             | MAC               | GLOBAL STATUS | CONTENT VIEW              | LIFECYCLE ENVIRONMENT
---|-------------------|------------------|------------|----------------|-------------------|---------------|---------------------------|----------------------
12 | devel.croberts.io | CentOS_Stream 8  |            | 192.168.41.128 | 00:0c:29:82:76:c6 | Warning       | Default Organization View | Library
---|-------------------|------------------|------------|----------------|-------------------|---------------|---------------------------|----------------------
```