### PR TITLE
Fixes #38054 - Add full GPG Key URL to repo info

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -110,6 +110,7 @@ module HammerCLIKatello
             field :id, _("Id"), Fields::Field, :hide_blank => true
             field :name, _("Name"), Fields::Field, :hide_blank => true
           end
+          field :full_gpg_key_path, _("GPG Key Path"), Fields::Field, :hide_blank => true
         end
 
         label _("Sync") do


### PR DESCRIPTION
@sbernhard Here is the hammer PR:

Before:
```bash
Id:                      1
Name:                    Zoo
Label:                   Zoo
Description:
Organization:            Default Organization
Red Hat Repository:      no
Content Type:            yum
Content Label:           Default_Organization_Custom_Zoo
Mirroring Policy:        Content Only
Url:                     https://fixtures.pulpproject.org/rpm-no-comps/
Publish Via HTTP:        yes
Published At:            https://ip-10-0-168-170.rhos-01.prod.psi.rdu2.redhat.com/pulp/content/Default_Organization/Library/custom/Custom/Zoo/
Relative Path:           Default_Organization/Library/custom/Custom/Zoo
Download Policy:         immediate
Ignorable Content Units:
Publish Settings:
    Restrict to architecture: No restriction
    Restrict to OS Version:   No restriction
HTTP Proxy:
    HTTP Proxy Policy: global_default_http_proxy
Product:
    Id:   1
    Name: Custom
GPG Key:
    Id:   1
    Name: Capsule
```

After:
```bash
Id:                      1
Name:                    Zoo
Label:                   Zoo
Description:
Organization:            Default Organization
Red Hat Repository:      no
Content Type:            yum
Content Label:           Default_Organization_Custom_Zoo
Mirroring Policy:        Content Only
Url:                     https://fixtures.pulpproject.org/rpm-no-comps/
Publish Via HTTP:        yes
Published At:            https://ip-10-0-168-170.rhos-01.prod.psi.rdu2.redhat.com/pulp/content/Default_Organization/Library/custom/Custom/Zoo/
Relative Path:           Default_Organization/Library/custom/Custom/Zoo
Download Policy:         immediate
Ignorable Content Units:
Publish Settings:
    Restrict to architecture: No restriction
    Restrict to OS Version:   No restriction
HTTP Proxy:
    HTTP Proxy Policy: global_default_http_proxy
Product:
    Id:   1
    Name: Custom
GPG Key:
    Id:           1
    Name:         Capsule
    GPG Key Path: https://ip-10-0-168-170.rhos-01.prod.psi.rdu2.redhat.com/katello/api/v2/repositories/1/gpg_key_content
```