### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -68,6 +68,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'syslog', '~> 0.1.2'
   gem.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 
-  gem.add_dependency 'hammer_cli_foreman', '~> 3.9'
+  gem.add_dependency 'hammer_cli_foreman', '~> 5.0'
   gem.add_dependency 'hammer_cli_foreman_tasks', '~> 0.0.20'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint from ~> 3.9 to ~> 5.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)