### PR TITLE
Fixes #37232 - Added extra info for CV & repos

### DIFF
--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -100,9 +100,12 @@ module HammerCLIKatello
           field :published, _("Published"), Fields::Date
         end
 
-        collection :components, _("Components"), hide_blank: true, hide_empty: true do
+        collection :cv_components, _("Components"), hide_blank: true, hide_empty: true do
           field :id, _("Id")
           field :name, _("Name")
+          field :latest, _("Latest version"), Fields::Boolean
+          field :unpublished, _("Not yet published"), Fields::Boolean
+          field :always_latest, _("Always update to the latest"), Fields::Boolean
         end
 
         collection :activation_keys, _("Activation Keys"), hide_blank: true, hide_empty: true do
@@ -117,6 +120,18 @@ module HammerCLIKatello
           end
         end
 
+        if data["composite"]
+          data["cv_components"] = data["content_view_components"]&.map do |component|
+            cv_latest = component.dig("content_view", "latest_version")
+            {
+              "id" => component.dig("content_view_version", "id"),
+              "name" => component.dig("content_view_version", "name") || component.dig("content_view", "name"),
+              "always_latest" => component["latest"],
+              "latest" => cv_latest == component.dig("content_view_version", "version"),
+              "unpublished" => component["content_view_version"].nil?
+            }
+          end
+        end
         data
       end
 

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -85,6 +85,11 @@ module HammerCLIKatello
               Fields::Field, :hide_blank => true
         field :ignorable_content, _("Ignorable Content Units"), Fields::List, :hide_blank => true
 
+        label _("Publish Settings") do
+          field :restrict_to_arch, _("Restrict to architecture")
+          field :restrict_to_os_versions, _("Restrict to OS Version")
+        end
+
         label _("HTTP Proxy") do
           from :http_proxy do
             field :id, _("Id"), Fields::Field, :hide_blank => true
@@ -156,11 +161,20 @@ module HammerCLIKatello
           data["gpg_key_name"] = data["gpg_key"]["name"]
         end
 
+        setup_arch_and_os(data)
         setup_sync_state(data)
         setup_booleans(data)
         setup_mirroring_policy(data)
         setup_content_counts(data) if data["content_counts"]
         data
+      end
+
+      def setup_arch_and_os(data)
+        arch = data["arch"]
+        data["restrict_to_arch"] = arch == 'noarch' ? _('No restriction') : arch
+        os_versions = data["os_versions"] || []
+        data["restrict_to_os_versions"] = _('No restriction')
+        data["restrict_to_os_versions"] = os_versions.join(", ") unless os_versions.empty?
       end
 
       def setup_booleans(data)


### PR DESCRIPTION
Added new attributes for `repository info` and `content-view info` commands


for repository info it adds attributes to `Publish settings`
- `Restrict to architecture`
- `Restrict to OS Versions`



```bash
$ hammer repository info --id=1


Id:                      1
Name:                    katello
Label:                   katello
......
Publish Settings:        
    Restrict to architecture: x86_64
    Restrict to OS Version:   rhel-7
....
```

For content view info it shows information along
- CVV Id
- CVV Name / CV name (if the cv has not been published or has any versions)
- Whether its the latest version
- Whether its been published
-  Whether component is set to `Always update to the latest`

```bash
$ hammer content-view info --id=6
Id:                     6
Name:                   composite
....

Components:             
 1) Id:                          9
    Name:                        foo 1.0
    Latest version:              yes
    Not yet published:           no
    Always update to the latest: yes
 2) Id:                          
    Name:                        unpublished-cv
    Latest version:              yes
    Not yet published:           yes
    Always update to the latest: yes
 3) Id:                          10
    Name:                        view 7.0
    Latest version:              yes
    Not yet published:           no
    Always update to the latest: no
```