### PR TITLE
Refs #37151 - Fix --force flag to use option_override_name

### DIFF
--- a/lib/hammer_cli_katello/content_override.rb
+++ b/lib/hammer_cli_katello/content_override.rb
@@ -31,7 +31,7 @@ module HammerCLIKatello
           if option(:option_remove).exist?
             option(:option_value).rejected
           elsif option(:option_value).exist?
-            if !@option_values['option_value'].casecmp('enabled').zero? &&
+            if !@option_values['option_override_name'].casecmp('enabled').zero? &&
                @option_values['option_force'] == false
               raise ArgumentError, _("You must use --force to set a value other than 'enabled'")
             end

--- a/lib/hammer_cli_katello/content_override.rb
+++ b/lib/hammer_cli_katello/content_override.rb
@@ -33,7 +33,7 @@ module HammerCLIKatello
           elsif option(:option_value).exist?
             if !@option_values['option_override_name'].casecmp('enabled').zero? &&
                @option_values['option_force'] == false
-              raise ArgumentError, _("You must use --force to set a value other than 'enabled'")
+              raise ArgumentError, _("You must use --force to set an override other than 'enabled'")
             end
             option(:option_remove).rejected
           end

--- a/test/functional/activation_key/content_override_test.rb
+++ b/test/functional/activation_key/content_override_test.rb
@@ -66,7 +66,7 @@ describe 'activation-key content-override' do
   it "does not attach a content override with value other than enabled without --force" do
     api_expects_no_call
     error_msg = "Could not update content override:\n" \
-            "  You must use --force to set a value other than 'enabled'"
+            "  You must use --force to set an override other than 'enabled'"
 
     assert_failure run_cmd(%w(activation-key content-override --id=20 --content-label=foo --value=1 --override-name=protected)), error_msg
     result = run_cmd(%w(activation-key content-override id=20 --content-label=foo --value=1 --override-name=protected))

--- a/test/functional/activation_key/content_override_test.rb
+++ b/test/functional/activation_key/content_override_test.rb
@@ -7,7 +7,7 @@ describe 'activation-key content-override' do
   end
   it "attaches a content override" do
     label = "foo"
-    value = 'enabled'
+    value = 'true'
     id = 20
     params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}"]
     ex = api_expects(:activation_keys, :content_override) do |par|
@@ -23,17 +23,17 @@ describe 'activation-key content-override' do
     assert_cmd(expected_result, result)
   end
 
-  it "attaches a content override with name" do
+  it "attaches a content override with --override-name" do
     label = "foo"
-    value = 'enabled'
+    override_name = 'enabled'
+    value = 'true'
     id = 20
-    name = 'protected'
     params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}",
-              "--override-name=#{name}"]
+              "--override-name=#{override_name}"]
     ex = api_expects(:activation_keys, :content_override) do |par|
       par['id'] == id && par["content_overrides"][0]['content_label'] == label &&
         par['content_overrides'][0]['value'] == value &&
-        par['content_overrides'][0]['name'] == name
+        par['content_overrides'][0]['name'] == override_name
     end
     ex.returns({})
 
@@ -43,17 +43,17 @@ describe 'activation-key content-override' do
     assert_cmd(expected_result, result)
   end
 
-  it "attaches a content override with value other than enabled using --force" do
+  it "attaches a content override with override name other than enabled using --force" do
     label = "foo"
+    override_name = 'protected'
     value = '1'
     id = 20
-    name = 'protected'
     params = ["--id=#{id}", "--content-label=#{label}", "--value=#{value}",
-              "--override-name=#{name}", "--force"]
+              "--override-name=#{override_name}", "--force"]
     ex = api_expects(:activation_keys, :content_override) do |par|
       par['id'] == id && par["content_overrides"][0]['content_label'] == label &&
         par['content_overrides'][0]['value'] == value &&
-        par['content_overrides'][0]['name'] == name
+        par['content_overrides'][0]['name'] == override_name
     end
     ex.returns({})
 

--- a/test/functional/host/subscription/content_override_test.rb
+++ b/test/functional/host/subscription/content_override_test.rb
@@ -70,7 +70,7 @@ describe 'host subscription content-override' do
   it "does not attach a content override with value other than enabled without --force" do
     api_expects_no_call
     error_msg = "Could not update content override:\n" \
-            "  You must use --force to set a value other than 'enabled'"
+            "  You must use --force to set an override other than 'enabled'"
 
     assert_failure run_cmd(%w(host subscription content-override --host-id=20 --content-label=foo --value=1 --override-name=protected)), error_msg
     result = run_cmd(%w(host subscription content-override --host-id=20 --content-label=foo --value=1 --override-name=protected))

--- a/test/functional/host/subscription/content_override_test.rb
+++ b/test/functional/host/subscription/content_override_test.rb
@@ -11,7 +11,7 @@ describe 'host subscription content-override' do
 
   it "attaches a content override" do
     label = "foo"
-    value = 'enabled'
+    value = 'true'
     id = '20'
     params = ["--host-id=#{id}", "--content-label=#{label}", "--value=#{value}"]
     ex = api_expects(:host_subscriptions, :content_override, "content override") do |par|
@@ -29,15 +29,15 @@ describe 'host subscription content-override' do
 
   it "attaches a content override with name" do
     label = "foo"
-    value = 'enabled'
+    override_name = 'enabled'
+    value = '1'
     id = '20'
-    name = 'protected'
     params = ["--host-id=#{id}", "--content-label=#{label}", "--value=#{value}",
-              "--override-name=#{name}"]
+              "--override-name=#{override_name}"]
     ex = api_expects(:host_subscriptions, :content_override, "content override") do |par|
       par['host_id'].to_s == id && par["content_overrides"][0]['content_label'] == label &&
         par['content_overrides'][0]['value'] == value &&
-        par['content_overrides'][0]['name'] == name
+        par['content_overrides'][0]['name'] == override_name
     end
     ex.returns({})
 
@@ -49,15 +49,15 @@ describe 'host subscription content-override' do
 
   it "attaches a content override with value other than enabled using --force" do
     label = "foo"
-    value = 'enabled'
+    value = '1'
     id = '20'
-    name = 'protected'
+    override_name = 'protected'
     params = ["--host-id=#{id}", "--content-label=#{label}", "--value=#{value}",
-              "--override-name=#{name}", "--force"]
+              "--override-name=#{override_name}", "--force"]
     ex = api_expects(:host_subscriptions, :content_override, "content override") do |par|
       par['host_id'].to_s == id && par["content_overrides"][0]['content_label'] == label &&
         par['content_overrides'][0]['value'] == value &&
-        par['content_overrides'][0]['name'] == name
+        par['content_overrides'][0]['name'] == override_name
     end
     ex.returns({})
 


### PR DESCRIPTION
https://github.com/Katello/hammer-cli-katello/pull/977 should have validated `option_override_name`, but inadvertently looked at `option_value` instead. This caused `hammer content-override` to break completely.

Turns out our Hammer tests were also wrong. Params should be like
```
--override-name enabled
--value true

--override-name enabled
--value 1
```

but instead were like
```
--value enabled
```


To test:

```
hammer activation-key content-override --id 2 --content-label satellite-client-6-for-rhel-9-x86_64-rpms --value true
hammer activation-key content-override --id 2 --content-label satellite-client-6-for-rhel-9-x86_64-rpms --override-name foo --value 0
```

1. Without the `--override-name` flag, values `true`, `false`, `0`, and `1` (and really, any value) should work.
2. With the `--override-name` of `enabled`, the values above should also work.
3. With the `--override-name` of anything other than `enabled`, you should get the (new & improved) error
```
Could not update content override:
  You must use --force to set an override other than 'enabled'
```
