### PR TITLE
Fixes #38612 - Remove rolling CV from host info command

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -66,14 +66,11 @@ module HammerCLIKatello
                     :replaced_by => [_('Content Information'), _('Content View Environments'), _('CV Name')].join('/')
                   field :composite, _("Composite"), Fields::Boolean,
                     :replaced_by => [_('Content Information'), _('Content View Environments'), _('Composite CV')].join('/')
-                  field :rolling, _("Rolling"), Fields::Boolean,
-                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('Rolling CV')].join('/')
                 end
 
                 field :id, _("CV Id")
                 field :name, _("CV Name")
                 field :composite, _("Composite CV"), Fields::Boolean
-                field :rolling, _("Rolling CV"), Fields::Boolean
               end
               from :lifecycle_environment do
                 # Deprecated label. To be removed in future versions.


### PR DESCRIPTION
Hammer-cli-katello 1.17 exposes the "rolling CV" fields on Foreman 3.14 despite rolling CV not being "released" until 3.15+. We need to patch 1.17 to remove these fields from the default host info view.

**How to test**

1. Pull the 1.17.z branch of hammer-cli-katello and make sure it runs with the appropriately-outdated version of hammer-cli and hammer-cli-foreman (grab versions from foreman 3.14ish).
2. Run a `hammer host info` command and see that "Rolling CV" is not displayed next to "Composite CV".
3. Run a `hammer host info` command with `--fields ALL` and see that "Content view" -> "Rolling" is not displayed next to "Composite".
4. Ensure the rolling CV fields are not exposed when manually triggering them via `fields "Content Information/Content view environments/Rolling CV"`