### PR TITLE
Fix broken string interpolation with translations

### DIFF
--- a/lib/hammer_cli_katello/command_extensions/kickstart_repository.rb
+++ b/lib/hammer_cli_katello/command_extensions/kickstart_repository.rb
@@ -41,7 +41,7 @@ module HammerCLIKatello
         repos = repo_resource.call(:index, index_options)['results']
         if repos.empty?
           raise _("No such repository with name %{name}, in lifecycle environment"\
-                    " %{environment_id} and content view %{content_view_id}" % index_options)
+                    " %{environment_id} and content view %{content_view_id}") % index_options
         end
         repos.first['id']
       end

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -571,7 +571,7 @@ module HammerCLIKatello
           upload_results = results.dig('output', 'upload_results') || []
 
           if upload_results.empty?
-            print_message _("Successfully uploaded file %s" % name)
+            print_message _("Successfully uploaded file %s") % name
           else
             upload_results.each do |result|
               if result['type'] == 'docker_manifest'
@@ -579,7 +579,7 @@ module HammerCLIKatello
                   _("Successfully uploaded manifest file '%{name}' with digest '%{digest}'") % {
                     :name => name, :digest => result['digest'] })
               else
-                print_message _("Successfully uploaded file %s" % name)
+                print_message _("Successfully uploaded file %s") % name
               end
             end
           end

--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -32,9 +32,9 @@ module HammerCLIKatello
         if !data["virt_only"]
           _("Physical")
         elsif data["host"]
-          _("Guests of %s" % data['host']['name'])
+          _("Guests of %s") % data['host']['name']
         elsif data["hypervisor"]
-          _("Guests of %s" % data['hypervisor']['name'])
+          _("Guests of %s") % data['hypervisor']['name']
         elsif data["unmapper_guest"]
           _("Temporary")
         else


### PR DESCRIPTION
Previously it was interpolating a string and then translating it. That never works. Instead, you must first translate it and then interpolate.