### PR TITLE
Fixes #38678 - Add module stream Id to hammer filter rule

### DIFF
--- a/lib/hammer_cli_katello/filter.rb
+++ b/lib/hammer_cli_katello/filter.rb
@@ -49,6 +49,7 @@ module HammerCLIKatello
           field :start_date, _("Start Date"), Fields::Field, :hide_blank => true
           field :end_date, _("End Date"), Fields::Field, :hide_blank => true
           field :types, _("Types"), Fields::List, :hide_blank => true
+          field :module_stream_id, _("Module Stream ID"), Fields::Field, :hide_blank => true
           field :created_at, _("Created"), Fields::Date
           field :updated_at, _("Updated"), Fields::Date
         end

--- a/lib/hammer_cli_katello/filter_rule.rb
+++ b/lib/hammer_cli_katello/filter_rule.rb
@@ -19,6 +19,7 @@ module HammerCLIKatello
         field :errata_id, _("Errata ID")
         field :start_date, _("Start Date")
         field :end_date, _("End Date")
+        field :module_stream_id, _("Module Stream ID")
       end
 
       build_options
@@ -41,6 +42,7 @@ module HammerCLIKatello
         field :end_date, _("End Date"), Fields::Field, :hide_blank => true
         field :date_type, _("Date Type"), Fields::Field, :hide_blank => true
         field :types, _("Types"), Fields::List, :hide_blank => true
+        field :module_stream_id, _("Module Stream ID"), Fields::Field, :hide_blank => true
         field :created_at, _("Created"), Fields::Date
         field :updated_at, _("Updated"), Fields::Date
       end


### PR DESCRIPTION
Add module stream id to filter rule info.

Create a module stream filter with a rule.

Run the following in hammer (Replace filter id and filter rule ids):

hammer content-view filter info --id 3

hammer content-view filter rule info --content-view-filter-id 3 --id 1

Make sure you see the new module stream field in the output.