### PR TITLE
Fixes #37721 - Hammer erratum list output is wrong when using content-view filter

### DIFF
--- a/lib/hammer_cli_katello/erratum.rb
+++ b/lib/hammer_cli_katello/erratum.rb
@@ -22,16 +22,27 @@ module HammerCLIKatello
       validate_options :before, 'IdResolution' do
         organization_options = [:option_organization_id, :option_organization_name, \
                                 :option_organization_label]
+        content_view_options = [:option_content_view_id, :option_content_view_name]
 
-        if option(:option_product_name).exist?
+        if option(:option_product_name).exist? || option(:option_content_view_name).exist?
           any(*organization_options).required
+        end
+
+        if option(:option_content_view_version_version).exist?
+          any(*content_view_options).required
+        end
+
+        if any(*content_view_options).exist?
+          any(:option_content_view_version_id,
+              :option_content_view_version_version,
+              :option_environment_id,
+              :option_environment_name).required
         end
       end
 
       build_options do |o|
         o.expand.including(:products, :organizations, :content_views)
       end
-
       extend_with(HammerCLIKatello::CommandExtensions::LifecycleEnvironment.new)
     end
 

--- a/lib/hammer_cli_katello/id_resolver.rb
+++ b/lib/hammer_cli_katello/id_resolver.rb
@@ -119,6 +119,9 @@ module HammerCLIKatello
     end
 
     # rubocop:disable Style/EmptyElse
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def content_view_version_id(options)
       key_id = HammerCLI.option_accessor_name("id")
       key_content_view_id = HammerCLI.option_accessor_name("content_view_id")
@@ -128,7 +131,16 @@ module HammerCLIKatello
 
       options[key_content_view_id] ||= search_and_rescue(:content_view_id, "content_view", options)
 
+      if options[key_content_view_id] && options['option_environment_name'] &&
+         options['option_environment_id'].nil?
+        lifecycle_environment_resource_name = (HammerCLIForeman.param_to_resource('environment') ||
+         HammerCLIForeman.param_to_resource('lifecycle_environment')).singular_name
+        options['option_environment_id'] = lifecycle_environment_id(
+          scoped_options(lifecycle_environment_resource_name, options, :single))
+      end
+
       results = find_resources(:content_view_versions, options)
+
       options[from_environment_id] ||= from_lifecycle_environment_id(options)
 
       return pick_result(results, @api.resource(:content_view_versions))['id'] if results.size == 1
@@ -145,6 +157,9 @@ module HammerCLIKatello
       end
     end
     # rubocop:enable Style/EmptyElse
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     private
 


### PR DESCRIPTION
Add some validations around --content-view filter for errata lists.

1. If you're using cv-name, hammer needs to know org id to fetch the cv-id
2. Errata belongs to cv versions and not cv directly so if you're using --content-view(-id) filter, you also need to provide --environment params to fetch the exact cvv.
3. The --environment param was not working. Only the environment-id param was. This should fix that.

To test this create a CV with repo with some errata and publish it to a version promoted to any environment.

Then run:
hammer erratum list --content-view='RHEL7' --cve="CVE-2023-45288" --lifecycle-environment-id=1
 with different params passed to m,ake sure it all looks ok.
