### PR TITLE
Fixes #38392 - show container upstream name in repository list

### DIFF
--- a/lib/hammer_cli_katello/repository.rb
+++ b/lib/hammer_cli_katello/repository.rb
@@ -33,6 +33,7 @@ module HammerCLIKatello
         field :content_type, _("Content Type")
         field :content_label, _("Content Label")
         field :url, _("Url")
+        field :docker_upstream_name, _('Upstream Repository Name'), nil, :sets => ['ALL']
       end
 
       content_type_msg = _("Limit the repository type to return." \

--- a/test/functional/repository/list_test.rb
+++ b/test/functional/repository/list_test.rb
@@ -103,4 +103,23 @@ ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL
     result = run_cmd(@cmd + params)
     assert_cmd(expected, result)
   end
+
+  it "lists the repositories with container upstream name" do
+    params = ['--organization-id=1', '--fields=ALL']
+
+    ex = api_expects(:repositories, :index, 'repositories list with upstream container name') do |par|
+      par['organization_id'] == org_id && par['page'] == 1 &&
+        par['per_page'] == 1000
+    end
+
+    ex.returns(empty_response)
+
+    expected = CommandExpectation.new("---|------|---------|--------------|---------------|-----|-------------------------
+ID | NAME | PRODUCT | CONTENT TYPE | CONTENT LABEL | URL | UPSTREAM REPOSITORY NAME
+---|------|---------|--------------|---------------|-----|-------------------------
+")
+
+    result = run_cmd(@cmd + params)
+    assert_cmd(expected, result)
+  end
 end


### PR DESCRIPTION
Adds container upstream name optionally to the repository list command. Try --fields=ALL to see it.