### PR TITLE
Fixes #38014 - Add safe navigation for empty capsule content counts

### DIFF
--- a/lib/hammer_cli_katello/capsule.rb
+++ b/lib/hammer_cli_katello/capsule.rb
@@ -248,14 +248,16 @@ module HammerCLIKatello
 
         private
 
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def extend_data(data)
-          data["lifecycle_environments"].each do |lce|
-            lce["content_views"].each do |cv|
-              cv["repositories"].each do |repo|
+          data["lifecycle_environments"]&.each do |lce|
+            lce["content_views"]&.each do |cv|
+              cv["repositories"]&.each do |repo|
                 if cv["up_to_date"] && !data.dig("content_counts").nil?
                   cvv_count_repos = data.dig("content_counts", "content_view_versions",
                     cv["cvv_id"].to_s, "repositories")
-                  cvv_count_repos.each do |_repo_id, counts_and_metadata|
+                  cvv_count_repos&.each do |_repo_id, counts_and_metadata|
                     if counts_and_metadata.
                        dig("metadata", "library_instance_id") == repo["library_id"] &&
                        counts_and_metadata.dig("metadata", "env_id") == lce["id"]
@@ -272,7 +274,8 @@ module HammerCLIKatello
           end
           data
         end
-
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
         build_options
       end
 

--- a/test/functional/capsule/content/data/empty_counts.json
+++ b/test/functional/capsule/content/data/empty_counts.json
@@ -1,0 +1,7 @@
+{
+  "last_sync_time": "2016-01-10 00:27:51 +0100",
+  "active_sync_tasks": [],
+  "last_failed_sync_tasks": [],
+  "lifecycle_environments": [],
+  "content_counts": {}
+}

--- a/test/functional/capsule/content/info_test.rb
+++ b/test/functional/capsule/content/info_test.rb
@@ -53,6 +53,37 @@ describe 'capsule content info' do
     assert_cmd(expected_result, result)
   end
 
+  it "works with content counts being an empty hash" do
+    @sync_status = load_json('./data/sync_status_no_counts.json', __FILE__)
+    @sync_status['lifecycle_environments'] = [
+      load_json('./data/library_env.json', __FILE__),
+      load_json('./data/empty_counts.json', __FILE__)
+    ]
+
+    ex = api_expects(:capsule_content, :sync_status, 'Get sync info') do |par|
+      par['id'] == 3
+    end
+    ex.returns(@sync_status)
+
+    output = OutputMatcher.new([
+      "Lifecycle Environments:",
+      " 1) Name:          Library",
+      "    Organization:  Default Organization",
+      "    Content Views:",
+      "     1) Name:           Zoo View",
+      "        Composite:      no",
+      "        Last Published: 2023/10/09 19:18:15",
+      "        Repositories:",
+      "         1) Repository ID:   2",
+      "            Repository Name: Zoo",
+      "            Content Counts:"
+    ])
+    expected_result = success_result(output)
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
   it "works with no content counts" do
     @sync_status = load_json('./data/sync_status_no_counts.json', __FILE__)
     @sync_status['lifecycle_environments'] = [


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
* There is an action in Katello that can cause capsule content counts to be an empty hash, we don't safely navigate in Ruby to handle this and hammer blows up with a traceback causing a bad user experience. @sjha4 can probably add more context on how it happens.

* Added some unit tests to account for the empty hash and to make sure we handle it correctly

#### What are the testing steps for this pull request?
* Spin up a Satellite/Capsule or if you have a katello devel box add a smartproxy to it
* Have a Satellite with external Capsule, turn automatic content count calculation off.
* Create an LCE, assign it to the Capsule.
* Create and sync some repo (fake_yum1)
* Create a CV, add the repo to it, publish and promote to the LCE -> Capsule gets autosynced.
* On the Satellite/Devel box run the following:
* `foo = SmartProxy.find(X)`
* `foo.content_counts = {}`
* `foo.save`
* On Satellite try `hammer capsule content info --id X
* Apply PR and see if it shows the Capsule content info without a traceback