### PR TITLE
Fixes #38341 - Add Product host count to subscription list command

### DIFF
--- a/lib/hammer_cli_katello/subscription.rb
+++ b/lib/hammer_cli_katello/subscription.rb
@@ -18,6 +18,7 @@ module HammerCLIKatello
         field :end_date, _("End Date"), Fields::Date
         field :format_quantity, _("Quantity")
         field :consumed, _("Consumed")
+        field :product_host_count, _("Product Host Count")
       end
 
       def extend_data(data)


### PR DESCRIPTION
We added the column to the UI but missed it in hammer. 

Steps to test PR
* Import a manifest
* Checkout pr
* hammer subscription list --organization-id 1 --fields "Id","Name","Product host count"
---|-----------------------------------------------|-------------------
ID | NAME                                          | PRODUCT HOST COUNT
---|-----------------------------------------------|-------------------
1  | Red Hat Satellite Infrastructure Subscription | 1
---|-----------------------------------------------|-------------------