### PR TITLE
Fixes #38065 - Remove syspurpose addons from hammer

### DIFF
--- a/lib/hammer_cli_katello/activation_key.rb
+++ b/lib/hammer_cli_katello/activation_key.rb
@@ -102,13 +102,10 @@ module HammerCLIKatello
           field :service_level, _('Service Level'), Fields::Field, :hide_blank => true
           field :purpose_usage, _('Purpose Usage'), Fields::Field, :hide_blank => true
           field :purpose_role, _('Purpose Role'), Fields::Field, :hide_blank => true
-          field :purpose_addons, _('Purpose Addons'), Fields::List, :hide_blank => true
         end
       end
 
       def extend_data(data)
-        # Hack to hide purpose addons if it's not set since it's not possible to hide the Fields::List values
-        data["purpose_addons"] = data["purpose_addons"].length.positive? ? data["purpose_addons"] : nil
         limit = data["unlimited_hosts"] ? _("Unlimited") : data["max_hosts"]
 
         data["format_consumed"] = _("%{consumed} of %{limit}") %

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -109,7 +109,6 @@ module HammerCLIKatello
               field :service_level, _('Service Level')
               field :purpose_usage, _('Purpose Usage')
               field :purpose_role, _('Purpose Role')
-              field :purpose_addons, _('Purpose Addons'), Fields::List
             end
           end
         end

--- a/test/functional/activation_key/data/activation_key.json
+++ b/test/functional/activation_key/data/activation_key.json
@@ -13,7 +13,6 @@
     "name": "Library",
     "id": 1
   },
-  "purpose_addons": "Test Addon1, Test Addon2",
   "multi_content_view_environment": true,
   "organization": {
     "name": "Default Organization",

--- a/test/functional/activation_key/info_test.rb
+++ b/test/functional/activation_key/info_test.rb
@@ -22,7 +22,6 @@ describe 'activation-key info' do
                        ['Description', 'Activation key'],
                        ['Purpose Usage', 'Usage'],
                        ['Purpose Role', 'Role'],
-                       ['Purpose Addons', 'Test Addon1, Test Addon2'],
                        ['Multi Content View Environment', 'yes'],
                        ['Organization', ''],
                        ['Id', '1'],

--- a/test/functional/host/extensions/data/host.json
+++ b/test/functional/host/extensions/data/host.json
@@ -117,7 +117,6 @@
       "release_version":"7Server",
       "purpose_usage":"Production",
       "purpose_role":"Role",
-      "purpose_addons":"Test Addon1, Test Addon2",
       "autoheal":true,
       "registered_at":"2016-05-26 10:46:22 -0400",
       "activation_keys":[

--- a/test/functional/host/extensions/info_test.rb
+++ b/test/functional/host/extensions/info_test.rb
@@ -26,7 +26,6 @@ describe 'host info' do
                        ['Upgradable Packages', '4'],
                        ['Purpose Usage', 'Production'],
                        ['Purpose Role', 'Role'],
-                       ['Purpose Addons', 'Test Addon1, Test Addon2'],
                        ['Trace Status', 'Updated'],
                        ['Running image', 'potato'],
                        ['Running image digest',


### PR DESCRIPTION
Removing all the syspurpose addon stuff from hammer. Look around in the code and see if I missed anything. As long as tests pass it should be good to merge. 