### PR TITLE
Fixes #37894 - Add content-view-environments list command

### DIFF
--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -60,6 +60,12 @@ module HammerCLIKatello
                                          'hammer_cli_katello/lifecycle_environment'
                                         )
 
+  HammerCLI::MainCommand.lazy_subcommand("content-view-environment",
+                                         _("Manipulate content view environments"),
+                                         'HammerCLIKatello::ContentViewEnvironment',
+                                         'hammer_cli_katello/content_view_environment'
+                                        )
+
   HammerCLI::MainCommand.lazy_subcommand("product", _("Manipulate products"),
                                          'HammerCLIKatello::Product',
                                          'hammer_cli_katello/product'

--- a/lib/hammer_cli_katello/content_view_environment.rb
+++ b/lib/hammer_cli_katello/content_view_environment.rb
@@ -1,0 +1,27 @@
+module HammerCLIKatello
+  class ContentViewEnvironment < HammerCLIKatello::Command
+    resource :content_view_environments
+
+    class ListCommand < HammerCLIKatello::ListCommand
+      output do
+        field :id, _("Id")
+        field :label, _("Label")
+        from :environment do
+          field :name, _("Lifecycle Environment")
+        end
+        from :content_view do
+          field :name, _("Content View")
+        end
+        field :default, _("Default")
+        field :hosts_count, _("Hosts Count")
+        from :organization do
+          field :name, _("Organization")
+        end
+      end
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/11170

```
$ hammer content-view-environment list

---|-------------|-----------------------|---------------------------|---------|-------------|---------------------
ID | LABEL       | LIFECYCLE ENVIRONMENT | CONTENT VIEW              | DEFAULT | HOSTS COUNT | ORGANIZATION        
---|-------------|-----------------------|---------------------------|---------|-------------|---------------------
1  | Library     | Library               | Default Organization View | true    | 0           | Default Organization
2  | Library     | Library               | Default Organization View | true    | 0           | org2                
3  | Library/cv1 | Library               | cv1                       | false   | 1           | Default Organization
---|-------------|-----------------------|---------------------------|---------|-------------|---------------------
```
