### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_katello.gemspec
+++ b/hammer_cli_katello.gemspec
@@ -68,6 +68,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'syslog', '~> 0.1.2'
   gem.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 
-  gem.add_dependency 'hammer_cli_foreman', '~> 3.9'
+  gem.add_dependency 'hammer_cli_foreman', '>= 3.9', '< 6.0'
   gem.add_dependency 'hammer_cli_foreman_tasks', '~> 0.0.20'
 end


### PR DESCRIPTION
## Summary
Cherry-pick of the fix from main: relax `hammer_cli_foreman` dependency from `~> 3.9` (which excludes 5.x) to `>= 3.9, < 6.0` to allow Foreman 5.x versions.

Fixes repoclosure failure on EL10 for Katello 5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)