### PR TITLE
Fixes #37151 - Add --force flag to content overrides

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Encoding:
   Enabled: false
 
 LineLength:
-  Max: 100
+  Max: 150
 
 FormatString:
   Enabled: false # we use % for i18n

--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
 
 require 'hammer_cli_katello/version'
 
-# rubocop:disable Layout/LineLength
 begin
   Dir["locale/**/*.po"].each do |po|
     mo = po.sub(/hammer_cli_katello\.po$/, "LC_MESSAGES/hammer_cli_katello.mo")
@@ -15,7 +14,6 @@ begin
 rescue => e
   puts "#{e} not found"
 end
-# rubocop:enable Layout/LineLength
 
 Gem::Specification.new do |gem|
   gem.authors = [

--- a/lib/hammer_cli_katello.rb
+++ b/lib/hammer_cli_katello.rb
@@ -43,7 +43,7 @@ module HammerCLIKatello
                                           'hammer_cli_katello/organization'
                                          )
 
-  HammerCLI::MainCommand.lazy_subcommand!("alternate-content-source", _("Manipulate alternate content sources"), # rubocop:disable LineLength
+  HammerCLI::MainCommand.lazy_subcommand!("alternate-content-source", _("Manipulate alternate content sources"),
                                          'HammerCLIKatello::AcsCommand',
                                          'hammer_cli_katello/acs'
                                          )

--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -107,9 +107,8 @@ module HammerCLIKatello
       end
 
       def extend_data(data)
-        # rubocop:disable Layout/LineLength
         # Hack to hide purpose addons if it's not set since it's not possible to hide the Fields::List values
-        data["purpose_addons"].length.positive? ? data["purpose_addons"] = data["purpose_addons"] : data["purpose_addons"] = nil
+        data["purpose_addons"] = data["purpose_addons"].length.positive? ? data["purpose_addons"] : nil
         limit = data["unlimited_hosts"] ? _("Unlimited") : data["max_hosts"]
 
         data["format_consumed"] = _("%{consumed} of %{limit}") %
@@ -118,7 +117,6 @@ module HammerCLIKatello
                                     :limit => limit
                                   }
         data
-        # rubocop:enable Layout/LineLength
       end
 
       build_options

--- a/lib/hammer_cli_katello/command_extensions/kickstart_repository.rb
+++ b/lib/hammer_cli_katello/command_extensions/kickstart_repository.rb
@@ -23,11 +23,9 @@ module HammerCLIKatello
           raise _('Please provide --lifecycle-environment-id') unless env_id
 
           raise _('Please provide --content-view-id') unless cv_id
-          # rubocop:disable LineLength
           resource_hash['kickstart_repository_id'] = HammerCLIKatello::CommandExtensions::KickstartRepository.fetch_repo_id(
             cv_id, env_id, cmd_obj.option_kickstart_repository
           )
-          # rubocop:enable LineLength
         end
       end
 

--- a/lib/hammer_cli_katello/content_override.rb
+++ b/lib/hammer_cli_katello/content_override.rb
@@ -8,6 +8,9 @@ module HammerCLIKatello
         success_message _("Updated content override.")
         failure_message _("Could not update content override")
 
+        option "--force", "FORCE", _("Force the override. Required for overrides other than 'enabled'"),
+                :attribute_name => :option_force, default: false
+
         option "--content-label", "CONTENT_LABEL", _("Label of the content"),
                :attribute_name => :option_content_label, :required => true
 
@@ -28,6 +31,10 @@ module HammerCLIKatello
           if option(:option_remove).exist?
             option(:option_value).rejected
           elsif option(:option_value).exist?
+            if !@option_values['option_value'].casecmp('enabled').zero? &&
+               @option_values['option_force'] == false
+              raise ArgumentError, _("You must use --force to set a value other than 'enabled'")
+            end
             option(:option_remove).rejected
           end
         end

--- a/lib/hammer_cli_katello/content_view.rb
+++ b/lib/hammer_cli_katello/content_view.rb
@@ -26,7 +26,6 @@ module HammerCLIKatello
 
     class InfoCommand < HammerCLIKatello::InfoCommand
       include OrganizationOptions
-      # rubocop:disable Layout/LineLength
 
       output do
         field :id, _("Id")
@@ -137,7 +136,6 @@ module HammerCLIKatello
 
       build_options
     end
-    # rubocop:enable Layout/LineLength
 
     class CreateCommand < HammerCLIKatello::CreateCommand
       success_message _("Content view created.")

--- a/lib/hammer_cli_katello/content_view_version.rb
+++ b/lib/hammer_cli_katello/content_view_version.rb
@@ -65,9 +65,7 @@ module HammerCLIKatello
               field :content, _('Type')
               field :inclusion, _('Inclusion'), Fields::Boolean
               field :original_packages, _('Original packages'), Fields::Boolean, hide_blank: true
-              # rubocop:disable Layout/LineLength
               field :original_module_streams, _('Original module streams'), Fields::Boolean, hide_blank: true
-              # rubocop:enable Layout/LineLength
             end
             collection :rules, _("Rules"), hide_blank: true, hide_empty: true do
               field :id, _('Id')

--- a/test/functional/activation_key/content_override_test.rb
+++ b/test/functional/activation_key/content_override_test.rb
@@ -5,9 +5,9 @@ describe 'activation-key content-override' do
   before do
     @cmd = %w(activation-key content-override)
   end
-  it "attaches a content label" do
+  it "attaches a content override" do
     label = "foo"
-    value = '1'
+    value = 'enabled'
     id = 20
     params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}"]
     ex = api_expects(:activation_keys, :content_override) do |par|
@@ -23,9 +23,9 @@ describe 'activation-key content-override' do
     assert_cmd(expected_result, result)
   end
 
-  it "attaches a content label with name" do
+  it "attaches a content override with name" do
     label = "foo"
-    value = '1'
+    value = 'enabled'
     id = 20
     name = 'protected'
     params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}",
@@ -41,6 +41,36 @@ describe 'activation-key content-override' do
 
     result = run_cmd(@cmd + params)
     assert_cmd(expected_result, result)
+  end
+
+  it "attaches a content override with value other than enabled using --force" do
+    label = "foo"
+    value = '1'
+    id = 20
+    name = 'protected'
+    params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}",
+              "--override-name=#{name}", "--force"]
+    ex = api_expects(:activation_keys, :content_override) do |par|
+      par['id'] == id && par["content_overrides"][0]['content_label'] == label &&
+        par['content_overrides'][0]['value'] == value &&
+        par['content_overrides'][0]['name'] == name
+    end
+    ex.returns({})
+
+    expected_result = success_result("Updated content override.\n")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected_result, result)
+  end
+
+  it "does not attach a content override with value other than enabled without --force" do
+    api_expects_no_call
+    error_msg = "Could not update content override:\n" \
+            "  You must use --force to set a value other than 'enabled'"
+
+    assert_failure run_cmd(%w(activation-key content-override --id=20 --content-label=foo --value=1 --override-name=protected)), error_msg
+    result = run_cmd(%w(activation-key content-override id=20 --content-label=foo --value=1 --override-name=protected))
+    assert_equal 64, result.exit_code
   end
 
   it "removes override" do

--- a/test/functional/activation_key/list_test.rb
+++ b/test/functional/activation_key/list_test.rb
@@ -35,7 +35,6 @@ describe 'listing activation-keys' do
     end
 
     ex.returns(empty_response)
-    # rubocop:disable Layout/LineLength
     expected_result = success_result("---|------|------------|---------------------------|-------------------------------
 ID | NAME | HOST LIMIT | CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONMENT
 ---|------|------------|---------------------------|-------------------------------
@@ -44,7 +43,6 @@ ID | NAME | HOST LIMIT | CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONM
     result = run_cmd(@cmd + params)
     assert_cmd(expected_result, result)
   end
-  # rubocop:enable Layout/LineLength
 
   it "lists the activation-keys belonging to a lifecycle environment by name" do
     params = ["--organization-id=#{org_id}", '--lifecycle-environment=test']
@@ -57,7 +55,6 @@ ID | NAME | HOST LIMIT | CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONM
     end
 
     ex.returns(empty_response)
-    # rubocop:disable Layout/LineLength
     expected_result = success_result("---|------|------------|---------------------------|-------------------------------
 ID | NAME | HOST LIMIT | CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONMENT
 ---|------|------------|---------------------------|-------------------------------
@@ -66,5 +63,4 @@ ID | NAME | HOST LIMIT | CONTENT VIEW ENVIRONMENTS | MULTI CONTENT VIEW ENVIRONM
     result = run_cmd(@cmd + params)
     assert_cmd(expected_result, result)
   end
-  # rubocop:enable Layout/LineLength
 end

--- a/test/functional/content_export/list_test.rb
+++ b/test/functional/content_export/list_test.rb
@@ -22,12 +22,10 @@ describe 'content-export list' do
     ex = api_expects(:content_exports, :index)
 
     ex.returns(empty_response)
-    # rubocop:disable LineLength
     expected_result = success_result('---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ID | DESTINATION SERVER | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-export list))
     assert_cmd(expected_result, result)
   end
@@ -38,12 +36,10 @@ ID | DESTINATION SERVER | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERS
     ex = api_expects(:content_exports, :index)
 
     ex.returns(empty_response)
-    # rubocop:disable LineLength
     expected_result = success_result('---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ID | DESTINATION SERVER | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-export list --content-view-id=1))
     assert_cmd(expected_result, result)
   end
@@ -52,12 +48,10 @@ ID | DESTINATION SERVER | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERS
     ex = api_expects(:content_exports, :index)
 
     ex.returns(empty_response)
-    # rubocop:disable LineLength
     expected_result = success_result('---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ID | DESTINATION SERVER | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|--------------------|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-export list --content-view-version-id=1))
     assert_cmd(expected_result, result)
   end

--- a/test/functional/content_import/list_test.rb
+++ b/test/functional/content_import/list_test.rb
@@ -23,12 +23,10 @@ describe 'content-import list' do
 
     ex.returns(empty_response)
 
-    # rubocop:disable LineLength
     expected_result = success_result('---|------|------|----------------------|-------------------------|------------|-----------
 ID | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-import list))
     assert_cmd(expected_result, result)
   end
@@ -39,12 +37,10 @@ ID | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT |
     ex = api_expects(:content_imports, :index)
 
     ex.returns(empty_response)
-    # rubocop:disable LineLength
     expected_result = success_result('---|------|------|----------------------|-------------------------|------------|-----------
 ID | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-import list --content-view-id=1))
     assert_cmd(expected_result, result)
   end
@@ -53,12 +49,10 @@ ID | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT |
     ex = api_expects(:content_imports, :index)
 
     ex.returns(empty_response)
-    # rubocop:disable LineLength
     expected_result = success_result('---|------|------|----------------------|-------------------------|------------|-----------
 ID | PATH | TYPE | CONTENT VIEW VERSION | CONTENT VIEW VERSION ID | CREATED AT | UPDATED AT
 ---|------|------|----------------------|-------------------------|------------|-----------
 ')
-    # rubocop:enable LineLength
     result = run_cmd(%w(content-import list --content-view-version-id=1))
     assert_cmd(expected_result, result)
   end

--- a/test/functional/content_units/list_test.rb
+++ b/test/functional/content_units/list_test.rb
@@ -41,7 +41,6 @@ module HammerCLIKatello
         assert(r.err.include?("--product, --product-id is required"), "Invalid error message")
       end
 
-      # rubocop:disable LineLength
       it 'may be specified by name and product ID' do
         expect_repository_search(2, 'repo1', 1)
 
@@ -49,7 +48,6 @@ module HammerCLIKatello
           .with_params('content_type' => 'python_package', 'repository_id' => 1)
         run_cmd(%w(content-units list --content-type python_package --repository repo1 --product-id 2))
       end
-      # rubocop:enable LineLength
     end
 
     describe 'organization options' do
@@ -78,7 +76,6 @@ module HammerCLIKatello
     end
 
     describe 'content-view options' do
-      # rubocop:disable LineLength
       it 'may be specified by ID' do
         api_expects(:content_view_versions, :index)
           .with_params('content_view_id' => 1, 'version' => '2.1')
@@ -100,7 +97,6 @@ module HammerCLIKatello
         expected_error = "--organization-id, --organization, --organization-label is required"
         assert(r.err.include?(expected_error), "Invalid error message")
       end
-      # rubocop:enable LineLength
     end
   end
 end

--- a/test/functional/repository/update_test.rb
+++ b/test/functional/repository/update_test.rb
@@ -47,9 +47,7 @@ module HammerCLIKatello
               .with_params('id' => upload_id, 'repository_id' => repo_id)
 
         ex3.returns("")
-        # rubocop:disable LineLength
         result = run_cmd(%W(repository update --id #{repo_id} --docker-tag #{tag_name} --docker-digest #{digest}))
-        # rubocop:enable LineLength
         assert_equal(result.exit_code, 0)
       end
     end

--- a/test/functional/repository/upload_test.rb
+++ b/test/functional/repository/upload_test.rb
@@ -40,7 +40,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                        :uploads => [{
@@ -51,7 +50,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
 
     ex2.returns(import_uploads_response)
     expect_foreman_task(task_id)
@@ -76,7 +74,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :content_type => 'srpm', :async => true,
                        :uploads => [{
@@ -87,7 +84,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
 
     ex2.returns(import_uploads_response)
     expect_foreman_task(task_id)
@@ -113,7 +109,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                        :uploads => [{
@@ -124,7 +119,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
 
     ex2.returns(400)
 
@@ -148,7 +142,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                        :uploads => [{
@@ -159,7 +152,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
 
     ex2.returns(import_uploads_response)
     expect_foreman_task(task_id)
@@ -195,7 +187,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                        :uploads => [{
@@ -206,7 +197,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
 
     ex2.returns(import_uploads_response)
     expect_foreman_task(task_id)
@@ -231,7 +221,6 @@ describe 'upload repository' do
          .with_params(:repository_id => repo_id, :size => file.size)
 
     ex.returns(upload_response)
-    # rubocop:disable LineLength
     ex2 = api_expects(:repositories, :import_uploads, 'Take in an upload')
           .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                        :uploads => [{
@@ -242,7 +231,6 @@ describe 'upload repository' do
                          :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                        }]
                       )
-    # rubocop:enable LineLength
     ex2.returns(import_uploads_response)
     expect_foreman_task(task_id)
     expect_foreman_task(task_id)
@@ -270,7 +258,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex = api_expects(:repositories, :import_uploads, 'Take in an upload')
          .with_params(:id => repo_id, :sync_capsule => false, :publish_repository => false, :async => true,
                       :uploads => [{
@@ -281,7 +268,6 @@ describe 'upload repository' do
                         :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                       }]
                      )
-    # rubocop:enable LineLength
 
     ex.returns(import_uploads_response)
     expect_foreman_task(task_id)
@@ -299,7 +285,6 @@ describe 'upload repository' do
 
     ex.returns(upload_response)
 
-    # rubocop:disable LineLength
     ex = api_expects(:repositories, :import_uploads, 'Take in an upload')
          .with_params(:id => repo_id, :sync_capsule => true, :publish_repository => true, :async => true,
                       :uploads => [{
@@ -310,7 +295,6 @@ describe 'upload repository' do
                         :checksum => 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                       }]
                      )
-    # rubocop:enable LineLength
 
     ex.returns(import_uploads_response)
     expect_foreman_task(task_id)


### PR DESCRIPTION
We only support enabled as a value on content overrides, adding a flag that makes the user add --force for anything other than enabled. Increased the line length to 150 from discussions with Quinn on my last PR since Katello is at 200.

@jeremylenz github was down earlier and was stuck pushing my changes, after it finished 30 mins later it closed my pr and I can't open it again saying the branch was force pushed to. So here is the updated pr with the changes you requested in https://github.com/Katello/hammer-cli-katello/pull/973