### PR TITLE
Fixes 37235 - Add verify-checksum command for CV versions in hammer

### DIFF
--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -109,6 +109,19 @@ module HammerCLIKatello
       end
     end
 
+    class VerifyChecksum < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+
+      action :verify_checksum
+      command_name "verify-checksum"
+
+      success_message _("Verifying checksum of Content View Version repositories with task %{id}.")
+      failure_message _("Could not verify checksum of repositories in the Content View Version")
+      build_options do |o|
+        o.expand(:all).including(:content_views, :organizations)
+      end
+    end
+
     class PromoteCommand < HammerCLIKatello::SingleResourceCommand
       include HammerCLIForemanTasks::Async
       include LifecycleEnvironmentNameMapping


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
1. Add a hammer action for verify-checksum on CV versions
#### What are the testing steps for this pull request?
Run the command below with https://github.com/Katello/katello/pull/10923 checked out.
`hammer -r content-view version verify-checksum --id :id --organization "Default_Organization"`