### PR TITLE
Refs #37894 - Add activation keys count to CVE list

### DIFF
--- a/lib/hammer_cli_katello/content_view_environment.rb
+++ b/lib/hammer_cli_katello/content_view_environment.rb
@@ -6,7 +6,7 @@ module HammerCLIKatello
       output do
         field :id, _("Id")
         field :label, _("Label")
-        from :environment do
+        from :lifecycle_environment do
           field :name, _("Lifecycle Environment")
         end
         from :content_view do
@@ -14,6 +14,7 @@ module HammerCLIKatello
         end
         field :default, _("Default")
         field :hosts_count, _("Hosts Count")
+        field :activation_keys_count, _("Activation Keys Count")
         from :organization do
           field :name, _("Organization")
         end


### PR DESCRIPTION
Activation keys count was just added to the API. This adds it to Hammer output.
Requires https://github.com/Katello/katello/pull/11170

```
# hammer content-view-environment list
---|---------|-----------------------|---------------------------|---------|-------------|-----------------------|---------------------
ID | LABEL   | LIFECYCLE ENVIRONMENT | CONTENT VIEW              | DEFAULT | HOSTS COUNT | ACTIVATION KEYS COUNT | ORGANIZATION        
---|---------|-----------------------|---------------------------|---------|-------------|-----------------------|---------------------
1  | Library | Library               | Default Organization View | true    | 1           | 1                     | Default Organization
---|---------|-----------------------|---------------------------|---------|-------------|-----------------------|---------------------
```

