### PR TITLE
Fixes #38405 - Flatten CV and LE fields for hosts in CVE. Deprecate existing fields.

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -6,6 +6,7 @@ require 'hammer_cli_katello/host_package_group'
 require 'hammer_cli_katello/host_traces'
 require 'hammer_cli_katello/host_bootc'
 
+# rubocop:disable Metrics/ModuleLength
 module HammerCLIKatello
   module HostExtensions
     ::HammerCLIForeman::Host::CreateCommand.instance_eval do
@@ -57,18 +58,34 @@ module HammerCLIKatello
                   _("Content View Environment Labels"), Fields::Field
             collection :content_view_environments, _('Content View Environments') do
               from :content_view do
-                label _("Content view") do
-                  field :id, _("Id")
-                  field :name, _("Name")
-                  field :composite, _("Composite"), Fields::Boolean
-                  field :rolling, _("Rolling"), Fields::Boolean
+                # Deprecated label. To be removed in future versions.
+                label _("Content view"), :sets => ['ALL'] do
+                  field :id, _("Id"), Fields::Field,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('CV Id')].join('/')
+                  field :name, _("Name"), Fields::Field,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('CV Name')].join('/')
+                  field :composite, _("Composite"), Fields::Boolean,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('Composite CV')].join('/')
+                  field :rolling, _("Rolling"), Fields::Boolean,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('Rolling CV')].join('/')
                 end
+
+                field :id, _("CV Id")
+                field :name, _("CV Name")
+                field :composite, _("Composite CV"), Fields::Boolean
+                field :rolling, _("Rolling CV"), Fields::Boolean
               end
               from :lifecycle_environment do
-                label _("Lifecycle environment") do
-                  field :id, _("Id")
-                  field :name, _("Name")
+                # Deprecated label. To be removed in future versions.
+                label _("Lifecycle environment"), :sets => ['ALL'] do
+                  field :id, _("Id"), Fields::Field,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('LE Id')].join('/')
+                  field :name, _("Name"), Fields::Field,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('LE Name')].join('/')
                 end
+
+                field :id, _("LE Id")
+                field :name, _("LE Name")
               end
               field :label, _("Label")
             end
@@ -138,3 +155,4 @@ module HammerCLIKatello
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
### Main changes
This flattens the content view environment fields to bring them more inline with other hammer outputs. In host content view environment info outputs, the content view and lifecycle environment fields will be displayed at the same level as the CVE label. The existing CV and LE labels will be hidden from the default view and will be deprecated + removed from hammer entirely in several versions. Example shown below:

Existing:
```
$ hammer host info --id [id]
(...)
Content Information:      
    Content View Environment Labels: Library/Test_CCV
    Content View Environments:       
     1) Content view:          
            Id:        5
            Name:      Test CCV
            Composite: yes
            Rolling:   no
        Lifecycle environment: 
            Id:   1
            Name: Library
        Label:                 Library/Test_CCV

$ hammer --csv host info --id 1 --fields "Name,Content Information/Content view environments/Lifecycle environment/Id"
Name,Content View Environments::Lifecycle environment::1
centos9-host-1.redhat.example.com,"{""id""=>1, ""name""=>""Library"", ""lifecycle_environment_library""=>true}"
```

New:
```
$ hammer host info --id [id]
(...)
Content Information:      
    Content View Environment Labels: Library/Test_CCV
    Content View Environments:       
     1) CV Id:        5
        CV Name:      Test CCV
        Composite CV: yes
        Rolling CV:   no
        LE Id:        1
        LE Name:      Library
        Label:        Library/Test_CCV
        
$ hammer --csv host info --id [id] --fields "Name,Content Information/Content view environments/LE Id"
Name,Content View Environments::LE Id::1
centos9-host-1.redhat.example.com,1

$ hammer host info --id [id] --fields ALL
Warning: Field 'Content Information/Content View Environments/Content view/Id' is deprecated. Consider using 'Content Information/Content View Environments/CV Id' instead.
Warning: Field 'Content Information/Content View Environments/Content view/Name' is deprecated. Consider using 'Content Information/Content View Environments/CV Name' instead.
Warning: Field 'Content Information/Content View Environments/Content view/Composite' is deprecated. Consider using 'Content Information/Content View Environments/Composite CV' instead.
Warning: Field 'Content Information/Content View Environments/Content view/Rolling' is deprecated. Consider using 'Content Information/Content View Environments/Rolling CV' instead.
Warning: Field 'Content Information/Content View Environments/Lifecycle environment/Id' is deprecated. Consider using 'Content Information/Content View Environments/CV Id' instead.
Warning: Field 'Content Information/Content View Environments/Lifecycle environment/Name' is deprecated. Consider using 'Content Information/Content View Environments/CV Name' instead.
Content Information:      
    Content View Environment Labels: Library/Test_CCV
    Content View Environments:       
     1) Content view:          
            Id:        5
            Name:      Test CCV
            Composite: yes
            Rolling:   no
        CV Id:                 5
        CV Name:               Test CCV
        Composite CV:          yes
        Rolling CV:            no
        Lifecycle environment: 
            Id:   1
            Name: Library
        LE Id:                 1
        LE Name:               Library
        Label:                 Library/Test_CCV
```

### Additional rationale / info
This PR stems from [an issue](https://projects.theforeman.org/issues/38405) discovered with our CSV rendering where labels inside of a collection do not render out properly. Rather than fixing that behavior, this PR kicks the can down the road and sidesteps the only place in hammer-cli-foreman and hammer-cli-katello this pops up. This change (showing all properties of a collection item on the item's "top" level) fits the behavior seen in other hammer subcommands.