### PR TITLE
Fixes #38127 - Add hammer host bootc images sub-commamd

### DIFF
--- a/lib/hammer_cli_katello/host.rb
+++ b/lib/hammer_cli_katello/host.rb
@@ -6,6 +6,7 @@ require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_deb'
 require 'hammer_cli_katello/host_package_group'
 require 'hammer_cli_katello/host_traces'
+require 'hammer_cli_katello/host_bootc'
 
 module HammerCLIKatello
   HammerCLIForeman::Host.subcommand "errata",
@@ -31,4 +32,8 @@ module HammerCLIKatello
   HammerCLIForeman::Host.subcommand "traces",
                                     HammerCLIKatello::HostTraces.desc,
                                     HammerCLIKatello::HostTraces
+
+  HammerCLIForeman::Host.subcommand "bootc",
+                                    HammerCLIKatello::HostBootc.desc,
+                                    HammerCLIKatello::HostBootc
 end

--- a/lib/hammer_cli_katello/host_bootc.rb
+++ b/lib/hammer_cli_katello/host_bootc.rb
@@ -1,0 +1,34 @@
+module HammerCLIKatello
+  class HostBootc < HammerCLIKatello::Command
+    resource :host_bootc_images
+    desc "Manage bootc images on your hosts"
+
+    class ImagesCommand < HammerCLIKatello::ListCommand
+      action :bootc_images
+      command_name "images"
+
+      output do
+        field :bootc_booted_image, _("Running image")
+        field :bootc_booted_digest, _("Running image digest")
+        field :host_count, _("Host count")
+      end
+
+      def send_request
+        self.class.parse_data(super)
+      end
+
+      def self.parse_data(data_collection)
+        data = data_collection.inject([]) do |list, item|
+          list + item["digests"].collect do |digest|
+            digest.merge(:bootc_booted_image => item["bootc_booted_image"])
+          end
+        end
+        HammerCLI::Output::RecordCollection.new(data, :meta => data_collection.meta)
+      end
+
+      build_options
+    end
+
+    autoload_subcommands
+  end
+end

--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -4,6 +4,7 @@ require 'hammer_cli_katello/host_subscription'
 require 'hammer_cli_katello/host_package'
 require 'hammer_cli_katello/host_package_group'
 require 'hammer_cli_katello/host_traces'
+require 'hammer_cli_katello/host_bootc'
 
 module HammerCLIKatello
   module HostExtensions


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/11277.

New command `hammer host bootc images`