### PR TITLE
Remove warnings for ostruct, csv and syslog

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -63,6 +63,9 @@ Gem::Specification.new do |gem|
   gem.version = HammerCLIKatello.version
   gem.required_ruby_version = '>= 2.7', '< 4'
 
+  gem.add_development_dependency 'csv', '~> 3.2.8'
+  gem.add_development_dependency 'ostruct', '~> 0.6.0'
+  gem.add_development_dependency 'syslog', '~> 0.1.2'
   gem.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 
   gem.add_dependency 'hammer_cli_foreman', '~> 3.9'


### PR DESCRIPTION
Before
```bash
bash-5.1$ hammer repository list
WARNING: File locale/vi/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
/usr/share/ruby/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/opt/app-root/src/hammer-cli-katello/vendor/ruby/3.3.0/gems/hammer_cli-3.13.0/lib/hammer_cli/settings.rb:2: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add syslog to your Gemfile or gemspec to silence this warning.
/opt/app-root/src/hammer-cli-katello/vendor/ruby/3.3.0/gems/hammer_cli-3.13.0/lib/hammer_cli/output/adapter.rb:5: warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add csv to your Gemfile or gemspec to silence this warning.
```

After
``` bash
bash-5.1$ hammer repository list
WARNING: File locale/vi/LC_MESSAGES/hammer_cli_katello.mo outdated, regenerate with 'make all-mo'
```