### PR TITLE
Fixes #37415 - Add CLI support for repository verify checksum

### DIFF
--- a/lib/hammer_cli_katello/product.rb
+++ b/lib/hammer_cli_katello/product.rb
@@ -78,6 +78,7 @@ module HammerCLIKatello
     end
 
     class UpdateProxyCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
       desc _("Updates an HTTP Proxy for a product")
       resource :products_bulk_actions, :update_http_proxy
       command_name 'update-proxy'
@@ -88,6 +89,22 @@ module HammerCLIKatello
       validate_options do
         option(:option_ids).required
         option(:option_http_proxy_policy).required
+      end
+
+      build_options
+    end
+
+    class VerifyChecksumCommand < HammerCLIKatello::SingleResourceCommand
+      include HammerCLIForemanTasks::Async
+      desc _("Verify checksum for one or more products")
+      resource :products_bulk_actions, :verify_checksum_products
+      command_name 'verify-checksum'
+
+      success_message _("Verified checksum of product repositories with task %{id}.")
+      failure_message _("Could not verify checksum of repositories in the product")
+
+      validate_options do
+        option(:option_ids).required
       end
 
       build_options

--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -676,6 +676,32 @@ module HammerCLIKatello
       end
     end
 
+    class VerifyChecksum < HammerCLIKatello::SingleResourceCommand
+      extend RepositoryScopedToProduct
+      include HammerCLIForemanTasks::Async
+      include OrganizationOptions
+
+      validate_repo_name_requires_product_options
+      action :verify_checksum
+      command_name "verify-checksum"
+
+      success_message _("Verified checksum of repository with task %{id}.")
+      failure_message _("Could not verify checksum of repository")
+
+      validate_options :before, 'IdResolution' do
+        organization_options = [:option_organization_id, :option_organization_name, \
+                                :option_organization_label]
+
+        if option(:option_product_name).exist?
+          any(*organization_options).required
+        end
+      end
+
+      build_options do |o|
+        o.expand(:all).including(:products)
+      end
+    end
+
     class ReclaimSpaceCommand < HammerCLIKatello::SingleResourceCommand
       extend RepositoryScopedToProduct
       include HammerCLIForemanTasks::Async

--- a/test/functional/product/update_proxy_test.rb
+++ b/test/functional/product/update_proxy_test.rb
@@ -9,9 +9,8 @@ describe 'update an http proxy on a product' do
 
   let(:sync_response) do
     {
-      'id' => 1,
-      'state' => 'planned',
-      'action' => 'Update http proxy'
+      'id' => '1',
+      'state' => 'planned'
     }
   end
 
@@ -23,8 +22,8 @@ describe 'update an http proxy on a product' do
     ]
 
     ex = api_expects(:products_bulk_actions, :update_http_proxy, 'update an http-proxy')
-         .with_params('ids' => '1', 'http_proxy_policy' => 'use_selected_http_proxy',
-                      'http_proxy_id' => '1')
+         .with_params("ids" => [1], "http_proxy_policy" => "use_selected_http_proxy",
+                      "http_proxy_id" => 1)
     ex.returns(sync_response)
 
     expect_foreman_task('3')
@@ -34,15 +33,10 @@ describe 'update an http proxy on a product' do
   end
 
   it 'fails with missing required params' do
-    params = ['--proxy-id=1']
-
-    ex = api_expects(:products_bulk_actions, :update_http_proxy, 'update an http-proxy')
-         .with_params('proxy_id' => '1')
-    ex.returns(
-      'proxy_id' => '1'
-    )
-
+    params = ['--http-proxy-id=1']
+    api_expects_no_call
     result = run_cmd(@cmd + params)
-    assert_equal(result.exit_code, 70)
+    assert(result.err[/--ids is required/],
+       "ids requirements must be validated")
   end
 end

--- a/test/functional/product/verify_checksum_test.rb
+++ b/test/functional/product/verify_checksum_test.rb
@@ -1,0 +1,31 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe 'verify checksum on a product' do
+  include ForemanTaskHelpers
+
+  before do
+    @cmd = %w(product verify-checksum)
+  end
+
+  let(:sync_response) do
+    {
+      'id' => '1',
+      'state' => 'planned'
+    }
+  end
+
+  it 'verifies products ' do
+    params = [
+      '--ids=1'
+    ]
+
+    ex = api_expects(:products_bulk_actions, :verify_checksum_products, 'verify checksum')
+         .with_params('ids' => [1])
+    ex.returns(sync_response)
+
+    expect_foreman_task('3')
+
+    result = run_cmd(@cmd + params)
+    assert_equal(HammerCLI::EX_OK, result.exit_code)
+  end
+end

--- a/test/functional/repository/verify_checksum_test.rb
+++ b/test/functional/repository/verify_checksum_test.rb
@@ -1,0 +1,105 @@
+require_relative '../test_helper'
+require_relative '../organization/organization_helpers'
+require 'hammer_cli_katello/repository'
+module HammerCLIKatello
+  describe Repository::VerifyChecksum do
+    include OrganizationHelpers
+    it 'allows minimal options' do
+      api_expects(:repositories, :verify_checksum) do |p|
+        p['id'] == 1
+      end
+      run_cmd(%w(repository verify-checksum --id 1))
+    end
+
+    describe 'resolves repository ID' do
+      it 'by requiring product' do
+        api_expects_no_call
+        result = run_cmd(%w(repository verify-checksum --name repo1))
+        assert(result.err[/--product, --product-id is required/], 'Incorrect error message')
+      end
+
+      it 'by product ID' do
+        ex = api_expects(:repositories, :index) do |p|
+          p['name'] == 'repo1' && p['product_id'] == 3
+        end
+        ex.returns(index_response([{'id' => 1}]))
+
+        api_expects(:repositories, :verify_checksum) do |p|
+          p['id'] == 1
+        end
+
+        run_cmd(%w(repository verify-checksum --name repo1 --product-id 3))
+      end
+    end
+
+    describe 'resolves product ID' do
+      it 'by requiring organization options' do
+        api_expects_no_call
+        result = run_cmd(%w(repository verify-checksum --name repo1 --product prod1))
+        assert(result.err[/--organization-id, --organization, --organization-label is required/],
+               "Organization option requirements must be validated")
+      end
+
+      it 'by organization ID' do
+        ex = api_expects(:products, :index) do |p|
+          p['name'] == 'prod3' && p['organization_id'] == '5'
+        end
+        ex.returns(index_response([{'id' => 3}]))
+
+        ex = api_expects(:repositories, :index) do |p|
+          p['name'] == 'repo1' && p['product_id'] == 3
+        end
+        ex.returns(index_response([{'id' => 1}]))
+
+        api_expects(:repositories, :verify_checksum) do |p|
+          p['id'] == 1
+        end
+
+        run_cmd(%w(repository verify-checksum --name repo1 --product prod3 --organization-id 5
+                  ))
+      end
+
+      it 'by organization name' do
+        expect_organization_search('org5', 5)
+
+        ex = api_expects(:products, :index) do |p|
+          p['name'] == 'prod3' && p['organization_id'] == 5
+        end
+        ex.returns(index_response([{'id' => 3}]))
+
+        ex = api_expects(:repositories, :index) do |p|
+          p['name'] == 'repo1' && p['product_id'] == 3
+        end
+        ex.returns(index_response([{'id' => 1}]))
+
+        api_expects(:repositories, :verify_checksum) do |p|
+          p['id'] == 1
+        end
+
+        run_cmd(%w(repository verify-checksum --name repo1 --product prod3 --organization org5
+                  ))
+      end
+
+      it 'by organization label' do
+        expect_organization_search('org5', 5, field: 'label')
+
+        ex = api_expects(:products, :index) do |p|
+          p['name'] == 'prod3' && p['organization_id'] == 5
+        end
+        ex.returns(index_response([{'id' => 3}]))
+
+        ex = api_expects(:repositories, :index) do |p|
+          p['name'] == 'repo1' && p['product_id'] == 3
+        end
+        ex.returns(index_response([{'id' => 1}]))
+
+        api_expects(:repositories, :verify_checksum) do |p|
+          p['id'] == 1
+        end
+
+        run_cmd(%w(repository verify-checksum --name repo1 --product prod3 --organization-label org5
+                  ))
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
$ hammer repository  verify-checksum --id=2
[....................................................................................................................................................................] [100%]
Waiting to start.
--------------------------------
Identify corrupted units: 0/0
Identify missing units: 0/0
Repair corrupted units: 0/0
```


Product has 4 repositories so 4 tasks..
```
$ hammer product verify-checksum --ids=1
[....................................................................................................................................................................] [100%]
4 task(s), 4 success, 0 fail
```