### PR TITLE
Fixes #37948 - Update host output for MultiCV to match AK output

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -55,7 +55,7 @@ module HammerCLIKatello
         field :format_consumed, _("Host Limit")
         field :multi_content_view_environment, _("Multi Content View Environment"), Fields::Boolean
         field :release_version, _("Release Version"), Fields::Field, :hide_blank => true
-        field :content_view_environment_labels, _("Content View Environments"), Fields::Field
+        field :content_view_environment_labels, _("Content View Environment Labels"), Fields::Field
 
         collection :organization, _("Organization") do
           field :id, _("Id"), Fields::Field, :hide_blank => true

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -26,12 +26,10 @@ module HammerCLIKatello
     ::HammerCLIForeman::Host::ListCommand.instance_eval do
       output do
         from :content_facet_attributes do
-          from :content_view do
-            field :name, _('Content View'), Fields::List
-          end
-          from :lifecycle_environment do
-            field :name, _('Lifecycle environment'), Fields::List
-          end
+          field :content_view_environment_labels, _("Content View Environments"),
+                                              Fields::List, :max_width => 300
+          field :multi_content_view_environment,
+                _("Multi Content View Environment"), Fields::Boolean
           from :errata_counts do
             field :security, _("Security"), nil, :sets => ['ALL']
             field :bugfix, _("Bugfix"), nil, :sets => ['ALL']
@@ -46,7 +44,9 @@ module HammerCLIKatello
       output do
         label _('Content Information') do
           from :content_facet_attributes do
-            collection :content_view_environments, _('Content view environments') do
+            field :content_view_environment_labels,
+                  _("Content View Environment Labels"), Fields::Field
+            collection :content_view_environments, _('Content View Environments') do
               from :content_view do
                 label _("Content view") do
                   field :id, _("Id")
@@ -60,6 +60,7 @@ module HammerCLIKatello
                   field :name, _("Name")
                 end
               end
+              field :label, _("Label")
             end
 
             label _("Content Source") do

--- a/test/functional/host/extensions/data/host_list.json
+++ b/test/functional/host/extensions/data/host_list.json
@@ -95,6 +95,27 @@
                "id":1,
                "name":"Library"
             },
+            "content_view_environment_labels": "Library",
+            "multi_content_view_environment": false,
+            "content_view_environments": [
+               {
+                  "content_view": {
+                        "id": 1,
+                        "name": "Default Organization View",
+                        "composite": false,
+                        "content_view_version": "1.0",
+                        "content_view_version_id": 1,
+                        "content_view_version_latest": true,
+                        "content_view_default": true
+                  },
+                  "lifecycle_environment": {
+                        "id": 1,
+                        "name": "Library",
+                        "lifecycle_environment_library": true
+                  },
+                  "label": "Library"
+               }
+            ],
             "errata_counts":{
                "security":0,
                "bugfix":0,

--- a/test/functional/host/extensions/list_test.rb
+++ b/test/functional/host/extensions/list_test.rb
@@ -13,8 +13,8 @@ describe 'host list' do
 
     result = run_cmd(@cmd)
 
-    fields = ['CONTENT VIEW', 'LIFECYCLE ENVIRONMENT', 'TRACE STATUS']
-    values = ['Default Organization View', 'Library', 'updated']
+    fields = ['CONTENT VIEW ENVIRONMENTS', 'MULTI CONTENT VIEW ENVIRONMENT', 'TRACE STATUS']
+    values = ['Library', 'no', 'updated']
     expected_result = success_result(IndexMatcher.new([fields, values]))
     assert_cmd(expected_result, result)
   end


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/11194

1. Add some tidbits to `hammer host info`, namely `Content View Environment Labels` and `Label`

```
Content Information:      
    Content View Environment Labels: lce2/cv2,lce1/cv1
    Content View Environments:       
     1) Content view:          
            Id:        3
            Name:      cv2
            Composite: no
        Lifecycle environment: 
            Id:   3
            Name: lce2
        Label:                 lce2/cv2
```
2. Add `Label` to `hammer activation-key info` for consistency.

3. Add columns to `hammer host list` (removing the `CONTENT VIEW` and `LIFECYCLE ENVIRONMENT` columns):

```
CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONMENT
```