### PR TITLE
Fix filtering of debs

### DIFF
--- a/lib/hammer_cli_katello/foreman_search_options_creators.rb
+++ b/lib/hammer_cli_katello/foreman_search_options_creators.rb
@@ -28,6 +28,10 @@ module HammerCLIKatello
       create_search_options_without_katello_api(options, api.resource(:operatingsystems), mode)
     end
 
+    def create_debs_search_options(options, mode = nil)
+      create_search_options_without_katello_api(options, api.resource(:debs), mode)
+    end
+
     def create_domains_search_options(options, mode = nil)
       create_search_options_without_katello_api(options, api.resource(:domains), mode)
     end


### PR DESCRIPTION
Filter for deb-packages did not use the 'search' parameter. This meant the request returned all deb-packages instead of the filtered ones:
```
$ hammer --debug content-view version incremental-update --content-view-version-id 40 --lifecycle-environment-ids 7 --debs odin,thor
...
[ INFO 2024-10-17T16:50:32 API] Server: https://centos9-katello-devel.example.com/
[ INFO 2024-10-17T16:50:32 API] GET /katello/api/debs
[DEBUG 2024-10-17T16:50:32 API] Params: {
       "name" => "thor",
    :per_page => 1000,
        :page => 1
}
[DEBUG 2024-10-17T16:50:32 API] Headers: {
    :params => {
           "name" => "thor",
        :per_page => 1000,
            :page => 1
    }
}
