### PR TITLE
Add rolling CV fields back to host info

### DIFF
--- a/lib/hammer_cli_katello/host_extensions.rb
+++ b/lib/hammer_cli_katello/host_extensions.rb
@@ -66,11 +66,14 @@ module HammerCLIKatello
                     :replaced_by => [_('Content Information'), _('Content View Environments'), _('CV Name')].join('/')
                   field :composite, _("Composite"), Fields::Boolean,
                     :replaced_by => [_('Content Information'), _('Content View Environments'), _('Composite CV')].join('/')
+                  field :rolling, _("Rolling"), Fields::Boolean,
+                    :replaced_by => [_('Content Information'), _('Content View Environments'), _('Rolling CV')].join('/')
                 end
 
                 field :id, _("CV Id")
                 field :name, _("CV Name")
                 field :composite, _("Composite CV"), Fields::Boolean
+                field :rolling, _("Rolling CV"), Fields::Boolean
               end
               from :lifecycle_environment do
                 # Deprecated label. To be removed in future versions.


### PR DESCRIPTION
**What has changed:**
[This PR](https://github.com/Katello/hammer-cli-katello/commit/4cc32b9d9e67ae165a810758c0df590b585ccefa) mistakenly removed two host info fields because we all thought hammer-cli-katello 1.17 was related to Foreman 3.14 (the confusion was because 1.17 had the same version number as Satellite 6.17, aka Foreman 3.14). This PR adds those fields back.


**How to test**

1. Run a `hammer host info` command and see that "Rolling CV" is not displayed next to "Composite CV".
2. Run a `hammer host info` command with `--fields ALL` and see that "Content view" -> "Rolling" is not displayed next to "Composite".