### PR TITLE
Fixes #39373 - Display API validation errors for host updates

### DIFF
--- a/lib/hammer_cli_katello/exception_handler.rb
+++ b/lib/hammer_cli_katello/exception_handler.rb
@@ -4,7 +4,8 @@ module HammerCLIKatello
     def mappings
       super + [
         [RestClient::InternalServerError, :handle_internal_error],
-        [RestClient::BadRequest, :handle_bad_request]
+        [RestClient::BadRequest, :handle_bad_request],
+        [RestClient::UnprocessableEntity, :handle_unprocessable_entity]
       ]
     end
 

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -1,0 +1,77 @@
+require_relative '../test_helper'
+require 'hammer_cli_katello/exception_handler'
+
+describe HammerCLIKatello::ExceptionHandler do
+  let(:handler) { HammerCLIKatello::ExceptionHandler.new }
+
+  describe '#mappings' do
+    it 'includes UnprocessableEntity mapping' do
+      mappings = handler.mappings
+      unprocessable_mapping = mappings.find { |m| m[0] == RestClient::UnprocessableEntity }
+
+      _(unprocessable_mapping).wont_be_nil
+      _(unprocessable_mapping[1]).must_equal :handle_unprocessable_entity
+    end
+
+    it 'includes InternalServerError mapping' do
+      mappings = handler.mappings
+      internal_error_mapping = mappings.find { |m| m[0] == RestClient::InternalServerError }
+
+      _(internal_error_mapping).wont_be_nil
+      _(internal_error_mapping[1]).must_equal :handle_internal_error
+    end
+
+    it 'includes BadRequest mapping' do
+      mappings = handler.mappings
+      bad_request_mapping = mappings.find { |m| m[0] == RestClient::BadRequest }
+
+      _(bad_request_mapping).wont_be_nil
+      _(bad_request_mapping[1]).must_equal :handle_bad_request
+    end
+  end
+
+  describe '#handle_unprocessable_entity' do
+    it 'extracts and prints displayMessage from API response' do
+      error_response_body = {
+        'displayMessage' => 'Validation failed: Host example.com: Cannot add content view environment to content facet.',
+        'errors' => {
+          'base' => ['Host example.com: Cannot add content view environment to content facet.']
+        }
+      }.to_json
+
+      # RestClient exceptions expect the response to be accessible as a string
+      exception = RestClient::UnprocessableEntity.new
+      exception.instance_variable_set(:@response, error_response_body)
+
+      # Capture the output
+      output = StringIO.new
+      handler.stub :print_error, ->(msg) { output.puts(msg) } do
+        handler.stub :log_full_error, ->(_) {} do
+          result = handler.send(:handle_unprocessable_entity, exception)
+          _(result).must_equal HammerCLI::EX_DATAERR
+          _(output.string).must_include 'Validation failed'
+          _(output.string).must_include 'Cannot add content view environment'
+        end
+      end
+    end
+
+    it 'falls back to exception message if JSON parsing fails' do
+      # Create a mock response that responds to code but has invalid JSON body
+      response_mock = 'Not valid JSON'
+      response_mock.define_singleton_method(:code) { 422 }
+
+      exception = RestClient::UnprocessableEntity.new
+      exception.instance_variable_set(:@response, response_mock)
+
+      output = StringIO.new
+      handler.stub :print_error, ->(msg) { output.puts(msg) } do
+        handler.stub :log_full_error, ->(_) {} do
+          result = handler.send(:handle_unprocessable_entity, exception)
+          _(result).must_equal HammerCLI::EX_DATAERR
+          # When JSON parsing fails, it should fall back to the exception message
+          _(output.string).wont_be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### When updating a host with invalid content view environments, the API returns detailed validation errors in the 'displayMessage' field, but hammer was only showing "Could not update the host" without details.

Root cause:
- RestClient::UnprocessableEntity (422 status) wasn't mapped to handle_unprocessable_entity in the exception handler
- The existing handle_unprocessable_entity method extracts displayMessage but was never being called

This commit adds the missing exception mapping, so users see:
  Could not update the host:
    Validation failed: Host example.com: Cannot add content view
    environment to content facet. The host's content source 'proxy.com'
    does not sync lifecycle environment 'Library'.

Instead of just:
  Could not update the host

#### Before patch:
```bash
hammer -d host update --id 3 --content-view-environments Library/Zoo
Could not update the host.
```
#### After patch:
```bash
hammer host update --id 3 --content-view-environments Library/Zoo
Could not update the host:
Validation failed: Host host.example.com: Cannot add content view environment to content facet. The host's content source 'capsule.example.com' does not sync lifecycle environment 'Library'.
```
Requires: https://github.com/theforeman/hammer-cli-foreman/pull/655

#### Testing Steps:

1. Create multiple Content Views (e.g., cv_1 & cv_2) and multiple Lifecycle Environments (e.g., 'Library' and 'Dev').

2. Publish new versions of all Content Views and promote them to the 'Dev' lifecycle environment.

3. Add only the 'Dev' lifecycle environment to the external Capsule, ensuring that the 'Library' lifecycle environment is not added. Then, synchronize the Capsule server.

4. Register the client to the Capsule server.

5. Try to update the hosts content view environments to one not synced on the capsule
`hammer -d host update --id 3 --content-view-environments Library/Zoo`

6. Verify you see the real error and not the generic can't update host error