### PR TITLE
Declare compatible with Ruby < 4

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |gem|
   gem.name = 'hammer_cli_katello'
   gem.require_paths = ['lib']
   gem.version = HammerCLIKatello.version
-  gem.required_ruby_version = '>= 2.7', '< 3.2'
+  gem.required_ruby_version = '>= 2.7', '< 4'
 
   gem.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 


### PR DESCRIPTION
This helps developers on current Fedora where either Ruby 3.2 (f39) or Ruby 3.3 (f40) is used.